### PR TITLE
docs:修复贡献指南多语言跳转错误

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribution Guide
 
-[English](CONTRIBUTING.md) | [官话 - 简体中文](CONTRIBUTING-cmn_CN.md) | [官話 - 繁体中文](CONTRIBUTING-cmn_TW.md) | [廣東話](CONTRIBUTING-jyut.md)
+[English](/docs/CONTRIBUTING.md) | [官话 - 简体中文](/docs/CONTRIBUTING-cmn_CN.md) | [官話 - 繁体中文](/docs/CONTRIBUTING-cmn_TW.md)
 
 ## 💻 Setting up the Development Environment
 


### PR DESCRIPTION
如果从项目主页打开其他语言的贡献指南，他会404
我把路径改为了根目录，这样就不会404了
同时删除了不存在的广东话