### PR TITLE
fix: 网格布局CSS变量改为响应式计算属性以修复列数设置失效

### DIFF
--- a/src/components/VideoCardGrid.vue
+++ b/src/components/VideoCardGrid.vue
@@ -397,7 +397,7 @@ const isHorizontal = computed(() => {
 const gridContainerStyle = computed(() => ({
   pointerEvents: (isScrolling.value ? 'none' : 'auto') as 'none' | 'auto',
   ...shadowStyleVars.value,
-  ...gridCssVars,
+  ...gridCssVars.value,
 }))
 
 // 是否显示初始骨架屏（数据量不足阈值且还有更多内容时）

--- a/src/composables/useGridLayout.ts
+++ b/src/composables/useGridLayout.ts
@@ -4,17 +4,14 @@ import { computed } from 'vue'
 import type { GridLayoutType } from '~/logic'
 import { gridColumns } from '~/logic'
 
-// 页面加载时读取一次，之后不再监听变化（需刷新页面生效）
-const initialGridColumns = { ...gridColumns.value }
-
-const gridCssVars: CSSProperties = {
-  '--grid-cols-base': initialGridColumns.base,
-  '--grid-cols-sm': initialGridColumns.sm,
-  '--grid-cols-md': initialGridColumns.md,
-  '--grid-cols-lg': initialGridColumns.lg,
-  '--grid-cols-xl': initialGridColumns.xl,
-  '--grid-cols-xxl': initialGridColumns.xxl,
-} as CSSProperties
+const gridCssVars = computed<CSSProperties>(() => ({
+  '--grid-cols-base': gridColumns.value.base,
+  '--grid-cols-sm': gridColumns.value.sm,
+  '--grid-cols-md': gridColumns.value.md,
+  '--grid-cols-lg': gridColumns.value.lg,
+  '--grid-cols-xl': gridColumns.value.xl,
+  '--grid-cols-xxl': gridColumns.value.xxl,
+}))
 
 export function useGridLayout(gridLayout: () => GridLayoutType) {
   const gridClass = computed((): string => {


### PR DESCRIPTION
fix #421 

### 问题分析

详见：https://github.com/keleus/BewlyCat/issues/421#issuecomment-3678674819

### 修复方法

对应的css变量重新更改为 `computed` 计算属性，实时更新

> [!WARNING]
> 列数变为了实时更新，可能需要确认在不同设备上的 更改设置选项时的性能影响，本人测试没有显著问题