### PR TITLE
fix(videoPage): 收藏确认按钮在不可用时 悬浮仍然高亮

### DIFF
--- a/src/styles/adaptedStyles/pages/videoPage.scss
+++ b/src/styles/adaptedStyles/pages/videoPage.scss
@@ -79,7 +79,7 @@
     .note-up .up-desc-container .desc-top .attention-btn-container:hover,
     .note-up .up-desc-container .desc-top .attention-btn-container.is-attention:hover,
     .report-dialog .vui_dialog--footer .report-dialog-footer .button-wrap .comfirm-report:hover,
-    .collection-m-exp .bottom .btn:hover,
+    .collection-m-exp .bottom .btn:not(.disable):hover,
     .upinfo-btn-panel .following-charge-btn:hover {
       background-color: var(--bew-theme-color-80);
     }


### PR DESCRIPTION
Fix #131 

按钮在禁用时拥有 `disable` 类

`:not(.disable)` 以防止选中禁用的按钮，不影响可用按钮的高亮