### PR TITLE
fix(SearchBar): 修复搜索栏聚焦时出现的人物与搜索栏间遮挡关系的问题

### DIFF
--- a/src/components/SearchBar/SearchBar.vue
+++ b/src/components/SearchBar/SearchBar.vue
@@ -558,6 +558,7 @@ function handleClearKeyword() {
       <Transition name="focus-character">
         <img
           v-show="focusedCharacter && isFocus" :src="focusedCharacter"
+          class="focus-character-image"
           width="100" object-contain pos="absolute right-0 bottom-40px"
         >
       </Transition>
@@ -791,9 +792,20 @@ function handleClearKeyword() {
   }
 
   .search-bar {
+    .focus-character-image {
+      pointer-events: none;
+      z-index: 0;
+    }
+
+    > button {
+      z-index: 2;
+    }
+
     input {
       @include card-content;
       appearance: none;
+      position: relative;
+      z-index: 1;
 
       &[type="search"]::-webkit-search-cancel-button,
       &[type="search"]::-webkit-search-decoration,


### PR DESCRIPTION
| 修复前 | 修复后 |
--- | ---
| <img width="150" height="150" alt="image" src="https://github.com/user-attachments/assets/1f658b10-10eb-4c1e-bac1-d6e531a46d1b" /> | <img width="150" height="150" alt="image" src="https://github.com/user-attachments/assets/b5c6e849-8350-4ba5-a258-cbb5e58370bd" /> |

