### PR TITLE
fix: 在原生搜索页面始终隐藏顶栏搜索框

### DIFF
--- a/src/components/TopBar/composables/useTopBarInteraction.ts
+++ b/src/components/TopBar/composables/useTopBarInteraction.ts
@@ -115,10 +115,8 @@ export function useTopBarInteraction() {
         return false
     }
     else if (isSearchPage) {
-      // 原生搜索站点本身已有搜索框；启用插件搜索结果页后，隐藏顶栏搜索框以避免重复。
-      if (settings.value.usePluginSearchResultsPage)
-        return false
-      return true
+      // 原生搜索页面本身已有搜索框，隐藏顶栏搜索框避免重复
+      return false
     }
 
     return true


### PR DESCRIPTION
fix #405 
### 问题分析
在 #654 相关修复中，在某些场景进入原生搜索页时，“启用插件搜索结果页”可以隐藏顶栏搜索框，但是未启用时仍然会出现两个搜索框
<img width="2441" height="577" alt="image" src="https://github.com/user-attachments/assets/e4fff6f4-2e8a-4e58-b896-8b87ffd29add" />
<img width="1756" height="387" alt="image" src="https://github.com/user-attachments/assets/5660d789-c982-4f31-a156-7f64213b2869" />
### 修复方法
在原生搜索页面始终隐藏搜索框