### PR TITLE
fix: 修复首页的直播页面中开播up头像被拉伸的问题 #431

### DIFF
--- a/src/components/Picture.vue
+++ b/src/components/Picture.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
-defineProps<{
+withDefaults(defineProps<{
   src: string
   loading?: 'lazy' | 'eager'
   alt?: string
-}>()
+  aspectRatio?: string
+}>(), {
+  aspectRatio: '16 / 9',
+})
 </script>
 
 <template>
@@ -11,7 +14,7 @@ defineProps<{
     w-full max-w-full align-middle object-cover
     rounded="$bew-radius"
     bg="$bew-skeleton"
-    style="aspect-ratio: 16 / 9; display: block;"
+    :style="{ aspectRatio, display: 'block' }"
   >
     <source :srcset="`${src}.avif`" type="image/avif">
     <source :srcset="`${src}.webp`" type="image/webp">
@@ -22,7 +25,7 @@ defineProps<{
       decoding="async"
       block w-full h-full object-cover
       rounded-inherit
-      style="aspect-ratio: 16 / 9;"
+      :style="{ aspectRatio }"
     >
   </picture>
 </template>

--- a/src/components/VideoCard/VideoCardAuthor/components/VideoCardAuthorAvatar.vue
+++ b/src/components/VideoCard/VideoCardAuthor/components/VideoCardAuthorAvatar.vue
@@ -84,7 +84,8 @@ const isKetang = computed(() => {
       <Picture
         :src="`${removeHttpFromUrl(item.authorFace)}@50w_50h_1c`"
         loading="lazy"
-        w-inherit h-inherit
+        w-full h-full
+        aspect-ratio="1/1"
         rounded="1/2"
       />
 


### PR DESCRIPTION
fix #431
但是仍存在开播和未开播up信息所在位置高度不一致的问题。