### PR TITLE
chore：插件设置-首页-正在关注新布局-原不当注释改为不活跃名单，增加按钮控制

### DIFF
--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -429,6 +429,7 @@ settings:
   enable_following_inactive_blacklist_desc: 当UP主超过指定天数未更新或无投稿时，将自动移至不活跃名单。在ALL视图中出现更新或点击该UP主时会自动移出不活跃名单
   following_inactive_days: UP主不活跃天数
   following_inactive_days_desc: 许用“使用正在关注新布局”后该功能生效。与自主添加的用户黑名单无关，仅更改“正在关注”页面推荐
+  preserve_for_you_state: 留存个性推荐切换前状态
   preserve_for_you_state_desc: 当从dock栏切换到其他页面时，留存个性推荐页面的浏览状态，返回时保持切换前的内容
   use_search_page_mode: 首页使用搜索页模式
   settings_shared_with_the_search_page: 与搜索页共用的配置

--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -425,12 +425,10 @@ settings:
   following_filter_dynamic_videos_desc: 开启后，在 "正在关注" 页面中将隐藏标记为动态视频的内容
   use_following_new_layout: 使用正在关注新布局
   use_following_new_layout_desc: 左侧显示关注的UP主列表，右侧显示视频流
-  # 2026-04-03 Propelf Code Modification:不活跃自动黑名单主开关文案
-  enable_following_inactive_blacklist: 启用不活跃自动黑名单
-  enable_following_inactive_blacklist_desc: 关闭后不会因超过不活跃天数或无投稿而自动加入黑名单；已存在的黑名单与 ALL 视图或点击移出规则不变。
+  enable_following_inactive_blacklist: 启用不活跃名单
+  enable_following_inactive_blacklist_desc: 当UP主超过指定天数未更新或无投稿时，将自动移至不活跃名单。在ALL视图中出现更新或点击该UP主时会自动移出不活跃名单
   following_inactive_days: UP主不活跃天数
-  following_inactive_days_desc: 当UP主超过指定天数未更新或无投稿时，将自动移至黑名单。在ALL视图中出现更新或点击该UP主时会自动移出黑名单
-  preserve_for_you_state: 留存个性推荐切换前状态
+  following_inactive_days_desc: 许用“使用正在关注新布局”后该功能生效。与自主添加的用户黑名单无关，仅更改“正在关注”页面推荐
   preserve_for_you_state_desc: 当从dock栏切换到其他页面时，留存个性推荐页面的浏览状态，返回时保持切换前的内容
   use_search_page_mode: 首页使用搜索页模式
   settings_shared_with_the_search_page: 与搜索页共用的配置

--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -425,6 +425,9 @@ settings:
   following_filter_dynamic_videos_desc: 开启后，在 "正在关注" 页面中将隐藏标记为动态视频的内容
   use_following_new_layout: 使用正在关注新布局
   use_following_new_layout_desc: 左侧显示关注的UP主列表，右侧显示视频流
+  # 2026-04-03 Propelf Code Modification:不活跃自动黑名单主开关文案
+  enable_following_inactive_blacklist: 启用不活跃自动黑名单
+  enable_following_inactive_blacklist_desc: 关闭后不会因超过不活跃天数或无投稿而自动加入黑名单；已存在的黑名单与 ALL 视图或点击移出规则不变。
   following_inactive_days: UP主不活跃天数
   following_inactive_days_desc: 当UP主超过指定天数未更新或无投稿时，将自动移至黑名单。在ALL视图中出现更新或点击该UP主时会自动移出黑名单
   preserve_for_you_state: 留存个性推荐切换前状态

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -379,7 +379,6 @@ settings:
   following_filter_dynamic_videos_desc: 啟用後，在「正在跟隨」頁面中將隱藏標記為動態影片的內容
   use_following_new_layout: 使用正在跟隨新版面
   use_following_new_layout_desc: 左側顯示關注的 UP 主列表，右側顯示影片流
-  # 2026-04-03 Propelf Code Modification:不活躍自動黑名單主開關文案
   enable_following_inactive_blacklist: 啟用不活躍名單
   enable_following_inactive_blacklist_desc: 當UP主超過指定天數未更新或無投稿時，將自動移至不活躍名單。在ALL視圖中出現更新或點擊該UP主時會自動移出不活躍名單。
   following_inactive_days: UP 主不活躍天數

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -380,10 +380,10 @@ settings:
   use_following_new_layout: 使用正在跟隨新版面
   use_following_new_layout_desc: 左側顯示關注的 UP 主列表，右側顯示影片流
   # 2026-04-03 Propelf Code Modification:不活躍自動黑名單主開關文案
-  enable_following_inactive_blacklist: 啟用不活躍自動黑名單
-  enable_following_inactive_blacklist_desc: 關閉後不會因超過不活躍天數或無投稿而自動加入黑名單；已存在的黑名單與 ALL 視圖／點擊移出規則不變。
+  enable_following_inactive_blacklist: 啟用不活躍名單
+  enable_following_inactive_blacklist_desc: 當UP主超過指定天數未更新或無投稿時，將自動移至不活躍名單。在ALL視圖中出現更新或點擊該UP主時會自動移出不活躍名單。
   following_inactive_days: UP 主不活躍天數
-  following_inactive_days_desc: 當 UP 主超過指定天數未更新或無投稿時，將自動移至黑名單。在ALL視圖中出現更新或點擊該 UP 主時會自動移出黑名單
+  following_inactive_days_desc: 套用『使用正在關注新佈局』後該功能生效。與自主添加的用戶黑名單無關，僅更改『正在關注』頁面推薦。
   preserve_for_you_state: 留存為你推薦切換前狀態
   preserve_for_you_state_desc: 當從 Dock 欄切換到其他頁面時，留存為你推薦頁面的瀏覽狀態，返回時保持切換前的內容
   use_search_page_mode: 首頁使用搜尋頁模式

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -379,6 +379,9 @@ settings:
   following_filter_dynamic_videos_desc: 啟用後，在「正在跟隨」頁面中將隱藏標記為動態影片的內容
   use_following_new_layout: 使用正在跟隨新版面
   use_following_new_layout_desc: 左側顯示關注的 UP 主列表，右側顯示影片流
+  # 2026-04-03 Propelf Code Modification:不活躍自動黑名單主開關文案
+  enable_following_inactive_blacklist: 啟用不活躍自動黑名單
+  enable_following_inactive_blacklist_desc: 關閉後不會因超過不活躍天數或無投稿而自動加入黑名單；已存在的黑名單與 ALL 視圖／點擊移出規則不變。
   following_inactive_days: UP 主不活躍天數
   following_inactive_days_desc: 當 UP 主超過指定天數未更新或無投稿時，將自動移至黑名單。在ALL視圖中出現更新或點擊該 UP 主時會自動移出黑名單
   preserve_for_you_state: 留存為你推薦切換前狀態

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -429,11 +429,10 @@ settings:
   following_filter_dynamic_videos_desc: When enabled, videos marked as dynamic videos will be hidden in the "Following" page
   use_following_new_layout: Use new layout for Following tab
   use_following_new_layout_desc: Display followed UPs list on the left and video feed on the right
-  # 2026-04-03 Propelf Code Modification:master switch copy for inactive auto-blacklist
-  enable_following_inactive_blacklist: Enable inactive auto-blacklist
-  enable_following_inactive_blacklist_desc: When off, UPs are not auto-added for inactivity or having no videos. Existing blacklist entries and removal via ALL view or click are unchanged.
+  enable_following_inactive_blacklist: Enable Inactive List
+  enable_following_inactive_blacklist_desc: When a UP has not posted for the specified number of days or has no videos, they will be automatically moved to the Inactive List. They will be removed from the Inactive List when appearing in ALL view or when clicked
   following_inactive_days: UP inactive days
-  following_inactive_days_desc: When a UP has not posted for the specified number of days or has no videos, they will be automatically moved to the blacklist. They will be removed from the blacklist when appearing in ALL view or when clicked
+  following_inactive_days_desc: The feature takes effect after applying 'Use new layout for Following tab' It is unrelated to the custom user blacklist and only modifies recommendations within the 'new layout for Following tab' module.
   preserve_for_you_state: Preserve "For You" pre-switch state
   preserve_for_you_state_desc: When switching from dock to other pages, preserve the browsing state of the "For You" page and maintain content before switching when returning
   use_search_page_mode: Use search page mode on homepage

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -429,6 +429,9 @@ settings:
   following_filter_dynamic_videos_desc: When enabled, videos marked as dynamic videos will be hidden in the "Following" page
   use_following_new_layout: Use new layout for Following tab
   use_following_new_layout_desc: Display followed UPs list on the left and video feed on the right
+  # 2026-04-03 Propelf Code Modification:master switch copy for inactive auto-blacklist
+  enable_following_inactive_blacklist: Enable inactive auto-blacklist
+  enable_following_inactive_blacklist_desc: When off, UPs are not auto-added for inactivity or having no videos. Existing blacklist entries and removal via ALL view or click are unchanged.
   following_inactive_days: UP inactive days
   following_inactive_days_desc: When a UP has not posted for the specified number of days or has no videos, they will be automatically moved to the blacklist. They will be removed from the blacklist when appearing in ALL view or when clicked
   preserve_for_you_state: Preserve "For You" pre-switch state

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -362,10 +362,10 @@ settings:
   use_following_new_layout: 用跟緊啲人新版面
   use_following_new_layout_desc: 左邊顯示關注嘅UP主名單，右邊顯示影片流
   # 2026-04-03 Propelf Code Modification:唔活躍自動黑名單主開關文案
-  enable_following_inactive_blacklist: 啟用唔活躍自動黑名單
-  enable_following_inactive_blacklist_desc: 閂咗之後唔會因為超過唔活躍日數或者冇投稿就自動入黑名單；已經有嘅黑名單同 ALL 視圖／撳 UP 移出規則唔變。
+  enable_following_inactive_blacklist: 啟用唔活躍名單
+  enable_following_inactive_blacklist_desc: 閂咗之後唔會因為超過唔活躍日數或者冇投稿就自動入唔活躍名單；已經有嘅唔活躍名單同 ALL 視圖／撳 UP 移出規則唔變。
   following_inactive_days: UP主唔活躍天數
-  following_inactive_days_desc: 當UP主超過指定天數未更新或者冇投稿嗰陣，會自動移去黑名單。喺ALL視圖中出現更新或者撳咗個UP主嗰陣會自動移出黑名單
+  following_inactive_days_desc: 套用『用跟緊啲人新版面』之後個功能就會生效。同你自己加嘅用戶黑名單冇關，只係改咗『跟緊啲人』頁面嘅推薦內容。
   preserve_for_you_state: 留存估你心水切換前狀態
   preserve_for_you_state_desc: 喺dock欄切換到其它頁面嗰陣，留存估你心水頁面嘅瀏覽狀態，返嚟嗰陣保持切換前嘅內容
   use_search_page_mode: 主頁使用搵嘢頁模式

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -361,6 +361,9 @@ settings:
   following_filter_dynamic_videos_desc: 啟用後，喺「跟緊啲人」頁面入邊會隱藏標記為動態影片嘅內容
   use_following_new_layout: 用跟緊啲人新版面
   use_following_new_layout_desc: 左邊顯示關注嘅UP主名單，右邊顯示影片流
+  # 2026-04-03 Propelf Code Modification:唔活躍自動黑名單主開關文案
+  enable_following_inactive_blacklist: 啟用唔活躍自動黑名單
+  enable_following_inactive_blacklist_desc: 閂咗之後唔會因為超過唔活躍日數或者冇投稿就自動入黑名單；已經有嘅黑名單同 ALL 視圖／撳 UP 移出規則唔變。
   following_inactive_days: UP主唔活躍天數
   following_inactive_days_desc: 當UP主超過指定天數未更新或者冇投稿嗰陣，會自動移去黑名單。喺ALL視圖中出現更新或者撳咗個UP主嗰陣會自動移出黑名單
   preserve_for_you_state: 留存估你心水切換前狀態

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -361,7 +361,6 @@ settings:
   following_filter_dynamic_videos_desc: 啟用後，喺「跟緊啲人」頁面入邊會隱藏標記為動態影片嘅內容
   use_following_new_layout: 用跟緊啲人新版面
   use_following_new_layout_desc: 左邊顯示關注嘅UP主名單，右邊顯示影片流
-  # 2026-04-03 Propelf Code Modification:唔活躍自動黑名單主開關文案
   enable_following_inactive_blacklist: 啟用唔活躍名單
   enable_following_inactive_blacklist_desc: 閂咗之後唔會因為超過唔活躍日數或者冇投稿就自動入唔活躍名單；已經有嘅唔活躍名單同 ALL 視圖／撳 UP 移出規則唔變。
   following_inactive_days: UP主唔活躍天數

--- a/src/components/Settings/PluginComponentsAndPages/Home/Home.vue
+++ b/src/components/Settings/PluginComponentsAndPages/Home/Home.vue
@@ -411,16 +411,21 @@ function handleToggleHomeTab(tab: any) {
       <SettingsItem :title="$t('settings.use_following_new_layout')" :desc="$t('settings.use_following_new_layout_desc')">
         <Radio v-model="settings.useFollowingNewLayout" />
       </SettingsItem>
-      <SettingsItem :title="$t('settings.following_inactive_days')" :desc="$t('settings.following_inactive_days_desc')">
-        <Input
-          v-model="settings.followingInactiveDays" type="number" :min="1" :max="365"
-          w-120px
-        >
-          <template #suffix>
-            <span text="sm $bew-text-2" whitespace-nowrap>{{ $t('common.days') }}</span>
-          </template>
-        </Input>
+      <SettingsItem :title="$t('settings.enable_following_inactive_blacklist')" :desc="$t('settings.enable_following_inactive_blacklist_desc')">
+        <Radio v-model="settings.enableFollowingInactiveBlacklist" />
       </SettingsItem>
+      <template v-if="settings.enableFollowingInactiveBlacklist">
+        <SettingsItem :title="$t('settings.following_inactive_days')" :desc="$t('settings.following_inactive_days_desc')">
+          <Input
+            v-model="settings.followingInactiveDays" type="number" :min="1" :max="365"
+            w-120px
+          >
+            <template #suffix>
+              <span text="sm $bew-text-2" whitespace-nowrap>{{ $t('common.days') }}</span>
+            </template>
+          </Input>
+        </SettingsItem>
+      </template>
       <SettingsItem :title="$t('settings.following_tab_show_livestreaming_videos')">
         <Radio v-model="settings.followingTabShowLivestreamingVideos" />
       </SettingsItem>

--- a/src/contentScripts/views/Home/components/Following.vue
+++ b/src/contentScripts/views/Home/components/Following.vue
@@ -827,8 +827,9 @@ async function loadSingleUploaderTime(mid: number, retryCount: number = 0) {
 
             console.log(`[Following] Updated time for UP ${mid} (${loadedUploaderTimesCount.value}/${uploaderList.value.length})${updateInterval ? `, interval: ${Math.round(updateInterval / (24 * 60 * 60 * 1000))}d` : ''}`)
 
+            // 2026-04-03 Propelf Code Modification：仅开启「不活跃自动黑名单」时才写入黑名单
             // 检查是否应该加入黑名单（超过指定天数未更新）
-            if (shouldBeBlacklisted(uploader)) {
+            if (settings.value.enableFollowingInactiveBlacklist && shouldBeBlacklisted(uploader)) {
               addToBlacklist(mid)
             }
 
@@ -841,9 +842,10 @@ async function loadSingleUploaderTime(mid: number, retryCount: number = 0) {
         }
       }
       else {
+        // 2026-04-03 Propelf Code Modification:主开关关闭时不因无投稿自动进黑名单
         // API返回成功但没有视频数据，该UP主完全没有投稿，添加到黑名单
         const uploader = uploaderList.value.find(u => u.mid === mid)
-        if (uploader) {
+        if (uploader && settings.value.enableFollowingInactiveBlacklist) {
           addToBlacklist(mid)
           console.log(`[Following] No video data for UP ${mid}, added to blacklist`)
         }

--- a/src/contentScripts/views/Home/components/Following.vue
+++ b/src/contentScripts/views/Home/components/Following.vue
@@ -827,8 +827,7 @@ async function loadSingleUploaderTime(mid: number, retryCount: number = 0) {
 
             console.log(`[Following] Updated time for UP ${mid} (${loadedUploaderTimesCount.value}/${uploaderList.value.length})${updateInterval ? `, interval: ${Math.round(updateInterval / (24 * 60 * 60 * 1000))}d` : ''}`)
 
-            // 2026-04-03 Propelf Code Modification：仅开启「不活跃自动黑名单」时才写入黑名单
-            // 检查是否应该加入黑名单（超过指定天数未更新）
+            // 检查是否应该加入不活跃名单（超过指定天数未更新）
             if (settings.value.enableFollowingInactiveBlacklist && shouldBeBlacklisted(uploader)) {
               addToBlacklist(mid)
             }

--- a/src/contentScripts/views/Home/components/Following.vue
+++ b/src/contentScripts/views/Home/components/Following.vue
@@ -841,7 +841,6 @@ async function loadSingleUploaderTime(mid: number, retryCount: number = 0) {
         }
       }
       else {
-        // 2026-04-03 Propelf Code Modification:主开关关闭时不因无投稿自动进黑名单
         // API返回成功但没有视频数据，该UP主完全没有投稿，添加到黑名单
         const uploader = uploaderList.value.find(u => u.mid === mid)
         if (uploader && settings.value.enableFollowingInactiveBlacklist) {

--- a/src/logic/storage.ts
+++ b/src/logic/storage.ts
@@ -509,6 +509,7 @@ export const originalSettings: Settings = {
   useFollowingNewLayout: false, // 默认使用旧布局
   enableFollowingInactiveBlacklist: true,
   followingInactiveDays: 100, // 默认100天
+
   homePageTabVisibilityList: [],
   alwaysShowTabsOnHomePage: false,
   homeAdaptiveTitleFontSize: 16,

--- a/src/logic/storage.ts
+++ b/src/logic/storage.ts
@@ -290,7 +290,6 @@ export interface Settings {
   followingFilterChargingVideos: boolean // 过滤充电专属视频
   followingFilterDynamicVideos: boolean // 过滤动态视频
   useFollowingNewLayout: boolean
-  // 2026-04-03 Propelf Code Modification:不活跃自动黑名单总开关（关闭则不自动 addToBlacklist）
   enableFollowingInactiveBlacklist: boolean
   followingInactiveDays: number // UP主超过N天未更新则移至黑名单
 
@@ -508,7 +507,6 @@ export const originalSettings: Settings = {
   followingFilterChargingVideos: false, // 默认不过滤充电视频
   followingFilterDynamicVideos: false, // 默认不过滤动态视频
   useFollowingNewLayout: false, // 默认使用旧布局
-  // 2026-04-03 Propelf Code Modification:改为默认开启，这里与原先版本一致！
   enableFollowingInactiveBlacklist: true,
   followingInactiveDays: 100, // 默认100天
   homePageTabVisibilityList: [],

--- a/src/logic/storage.ts
+++ b/src/logic/storage.ts
@@ -290,6 +290,8 @@ export interface Settings {
   followingFilterChargingVideos: boolean // 过滤充电专属视频
   followingFilterDynamicVideos: boolean // 过滤动态视频
   useFollowingNewLayout: boolean
+  // 2026-04-03 Propelf Code Modification:不活跃自动黑名单总开关（关闭则不自动 addToBlacklist）
+  enableFollowingInactiveBlacklist: boolean
   followingInactiveDays: number // UP主超过N天未更新则移至黑名单
 
   homePageTabVisibilityList: { page: HomeSubPage, visible: boolean }[]
@@ -506,8 +508,9 @@ export const originalSettings: Settings = {
   followingFilterChargingVideos: false, // 默认不过滤充电视频
   followingFilterDynamicVideos: false, // 默认不过滤动态视频
   useFollowingNewLayout: false, // 默认使用旧布局
-  followingInactiveDays: 100, // 默认100天
-
+  // 2026-04-03 Propelf Code Modification:改为默认关闭，这里与原先版本不一致！
+  enableFollowingInactiveBlacklist: false,
+  followingInactiveDays: 40000, // 默认40000天
   homePageTabVisibilityList: [],
   alwaysShowTabsOnHomePage: false,
   homeAdaptiveTitleFontSize: 16,

--- a/src/logic/storage.ts
+++ b/src/logic/storage.ts
@@ -508,9 +508,9 @@ export const originalSettings: Settings = {
   followingFilterChargingVideos: false, // 默认不过滤充电视频
   followingFilterDynamicVideos: false, // 默认不过滤动态视频
   useFollowingNewLayout: false, // 默认使用旧布局
-  // 2026-04-03 Propelf Code Modification:改为默认关闭，这里与原先版本不一致！
-  enableFollowingInactiveBlacklist: false,
-  followingInactiveDays: 40000, // 默认40000天
+  // 2026-04-03 Propelf Code Modification:改为默认开启，这里与原先版本一致！
+  enableFollowingInactiveBlacklist: true,
+  followingInactiveDays: 100, // 默认100天
   homePageTabVisibilityList: [],
   alwaysShowTabsOnHomePage: false,
   homeAdaptiveTitleFontSize: 16,

--- a/src/logic/storage.ts
+++ b/src/logic/storage.ts
@@ -290,8 +290,8 @@ export interface Settings {
   followingFilterChargingVideos: boolean // 过滤充电专属视频
   followingFilterDynamicVideos: boolean // 过滤动态视频
   useFollowingNewLayout: boolean
-  enableFollowingInactiveBlacklist: boolean
-  followingInactiveDays: number // UP主超过N天未更新则移至黑名单
+  enableFollowingInactiveBlacklist: boolean // 启用不活跃名单
+  followingInactiveDays: number // UP主超过N天未更新则移至不活跃名单
 
   homePageTabVisibilityList: { page: HomeSubPage, visible: boolean }[]
   alwaysShowTabsOnHomePage: boolean
@@ -507,7 +507,7 @@ export const originalSettings: Settings = {
   followingFilterChargingVideos: false, // 默认不过滤充电视频
   followingFilterDynamicVideos: false, // 默认不过滤动态视频
   useFollowingNewLayout: false, // 默认使用旧布局
-  enableFollowingInactiveBlacklist: true,
+  enableFollowingInactiveBlacklist: true, // 默认启用不活跃名单
   followingInactiveDays: 100, // 默认100天
 
   homePageTabVisibilityList: [],


### PR DESCRIPTION
目前BewlyCat插件自动会开启100天的不活跃黑名单功能，我认为这个功能或许有点危险，修改为：
增加按钮控制功能开启与否，默认关闭，开启按钮后启用功能，按钮开启后把默认天数改为40000天（大于100年）
代码修改部分：
src/logic/storage.ts
1.增加对应boolean按钮（293-294）
2.修改为默认关闭（默认开启或许有危险）,把默认天数改为40000天（大于100年）（511-513）
src\components\Settings\PluginComponentsAndPages\Home\Home.vue
1.增加“不活跃黑名单主开关 + 折叠子项”逻辑（413-428）
src\contentScripts\views\Home\components\Following.vue
1.仅开启「不活跃自动黑名单」时才写入黑名单逻辑（830-832）
2.按钮关闭时取消不因无投稿自动进黑名单功能（845-848）
src\_locales\cmn-CN.yml
1.对应语言增加本开关相关文案（428-430）
src\_locales\cmn-TW.yml
1.对应语言增加本开关相关文案（382-384）//
src\_locales\en.yml
1.对应语言增加本开关相关文案(432-434)
src\_locales\jyut.yml
1.对应语言增加本开关相关文案(364-366)