### PR TITLE
fix:修复了切换暗色模式会闪一下的问题

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -152,28 +152,5 @@ img {
   }
 }
 
-/* Color Mode transition */
-::view-transition-old(root),
-::view-transition-new(root) {
-  animation: none !important;
-  mix-blend-mode: normal;
-  transition: none !important;
-}
-::view-transition-old(*),
-::view-transition-new(*),
-::view-transition-old(*::after),
-::view-transition-new(*::before) {
-  transition: none !important;
-}
-::view-transition-old(root) {
-  z-index: 1;
-}
-::view-transition-new(root) {
-  z-index: 2147483646;
-}
-.dark::view-transition-old(root) {
-  z-index: 2147483646;
-}
-.dark::view-transition-new(root) {
-  z-index: 1;
-}
+// Note: View Transition styles for theme toggle are injected dynamically via JS in useDark.ts
+// because this file is loaded in Shadow DOM and cannot affect document-level ::view-transition pseudo-elements


### PR DESCRIPTION
[https://github.com/keleus/BewlyCat/issues/319](https://github.com/keleus/BewlyCat/issues/319)
This pull request refactors how view transition styles for theme toggling (dark/light mode) are applied in the application. Instead of relying on static global CSS, the necessary styles are now injected dynamically via JavaScript within `useDark.ts`. This change ensures that view transition effects work correctly even when the main stylesheet is loaded in a Shadow DOM, which cannot affect document-level pseudo-elements. Additionally, the logic for toggling dark mode classes is slightly simplified, and the animation and z-index handling for transitions is improved.

**Dynamic View Transition Styling:**

* Removed static view transition styles from `main.scss` and added comments explaining that these styles are now injected dynamically due to Shadow DOM limitations.
* Injected view transition styles (animation and mix-blend-mode) directly into the document head in `useDark.ts` to ensure correct styling during theme transitions.
* Dynamically managed z-index for `::view-transition-old(root)` and `::view-transition-new(root)` based on the current theme, ensuring proper stacking during transitions.

**Dark Mode Toggle Logic Improvements:**

* Simplified the logic for adding and removing the `dark` class from the document body by removing unnecessary `nextTick` wrappers. [[1]](diffhunk://#diff-2b1ae5757ac97614e5d38cebd232b7b8f2585e09ca27f1e28946b751e0a7e49cL102-L104) [[2]](diffhunk://#diff-2b1ae5757ac97614e5d38cebd232b7b8f2585e09ca27f1e28946b751e0a7e49cL121-L123)

**Transition Cleanup:**

* Improved cleanup of dynamically injected styles after transitions complete, preventing style accumulation in the document head.