### PR TITLE
fix(settings): 英文时音量均衡使用说明超出窗口

### DIFF
--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -415,7 +415,7 @@ settings:
     search_results_count: 显示 {current} / {total} 个配置
     usage_guide:
       title: 使用说明
-      desc: |
+      desc: |-
         音量均衡功能可以为不同UP主设置个性化音量
         1. 启用音量均衡功能后，系统会自动监听音量变化
         2. 当你手动调整音量时，会弹出对话框询问是否记录UP主配置或调整基准音量

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -487,7 +487,6 @@ settings:
     usage_guide:
       desc: |-
         The volume equalization function can set personalized volumes for
-
         different UP
 
         1. After the volume equalization function is enabled, the system will

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -485,7 +485,7 @@ settings:
     up_volume: UP volume
     up_configs_desc: Manage personalized volume settings for each UP host
     usage_guide:
-      desc: >
+      desc: |-
         The volume equalization function can set personalized volumes for
 
         different UP


### PR DESCRIPTION
Fix #161 

在 yml 文件中，将原 `>` 更改为 `|-`，确保换行符被准确保留，并优化显示格式

更改后：

<img width="1717" height="1013" alt="image" src="https://github.com/user-attachments/assets/e5e3880e-4302-4fe4-8123-72de62106753" />
