### PR TITLE
修复与Bilibili Evolved的兼容性问题

### DIFF
--- a/src/contentScripts/index.ts
+++ b/src/contentScripts/index.ts
@@ -409,7 +409,7 @@ async function onDOMLoaded() {
     // 推荐使用方案2：CSS隐藏
     // 使用 CSS 隐藏 B 站原始页面，保留 DOM 结构
     injectCSS(`
-      body > *:not(#bewly):not(script):not(style):not(.bili-header) {
+      body > *:not(#bewly):not(script):not(style):not(.bili-header):not(.custom-navbar) {
         display: none !important;
         visibility: hidden !important;
         pointer-events: none !important;


### PR DESCRIPTION
缺少:not(.custom-navbar)会导致首页上的Bilibili Evolved消失