### PR TITLE
fix(perf): 移除静态背景不必要的 transform-gpu 以解决 Edge 滚动卡顿问题 (#385)

### DIFF
--- a/src/components/AppBackground.vue
+++ b/src/components/AppBackground.vue
@@ -282,7 +282,7 @@ function setAppWallpaperMaskingOpacity() {
         <!-- background -->
         <div
           pos="absolute top-0 left-0" w-full h-full duration-300 bg="cover center $bew-homepage-bg"
-          z--1 transform-gpu
+          z--1
           :style="{ backgroundImage: `url('${currentWallpaperUrl}')` }"
         />
         <!-- background mask -->
@@ -290,7 +290,7 @@ function setAppWallpaperMaskingOpacity() {
           <div
             v-if="(!settings.individuallySetSearchPageWallpaper && settings.enableWallpaperMasking) || (settings.searchPageEnableWallpaperMasking)"
             pos="absolute top-0 left-0" w-full h-full pointer-events-none
-            duration-300 z--1 transform-gpu
+            duration-300 z--1
           >
             <!-- 模糊图层 -->
             <div
@@ -332,7 +332,7 @@ function setAppWallpaperMaskingOpacity() {
         <div
           :style="{ backgroundImage: `url('${currentWallpaperUrl}')` }"
           pos="absolute top-0 left-0" w-full h-full duration-300 bg="cover center $bew-homepage-bg"
-          z--1 transform-gpu
+          z--1
         />
 
         <!-- background mask -->
@@ -340,7 +340,7 @@ function setAppWallpaperMaskingOpacity() {
           <div
             v-if="settings.enableWallpaperMasking"
             pos="absolute top-0 left-0" w-full h-full pointer-events-none
-            duration-300 z--1 transform-gpu
+            duration-300 z--1
           >
             <!-- 模糊图层 -->
             <div


### PR DESCRIPTION
**描述**  
修复 #385  

**修改内容**  
- 在 `src/components/AppBackground.vue` 中移除了背景和遮罩容器上的 `transform-gpu` 类。  

**原因说明**  
- **问题**：在 Microsoft Edge 上，静态背景元素使用 `transform-gpu` 强制图层提升，再叠加顶栏的 `backdrop-filter`，会导致 GPU 合成开销过大。
- 
- **解决方案**：移除 `transform-gpu`，避免浏览器不必要地将这些静态层提升为独立的 GPU 合成层。这样可以消除 Edge 上的合成器瓶颈，显著改善滚动性能并降低资源消耗，同时在 Chrome 和其他浏览器上保持正确的视觉效果。

图1：[最新CI构建版本性能消耗](https://github.com/keleus/BewlyCat/commit/cb4a0752460c32aacbf84276ebacf390ac36aa29)
<img width="2559" height="1056" alt="image" src="https://github.com/user-attachments/assets/b821a2e1-61a1-4ee2-b475-14a2a98e21b7" />

图2：本次修改后的性能消耗
<img width="2553" height="1052" alt="image" src="https://github.com/user-attachments/assets/7a3fec63-dfed-4fd2-8c43-2e6d029a9ece" />

均使用Edge效率模式测试