### PR TITLE
[WIP] fix(Select): 设置窗口的下拉菜单没有背景模糊

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, onUpdated, ref, watch } from 'vue'
+import { onMounted, onUpdated, ref } from 'vue'
 
 const props = defineProps<{
   options: OptionType[]
@@ -71,8 +71,8 @@ function onMouseEnter() {
 }
 
 // 显示选项时计算位置
-watch(showOptions, (newVal) => {
-  if (newVal) {
+watchEffect(() => {
+  if (showOptions.value) {
     calculatePosition()
   }
 }, { flush: 'pre' })

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -130,7 +130,7 @@ watchEffect(() => {
           }"
           pos="absolute" bg="$bew-elevated" shadow="$bew-shadow-2" p="2"
           m="t-2"
-          rounded="$bew-radius" z="10003" flex="~ col gap-1"
+          rounded="$bew-radius" z="10004" flex="~ col gap-1"
           w="full" max-h-300px overflow-y-overlay will-change-transform transform-gpu
         >
           <div
@@ -148,6 +148,14 @@ watchEffect(() => {
           </div>
         </div>
       </Transition>
+
+      <!-- 遮罩 外部滚动时关闭下拉菜单 -->
+      <div
+        v-if="showOptions"
+        pos="fixed top-0 left-0" w-full h-full
+        z="10003"
+        @wheel="closeOptions"
+      />
     </Teleport>
   </div>
 </template>

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -18,7 +18,7 @@ const { mainAppRef } = useBewlyApp()
 const label = ref<string>('')
 const showOptions = ref<boolean>(false)
 const dropdownPosition = ref({ top: 0, left: 0, width: 0 })
-const triggerRef = ref<HTMLElement | null>(null)
+const containerRef = ref<HTMLElement | null>(null)
 
 onUpdated(() => {
   // fix the issue when the dropdown menu text doesn't update in real-time based on the updated page language
@@ -40,10 +40,10 @@ onUnmounted(() => {
 
 /** 计算下拉菜单绝对位置 */
 function calculatePosition() {
-  if (!triggerRef.value)
+  if (!containerRef.value)
     return
 
-  const rect = triggerRef.value.getBoundingClientRect()
+  const rect = containerRef.value.getBoundingClientRect()
   dropdownPosition.value = {
     top: rect.bottom + window.scrollY,
     left: rect.left + window.scrollX,
@@ -82,7 +82,7 @@ watchEffect(() => {
 
 <template>
   <div
-    ref="triggerRef"
+    ref="containerRef"
     pos="relative"
     @mouseleave="onMouseLeave"
     @mouseenter="onMouseEnter"

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { onMounted, onUpdated, ref } from 'vue'
-
 const props = defineProps<{
   options: OptionType[]
   modelValue: any

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -75,7 +75,7 @@ watch(showOptions, (newVal) => {
   if (newVal) {
     calculatePosition()
   }
-})
+}, { flush: 'pre' })
 </script>
 
 <template>

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { useBewlyApp } from '~/composables/useAppProvider'
+
 const props = defineProps<{
   options: OptionType[]
   modelValue: any
@@ -10,6 +12,8 @@ interface OptionType {
   value: any
   label: string
 }
+
+const { mainAppRef } = useBewlyApp()
 
 const label = ref<string>('')
 const showOptions = ref<boolean>(false)
@@ -114,7 +118,7 @@ watchEffect(() => {
       />
     </div>
 
-    <Teleport to="body">
+    <Teleport :to="mainAppRef">
       <Transition name="dropdown">
         <div
           v-if="showOptions"


### PR DESCRIPTION
此 PR 针对先前已关闭的 Issue keleus/BewlyCat#79，原因是找到一种较好的方式解决该问题，希望提升可读性。

### 主要问题

嵌套的背景模糊元素产生了冲突，造成内层（下拉菜单）背景模糊没有应用，影响可读性，详见 https://github.com/keleus/BewlyCat/issues/79#issuecomment-3173753295 。

### 修复思路

将下拉菜单单独挂载到根组件，计算其位置并使用绝对定位，规避嵌套关系。

### 具体方法

使用 Vue3 的内置组件 [Teleport](https://cn.vuejs.org/guide/built-ins/teleport)，该组件允许将其内部的元素渲染到 DOM 结构的其他位置。

通过“传送”至 mainAppRef，从而下拉菜单不与设置模态本身的背景模糊产生嵌套关系，能够正确应用背景模糊。

再使用 JS 计算将其定位到正确位置。

### Before vs After

<img width="300" height="290" alt="image" src="https://github.com/user-attachments/assets/3f09fbd4-fa9f-4063-b21c-7a8b90ea3371" />
<img width="300" height="290" alt="image" src="https://github.com/user-attachments/assets/8f31226f-ea1a-4c91-b6b1-7d846cf766f9" />

下拉菜单的文字不再与后方文字重合。

尝试点击或滚动外部内容（如设置列表）时，下拉菜单自动关闭（原先滚动时会跟随滚动）

### Todos:

- [x] 实现 Teleport
- [x] 在窗口大小变化时更新位置
- [x] ~在组件滚动时跟随位置~ 外部滚动时关闭下拉菜单

测试：
- [ ] 测试在 Chrome 上表现
- [x] 测试在 Edge 上表现
- [x] 测试在 Firefox 上表现

<details><summary>另：关于背景太亮，文字不明显的问题</summary>
<p>

背景色太过鲜艳导致的前景不明显（如下图），个人认为可以在深色模式下添加额外的深色背景遮罩来解决，但不在这个 PR 的范围

<img width="604" height="380" alt="image" src="https://github.com/user-attachments/assets/d620ba9d-247c-4d99-ba6c-3a584212d19f" />

</p>
</details> 