### PR TITLE
fix: 修复番剧页面渐变遮罩的跨度问题

### DIFF
--- a/src/components/HorizontalScrollView.vue
+++ b/src/components/HorizontalScrollView.vue
@@ -81,9 +81,8 @@ function handleMouseScroll(event: WheelEvent) {
 </template>
 
 <style lang="scss" scoped>
-/* 简化遮罩渐变：使用3个关键点代替4个，提升性能 */
 .scroll-mask {
-  mask-image: linear-gradient(to right, transparent 0, black 40px, transparent 100%);
-  -webkit-mask-image: linear-gradient(to right, transparent 0, black 40px, transparent 100%);
+  mask-image: linear-gradient(to right, transparent 0, black 40px, black calc(100% - 40px), transparent 100%);
+  -webkit-mask-image: linear-gradient(to right, transparent 0, black 40px, black calc(100% - 40px), transparent 100%);
 }
 </style>


### PR DESCRIPTION
Close #439 

修复后：

<img width="2559" height="1433" alt="image" src="https://github.com/user-attachments/assets/d29d9008-ea59-4826-92d5-52fd637133f9" />
