### PR TITLE
修复 Firefox 系浏览器首页卡片的“稍后再看”点击失效

### DIFF
--- a/src/components/VideoCard/components/VideoCardCover.vue
+++ b/src/components/VideoCard/components/VideoCardCover.vue
@@ -509,8 +509,11 @@ onBeforeUnmount(() => {
         </div>
 
         <!-- Watcher later button -->
-        <button
+        <div
           v-if="showWatcherLater"
+          role="button"
+          tabindex="0"
+          :aria-label="isInWatchLater ? $t('common.added') : $t('common.save_to_watch_later')"
           pos="absolute top-0 right-0" z="2"
           p="x-2 y-1" m="1"
           rounded="$bew-radius"
@@ -520,6 +523,8 @@ onBeforeUnmount(() => {
           transform="scale-70 group-hover/cover:scale-100"
           duration-300
           @click.prevent.stop="emit('toggleWatchLater')"
+          @keydown.enter.prevent.stop="emit('toggleWatchLater')"
+          @keydown.space.prevent.stop="emit('toggleWatchLater')"
         >
           <Tooltip v-if="!isInWatchLater" :content="$t('common.save_to_watch_later')" placement="bottom-right" type="dark">
             <div i-mingcute:carplay-line />
@@ -527,7 +532,7 @@ onBeforeUnmount(() => {
           <Tooltip v-else :content="$t('common.added')" placement="bottom-right" type="dark">
             <Icon icon="line-md:confirm" />
           </Tooltip>
-        </button>
+        </div>
 
         <!-- Modern layout: Cover stats (bottom overlay) -->
         <div


### PR DESCRIPTION
## 问题说明

Closes #652。

在 Firefox 内核浏览器（例如 Firefox、Zen）中，首页视频卡片右上角的“稍后再看”控件无法正常触发，用户点击后不会执行预期的添加逻辑，因此也不会发出对应的请求。这个问题只在 Firefox 系浏览器上稳定出现，而 Chromium 系浏览器通常还能正常工作。

## 根因分析

首页卡片整体是通过 `ALink` 渲染出来的链接区域，封面上的“稍后再看”控件原本使用的是原生 `button` 元素。这样一来，最终 DOM 结构就变成了“可交互链接内部再嵌套一个可交互按钮”。这种交互元素嵌套本身不是稳定的结构，Chromium 对这类写法容忍度较高，但 Firefox 对事件命中和默认行为处理更严格，导致点击经常被外层链接上下文吞掉，内层按钮的切换逻辑没有真正执行。

## 修复方式

这次修改没有动“稍后再看”的业务逻辑，也没有改动接口调用链，而是只修正了控件的交互语义和事件入口：

- 将封面右上角的“稍后再看”控件从原生 `button` 改为普通元素，并保留原有的点击处理逻辑。
- 补充 `role="button"`、`tabindex="0"` 和 `aria-label`，保证这个控件仍然具备明确的按钮语义和可访问性。
- 增加 `Enter` 和空格键触发逻辑，使键盘操作和鼠标点击保持一致。
- 保留 `prevent` 和 `stop`，继续阻止事件落到外层卡片链接上，避免误触发卡片跳转。

这样做的目标是让 Firefox 不再处理“链接里嵌套原生按钮”这一不稳定结构，同时保证视觉和交互体验与原来一致。

## 验证情况

我本地完成了以下验证：

- 运行了 `vue-tsc --noEmit -p tsconfig.json`
- 运行了 `eslint src/components/VideoCard/components/VideoCardCover.vue`
- 由实际使用 Zen/Firefox 手动验证，确认首页卡片中的“稍后再看”现在可以正常工作

这次提交只包含源码修改，没有把本地构建产物一并提交。
