### PR TITLE
fix(IframeDrawer): 关闭时 URL 始终还原为启动页面

### DIFF
--- a/src/components/IframeDrawer.vue
+++ b/src/components/IframeDrawer.vue
@@ -26,6 +26,7 @@ const currentUrl = ref<string>(props.url)
 const showIframe = ref<boolean>(false)
 const delayCloseTimer = ref<NodeJS.Timeout | null>(null)
 const removeTopBarClassInjected = ref<boolean>(false)
+const originUrl = ref<string>()
 
 useEventListener(window, 'popstate', updateIframeUrl)
 
@@ -100,6 +101,7 @@ function setupIframeListeners() {
   })
 }
 onMounted(() => {
+  originUrl.value = window.location.href
   history.pushState(null, '', props.url)
   show.value = true
   headerShow.value = true
@@ -115,7 +117,7 @@ onBeforeUnmount(() => {
 })
 
 onUnmounted(() => {
-  history.replaceState(null, '', 'https://www.bilibili.com')
+  history.replaceState(null, '', originUrl.value)
 })
 
 function updateCurrentUrl(e: any) {


### PR DESCRIPTION
- 挂载时先记录 URL，再替换为目标 URL
- 卸载时恢复 URL

Fix #141

#### 测试：

- [x] Edge
- [x] Firefox