### PR TITLE
fix(Favorite): 修复加载过程中显示空图标

### DIFF
--- a/src/contentScripts/views/Favorites/Favorites.vue
+++ b/src/contentScripts/views/Favorites/Favorites.vue
@@ -286,7 +286,7 @@ function isMusic(item: FavoriteResource) {
       <Empty v-else-if="favoriteResources.length === 0 && !isLoading && !isFullPageLoading" m="t-55px b-6" />
       <template v-else>
         <Transition name="fade">
-          <Loading v-if="isFullPageLoading" w-full h-full pos="absolute top-0 left-0" mt--50px />
+          <Loading v-if="isFullPageLoading" w-full h-screen pos="absolute top-0 left-0" mt--50px />
         </Transition>
         <div grid="~ 2xl:cols-4 xl:cols-3 lg:cols-2 md:cols-1 sm:cols-1 cols-1 gap-5" m="t-55px b-6">
           <TransitionGroup name="list">


### PR DESCRIPTION
Fix #176 

恢复了 41568c51c04ed371ba2ed1fda10146e939b3e057 中被禁用的全页加载图标

### 实现的功能

- 从其他页面进入收藏页时先显示加载图标，再加载出内容
- 切换收藏夹时显示加载图标

### 更改内容

1. `isFullPageLoading` 初始置为 true 以使进入时就显示加载图标
2. 加载当前收藏夹第一页视频期间将 `isFullPageLoading` 置为 true
3. `isFullPageLoading` 为 true 时，仅居中显示 `<Loading />`，不显示 `<Empty />`

### 效果

![output](https://github.com/user-attachments/assets/b58e8348-b5d5-42ba-8244-9418c846ed42)