### PR TITLE
fix: 修复首页启用原版顶栏时显示为空白的问题 

### DIFF
--- a/src/contentScripts/index.ts
+++ b/src/contentScripts/index.ts
@@ -419,6 +419,13 @@ async function onDOMLoaded() {
       .home-redesign-base, .bilibili-gate-root {
         display: none !important;
       }
+      /* Ensure the original top bar remains visible and properly positioned */
+      /* The visibility/display will be controlled by .remove-top-bar class in removeTopBar.scss */
+      .bili-header {
+        position: relative !important;
+        left: 0 !important;
+        pointer-events: auto !important;
+      }
     `)
 
     // 温和的脚本清理（可选，减少后台资源消耗）

--- a/src/utils/bilibiliTopBar.ts
+++ b/src/utils/bilibiliTopBar.ts
@@ -39,17 +39,22 @@ export function detachOriginalBilibiliTopBar(doc: Document) {
 }
 
 export function ensureOriginalBilibiliTopBarAppended(doc: Document): boolean {
-  if (getDocumentTopBar(doc))
-    return true
-
-  if (!cachedOriginalTopBar)
+  const header = getDocumentTopBar(doc) || cachedOriginalTopBar
+  if (!header)
     return false
 
-  // Keep behavior consistent with the previous implementation: hide extra header contents.
-  const innerUselessContents = cachedOriginalTopBar.querySelectorAll<HTMLElement>(':scope > *:not(.bili-header__bar)')
+  // 1. 隐藏多余段落（如 banner 等），只保留顶栏条
+  const innerUselessContents = header.querySelectorAll<HTMLElement>(':scope > *:not(.bili-header__bar)')
   innerUselessContents.forEach(item => (item.style.display = 'none'))
 
-  doc.body.prepend(cachedOriginalTopBar)
+  // 2. 确保顶栏是 body 的直接子元素且位于最前
+  // 即使 header 已存在，如果它在某个被隐藏的父容器里，这里也会将其移动到 body 下
+  if (header.parentElement !== doc.body || header !== doc.body.firstElementChild) {
+    doc.body.prepend(header)
+  }
+
+  // 更新缓存引用
+  cachedOriginalTopBar = header
   return true
 }
 


### PR DESCRIPTION
Close #423 

通过追溯 Git 历史发现，问题引入自提交 02991515：

- 逻辑变更：该提交为了优化性能和减少 CLS（累积布局偏移），将首页处理方案从“物理清空 DOM” (document.body.innerHTML = '') 切换为了“CSS 方案隐藏”。
- 副作用：在物理清空方案下，顶栏重附到 body 后必然是直接子元素；在 CSS 方案下，顶栏可能仍嵌套在 B 站原始页面的深层容器中。
- 隐藏冲突：由于父容器被 CSS 规则隐藏，导致顶栏即便存在也无法显示。同时，通用的 body 排除规则未包含 .bili-header。

Changes

1. 完善选择器排除与样式锁定 (src/contentScripts/index.ts)
在 body > *:not(...) 隐藏规则中显式增加 :not(.bili-header) 排除项。
显式锁定 .bili-header 的样式（position: relative !important, left: 0 !important）。这能确保在 Bewly 首页环境下，顶栏位置固定且不被 B 站原始随动脚本干扰。

2. 增强顶栏劫持逻辑 (src/utils/bilibiliTopBar.ts)
重构 ensureOriginalBilibiliTopBarAppended函数：
位置强制重置：增加 parent 检测，如果顶栏已存在但不是 body 的直接子元素，则强制移动到 body 下。这解决了因“不再清空 body”导致的元素嵌套隐藏问题。
逻辑合并：确保无论何种加载路径，隐藏无用子内容（如 banner 等）的逻辑都能始终执行。

<img width="2553" height="1419" alt="image" src="https://github.com/user-attachments/assets/638c689c-9521-4749-9a9a-7b7aa2d2cfb6" />
