### PR TITLE
fix：删除版本号小尾巴

### DIFF
--- a/src/components/Settings/About/About.vue
+++ b/src/components/Settings/About/About.vue
@@ -127,7 +127,7 @@ async function checkGitHubRelease() {
             href="https://github.com/keleus/BewlyCat/releases" target="_blank"
             un-text="sm color-$bew-text-2 hover:color-$bew-text-3"
           >
-            v{{ version }} - Farewell
+            v{{ version }}
           </a>
         </p>
       </section>


### PR DESCRIPTION
这个小尾巴是原作者在最后一版加上的，意为“最后一版”，删掉好些