### PR TITLE
fix: resolve vite/client TypeScript type definition error

### DIFF
--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -46,6 +46,9 @@ common:
     index: 索引
     title: 标题
     name: 名称
+    keyword: 关键词
+    tag: 标签
+    category: 分区
     remark: 备注
     operations: 操作
   position:
@@ -421,6 +424,38 @@ settings:
     <kbd>Enter</kbd> 键添加新的筛选条件或确认修改。 按 <kbd>Esc</kbd> 键取消修改。 双击列以编辑当前列。
   filter_by_user_table:
     username_or_mid: 用户名 / MID
+  filter_by_up_fans_count: 按 UP 主粉丝数过滤
+  filter_by_up_fans_count_desc: 过滤粉丝数少于指定数量的 UP 主的视频。视频加载后在后台获取信息，未获取完成的 UP 主的视频会临时显示。
+  filter_by_up_fans_count_unit: 个粉丝
+  filter_by_tag: 按标签过滤
+  filter_by_tag_desc: >-
+    过滤含有指定关键词标签（标签/tag）的视频（不区分大小写）。
+    视频加载后在后台获取标签信息，未获取完成的视频会临时显示。
+    支持「热门」和「为你推荐」（网页模式和 App 模式）。
+
+    支持正则，格式为 <code>/abc&#124;\d+/</code>，前后需加 <code>/</code>。
+
+    <br/>
+
+    在下方的表格中，可以按 <kbd>Enter</kbd> 键新增或确认修改。
+
+    按 <kbd>Esc</kbd> 键取消修改。
+
+    双击列可以编辑当前列。
+  group_hot_search_filter: 热搜过滤
+  filter_hot_search: 屏蔽热搜内容
+  filter_hot_search_desc: >-
+    屏蔽包含指定关键词的热搜条目（不区分大小写）。
+
+    支持正则，格式为 <code>/abc&#124;\d+/</code>，前后需加 <code>/</code>。
+
+    <br/>
+
+    在下方的表格中，可以按 <kbd>Enter</kbd> 键新增或确认修改。
+
+    按 <kbd>Esc</kbd> 键取消修改。
+
+    双击列可以编辑当前列。
   following_tab_show_livestreaming_videos: 在 "正在关注" 中显示直播视频
   following_filter_charging_videos: 过滤充电专属视频
   following_filter_charging_videos_desc: 开启后，在 "正在关注" 页面中将隐藏需要充电才能观看的付费视频

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -46,6 +46,9 @@ common:
     index: 索引
     title: 標題
     name: 名稱
+    keyword: 關鍵詞
+    tag: 標籤
+    category: 分區
     remark: 備註
     operations: 操作
   position:
@@ -375,6 +378,38 @@ settings:
     按兩下欄位以編輯目前欄位。
   filter_by_user_table:
     username_or_mid: 使用者名稱 / MID
+  filter_by_up_fans_count: 依照 UP 主粉絲數過濾
+  filter_by_up_fans_count_desc: 過濾粉絲數少於指定數量的 UP 主的影片。影片載入後在背景取得資訊，未取得資訊的 UP 主影片會暫時顯示。
+  filter_by_up_fans_count_unit: 位粉絲
+  filter_by_tag: 依標籤過濾
+  filter_by_tag_desc: >-
+    過濾包含指定關鍵詞標籤（標籤/tag）的影片（不區分大小寫）。
+    影片載入後在背景取得標籤資訊，未取得資訊的影片會暫時顯示。
+    支援「熱門」和「為你推薦」（網頁模式和 App 模式）。
+
+    支援正規表達式，格式為 <code>/abc&#124;\d+/</code>，前後須加 <code>/</code>。
+
+    <br/>
+
+    在下方的表格中，可以按 <kbd>Enter</kbd> 鍵新增或確認修改。
+
+    按 <kbd>Esc</kbd> 鍵取消修改。
+
+    雙擊欄位可以編輯目前欄位。
+  group_hot_search_filter: 熱搜過濾
+  filter_hot_search: 封鎖熱搜內容
+  filter_hot_search_desc: >-
+    封鎖包含指定關鍵詞的熱搜條目（不區分大小寫）。
+
+    支援正規表達式，格式為 <code>/abc&#124;\d+/</code>，前後須加 <code>/</code>。
+
+    <br/>
+
+    在下方的表格中，可以按 <kbd>Enter</kbd> 鍵新增或確認修改。
+
+    按 <kbd>Esc</kbd> 鍵取消修改。
+
+    雙擊欄位可以編輯目前欄位。
   following_tab_show_livestreaming_videos: 在「正在跟隨」中顯示實況直播
   following_filter_charging_videos: 過濾充電專屬影片
   following_filter_charging_videos_desc: 啟用後，在「正在跟隨」頁面中將隱藏需要充電才能觀看的付費影片

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -46,6 +46,9 @@ common:
     index: Index
     title: Title
     name: Name
+    keyword: Keyword
+    tag: Tag
+    category: Category
     remark: Remark
     operations: Operations
   position:
@@ -425,6 +428,42 @@ settings:
     Double-click the column to edit the current column.
   filter_by_user_table:
     username_or_mid: Username / MID
+  filter_by_up_fans_count: Filter by UP fans count
+  filter_by_up_fans_count_desc: >-
+    Filter out videos from UP hosts with fewer than the specified number of followers.
+    Info is fetched in the background after videos load; videos from unfetched UPs are shown until their info arrives.
+  filter_by_up_fans_count_unit: followers
+  filter_by_tag: Filter by tag
+  filter_by_tag_desc: >-
+    Filter out videos that have any matching keyword tag (标签) attached to them (case-insensitive).
+    Tag info is fetched in the background after videos load; videos from unfetched entries are shown until their tags arrive.
+    Works on the Trending tab and For You recommendations (both web and app mode).
+
+    Alternatively, use regex, such as <code>/abc&#124;\d+/</code>, wrapped in <code>/</code>.
+
+    <br/>
+
+    In the table below, you can press the <kbd>Enter</kbd> key to add a new
+    filter or confirm a modification.
+
+    Press the <kbd>Esc</kbd> key to cancel the modification.
+
+    Double-click the column to edit the current column.
+  group_hot_search_filter: Hot Search Filter
+  filter_hot_search: Block hot search keywords
+  filter_hot_search_desc: >-
+    Block specific keywords from appearing in the hot search dropdown (case-insensitive).
+
+    Alternatively, use regex, such as <code>/abc&#124;\d+/</code>, wrapped in <code>/</code>.
+
+    <br/>
+
+    In the table below, you can press the <kbd>Enter</kbd> key to add a new
+    filter or confirm a modification.
+
+    Press the <kbd>Esc</kbd> key to cancel the modification.
+
+    Double-click the column to edit the current column.
   following_tab_show_livestreaming_videos: Show Live-streaming videos in the "Following" tab
   following_filter_charging_videos: Filter charging exclusive videos
   following_filter_charging_videos_desc: When enabled, paid videos that require charging to watch will be hidden in the "Following" page

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -46,6 +46,9 @@ common:
     index: 索引
     title: 標題
     name: 名稱
+    keyword: 關鍵詞
+    tag: 標籤
+    category: 分區
     remark: 備註
     operations: 操作
   position:
@@ -357,6 +360,39 @@ settings:
     撳兩吓欄位就可以改返入邊嘅嘢。
   filter_by_user_table:
     username_or_mid: 用戶名 / MID
+  filter_by_up_fans_count: 按 UP 主粉絲數过濾
+  filter_by_up_fans_count_desc: 过濾粉絲數少於指定數量的 UP 主的影片。影片載入後在後台取得資訊，未取得資訊的 UP 主影片會暫時顯示。
+  filter_by_up_fans_count_unit: 位粉絲
+
+  filter_by_tag: 按標籤过滤
+  filter_by_tag_desc: >-
+    过滤含有指定關鍵詞標籤（標籤/tag）的影片（不區分大小寫）。
+    影片載入後在後台取得標籤資訊，未取得資訊的影片會暫時顯示。
+    支援「熱門」同「為你推荐」（網頁模式同 App 模式）。
+
+    支援正規，格式為 <code>/abc&#124;\d+/</code>，前後須加 <code>/</code>。
+
+    <br/>
+
+    在下影表格度，可按 <kbd>Enter</kbd> 键新增或確認修改。
+
+    按 <kbd>Esc</kbd> 键取消修改。
+
+    雙擊列可編輯。
+  group_hot_search_filter: 熱搜过濾
+  filter_hot_search: 屏蔽熱搜内容
+  filter_hot_search_desc: >-
+    屏蔽包含指定关键词的熱搜條目（不區分大小寫）。
+
+    支援正規，格式為 <code>/abc&#124;\d+/</code>，前後須加 <code>/</code>。
+
+    <br/>
+
+    在下影表格度，可按 <kbd>Enter</kbd> 键新增或確認修改。
+
+    按 <kbd>Esc</kbd> 键取消修改。
+
+    雙擊列可編輯。
   following_tab_show_livestreaming_videos: 喺「跟緊啲人」入邊顯示實況直播
   following_filter_charging_videos: 過濾充電專屬影片
   following_filter_charging_videos_desc: 啟用後，喺「跟緊啲人」頁面入邊會隱藏需要充電先至可以睇嘅付費影片

--- a/src/background/messageListeners/api/user.ts
+++ b/src/background/messageListeners/api/user.ts
@@ -120,6 +120,18 @@ const API_USER = {
     },
     afterHandle: AHS.J_D,
   },
+  // https://github.com/SocialSisterYi/bilibili-API-collect/blob/master/docs/user/info.md#用户名片信息
+  getUpCardInfo: {
+    url: 'https://api.bilibili.com/x/web-interface/card',
+    _fetch: {
+      method: 'get',
+    },
+    params: {
+      mid: 0,
+      photo: false,
+    },
+    afterHandle: AHS.J_D,
+  },
 } satisfies APIMAP
 
 export default API_USER

--- a/src/background/messageListeners/api/video.ts
+++ b/src/background/messageListeners/api/video.ts
@@ -157,6 +157,17 @@ const API_VIDEO = {
     },
     afterHandle: AHS.J_D,
   },
+  // https://socialsisteryi.github.io/bilibili-API-collect/docs/video/tags.html#%E8%8E%B7%E5%8F%96%E8%A7%86%E9%A2%91%E6%A0%87%E7%AD%BE-web%E7%AB%AF
+  getVideoTags: {
+    url: 'https://api.bilibili.com/x/web-interface/view/detail/tag',
+    _fetch: {
+      method: 'get',
+    },
+    params: {
+      bvid: '',
+    },
+    afterHandle: AHS.J_D,
+  },
 } satisfies APIMAP
 
 export default API_VIDEO

--- a/src/components/SearchBar/SearchBar.vue
+++ b/src/components/SearchBar/SearchBar.vue
@@ -83,6 +83,24 @@ const searchHistory = shallowRef<HistoryItem[]>([])
 // 热搜相关状态
 const hotSearchList = ref<HotSearchItem[]>([])
 const isLoadingHotSearch = ref<boolean>(false)
+
+const filteredHotSearchList = computed<HotSearchItem[]>(() => {
+  if (!settings.value.enableBlockHotSearch || settings.value.blockHotSearch.length === 0)
+    return hotSearchList.value
+
+  const blockedStrings = settings.value.blockHotSearch
+    .filter(b => !(b.keyword.startsWith('/') && b.keyword.endsWith('/')))
+    .map(b => b.keyword.toUpperCase())
+  const blockedRegexes = settings.value.blockHotSearch
+    .filter(b => b.keyword.startsWith('/') && b.keyword.endsWith('/'))
+    .map(b => new RegExp(b.keyword.slice(1, -1), 'i'))
+
+  return hotSearchList.value.filter((item) => {
+    const kw = item.keyword.toUpperCase()
+    return !blockedStrings.some(b => kw.includes(b))
+      && !blockedRegexes.some(r => r.test(item.keyword))
+  })
+})
 // 搜索推荐相关状态
 const searchRecommendation = ref<SearchRecommendationItem | null>(null)
 const isLoadingSearchRecommendation = ref<boolean>(false)
@@ -100,7 +118,7 @@ const shouldShowSearchDropdown = computed(() => {
   if (!isFocus.value)
     return false
 
-  const hasHotSearch = (props.showHotSearch ?? settings.value.showHotSearchInTopBar) && hotSearchList.value.length > 0
+  const hasHotSearch = (props.showHotSearch ?? settings.value.showHotSearchInTopBar) && filteredHotSearchList.value.length > 0
   const hasSearchHistory = searchHistory.value.length !== 0
   if (!hasHotSearch && !hasSearchHistory)
     return false
@@ -632,7 +650,7 @@ function handleClearKeyword() {
       >
         <!-- 热搜区块 -->
         <div
-          v-if="(showHotSearch ?? settings.showHotSearchInTopBar) && hotSearchList.length > 0"
+          v-if="(showHotSearch ?? settings.showHotSearchInTopBar) && filteredHotSearchList.length > 0"
           class="hot-search-section"
         >
           <div class="title p-2 pb-0">
@@ -641,7 +659,7 @@ function handleClearKeyword() {
 
           <div class="hot-search-container p-2 grid grid-cols-2 gap-x-4 gap-y-1">
             <ALink
-              v-for="(item, index) in hotSearchList.slice(0, 10)" :key="item.keyword"
+              v-for="(item, index) in filteredHotSearchList.slice(0, 10)" :key="item.keyword"
               :href="buildKeywordHref(item.keyword)"
               type="searchBar"
               :custom-click-event="true"
@@ -674,7 +692,7 @@ function handleClearKeyword() {
 
         <!-- 分割线 -->
         <div
-          v-if="(showHotSearch ?? settings.showHotSearchInTopBar) && hotSearchList.length > 0 && searchHistory.length > 0"
+          v-if="(showHotSearch ?? settings.showHotSearchInTopBar) && filteredHotSearchList.length > 0 && searchHistory.length > 0"
           class="divider"
           mx-2 my-1 h-px bg="$bew-border-color"
         />

--- a/src/components/Settings/PluginComponentsAndPages/Home/Home.vue
+++ b/src/components/Settings/PluginComponentsAndPages/Home/Home.vue
@@ -13,6 +13,8 @@ import { getTVLoginQRCode, hasValidAppAuthTokens, pollTVLoginQRCode, revokeAcces
 import SettingsItem from '../../components/SettingsItem.vue'
 import SettingsItemGroup from '../../components/SettingsItemGroup.vue'
 import SearchPage from '../SearchPage/SearchPage.vue'
+import BlockHotSearchTable from './components/BlockHotSearchTable.vue'
+import FilterByTagTable from './components/FilterByTagTable.vue'
 import FilterByTitleTable from './components/FilterByTitleTable.vue'
 import FilterByUserTable from './components/FilterByUserTable.vue'
 
@@ -100,8 +102,16 @@ function handleCloseQRCodeDialog() {
   showQRCodeDialog.value = false
 }
 
-function handleExport(filterType: 'title' | 'user') {
-  const filters = filterType === 'title' ? settings.value.filterByTitle : settings.value.filterByUser
+function handleExport(filterType: 'title' | 'user' | 'tag' | 'hotSearch') {
+  let filters: { keyword: string, remark: string }[]
+  if (filterType === 'title')
+    filters = settings.value.filterByTitle
+  else if (filterType === 'user')
+    filters = settings.value.filterByUser
+  else if (filterType === 'tag')
+    filters = settings.value.filterByTag
+  else
+    filters = settings.value.blockHotSearch
   const jsonString = JSON.stringify(filters, null, 2) // Pretty print JSON
   const blob = new Blob([jsonString], { type: 'application/json' })
   const url = URL.createObjectURL(blob)
@@ -112,7 +122,7 @@ function handleExport(filterType: 'title' | 'user') {
   URL.revokeObjectURL(url)
 }
 
-function handleImport(filterType: 'title' | 'user') {
+function handleImport(filterType: 'title' | 'user' | 'tag' | 'hotSearch') {
   const input = document.createElement('input')
   input.type = 'file'
   input.accept = '.json'
@@ -132,8 +142,14 @@ function handleImport(filterType: 'title' | 'user') {
       if (filterType === 'title') {
         settings.value.filterByTitle = importedFilters
       }
-      else {
+      else if (filterType === 'user') {
         settings.value.filterByUser = importedFilters
+      }
+      else if (filterType === 'tag') {
+        settings.value.filterByTag = importedFilters
+      }
+      else {
+        settings.value.blockHotSearch = importedFilters
       }
       // toast.success(`${filterType} filters imported successfully`)
     }
@@ -163,6 +179,22 @@ function handleExportFilterByUser() {
 
 function handleImportFilterByUser() {
   handleImport('user')
+}
+
+function handleExportFilterByTag() {
+  handleExport('tag')
+}
+
+function handleImportFilterByTag() {
+  handleImport('tag')
+}
+
+function handleExportBlockHotSearch() {
+  handleExport('hotSearch')
+}
+
+function handleImportBlockHotSearch() {
+  handleImport('hotSearch')
 }
 
 function resetHomeTabs() {
@@ -402,6 +434,79 @@ function handleToggleHomeTab(tab: any) {
             </div>
 
             <FilterByUserTable />
+          </template>
+        </SettingsItem>
+      </div>
+
+      <SettingsItem :title="$t('settings.filter_by_up_fans_count')" :desc="$t('settings.filter_by_up_fans_count_desc')">
+        <div flex="~ justify-end" w-full>
+          <Input
+            v-if="settings.enableFilterByUpFansCount"
+            v-model="settings.filterByUpFansCount" type="number" :min="0"
+            flex-1
+          >
+            <template #suffix>
+              {{ $t('settings.filter_by_up_fans_count_unit') }}
+            </template>
+          </Input>
+          <Radio v-model="settings.enableFilterByUpFansCount" />
+        </div>
+      </SettingsItem>
+
+      <div grid="~ lg:gap-4 lg:cols-1 cols-1">
+        <SettingsItem
+          class="unrestricted-width-settings-item"
+          :title="$t('settings.filter_by_tag')"
+        >
+          <Radio v-model="settings.enableFilterByTag" />
+          <template v-if="settings.enableFilterByTag" #bottom>
+            <div text="$bew-text-2 sm" mb-2 v-html="$t('settings.filter_by_tag_desc')" />
+            <div flex="~ gap-2" mb-2>
+              <Button type="secondary" size="small" @click="handleImportFilterByTag">
+                <template #left>
+                  <div i-uil:import />
+                </template>
+                <input type="file" accept=".json" hidden>
+                {{ $t('common.operation.import') }}
+              </Button>
+              <Button type="secondary" size="small" @click="handleExportFilterByTag">
+                <template #left>
+                  <div i-uil:export />
+                </template>
+                {{ $t('common.operation.export') }}
+              </Button>
+            </div>
+            <FilterByTagTable />
+          </template>
+        </SettingsItem>
+      </div>
+    </SettingsItemGroup>
+
+    <SettingsItemGroup :title="$t('settings.group_hot_search_filter')">
+      <div grid="~ lg:gap-4 lg:cols-1 cols-1">
+        <SettingsItem
+          class="unrestricted-width-settings-item"
+          :title="$t('settings.filter_hot_search')"
+        >
+          <Radio v-model="settings.enableBlockHotSearch" />
+          <template v-if="settings.enableBlockHotSearch" #bottom>
+            <div text="$bew-text-2 sm" mb-2 v-html="$t('settings.filter_hot_search_desc')" />
+            <div flex="~ gap-2" mb-2>
+              <Button type="secondary" size="small" @click="handleImportBlockHotSearch">
+                <template #left>
+                  <div i-uil:import />
+                </template>
+                <input type="file" accept=".json" hidden>
+                {{ $t('common.operation.import') }}
+              </Button>
+              <Button type="secondary" size="small" @click="handleExportBlockHotSearch">
+                <template #left>
+                  <div i-uil:export />
+                </template>
+                {{ $t('common.operation.export') }}
+              </Button>
+            </div>
+            <BlockHotSearchTable />
           </template>
         </SettingsItem>
       </div>

--- a/src/components/Settings/PluginComponentsAndPages/Home/components/BlockHotSearchTable.vue
+++ b/src/components/Settings/PluginComponentsAndPages/Home/components/BlockHotSearchTable.vue
@@ -1,0 +1,191 @@
+<script lang="ts" setup>
+import { onKeyStroke } from '@vueuse/core'
+import { useI18n } from 'vue-i18n'
+import { useToast } from 'vue-toastification'
+
+import { settings } from '~/logic'
+
+const { t } = useI18n()
+const toast = useToast()
+
+const addingFilter = ref<{ keyword: string, remark: string }>({ keyword: '', remark: '' })
+const editingFilter = ref<{ keyword: string, remark: string }>({ keyword: '', remark: '' })
+const editingIndex = ref<number>(-1)
+const keywordRef = ref<HTMLInputElement | null>(null)
+const remarkRef = ref<HTMLInputElement | null>(null)
+
+function handleAddFilter() {
+  if (!addingFilter.value.keyword.trim())
+    return
+
+  const hasDuplicate = settings.value.blockHotSearch.find(
+    (item, itemIndex) => item.keyword === addingFilter.value.keyword.trim() && itemIndex !== editingIndex.value,
+  )
+  if (hasDuplicate) {
+    toast.warning(t('settings.filter_item_already_exist'))
+    return
+  }
+  settings.value.blockHotSearch.unshift({ ...addingFilter.value })
+  nextTick(() => {
+    handleClearAddingFilter()
+  })
+}
+
+function handleClearAddingFilter() {
+  addingFilter.value = { keyword: '', remark: '' }
+}
+
+async function handleEditFilter(index: number, focusItem: 'keyword' | 'remark' = 'keyword') {
+  editingIndex.value = index
+  editingFilter.value = { ...settings.value.blockHotSearch[index] }
+  await nextTick()
+
+  const inputElement = focusItem === 'keyword' ? keywordRef.value : remarkRef.value
+  if (Array.isArray(inputElement)) {
+    inputElement[0]?.focus()
+  }
+  else {
+    inputElement?.focus()
+  }
+}
+
+function handleConfirmFilter(index: number) {
+  if (!editingFilter.value.keyword.trim())
+    return
+
+  const hasDuplicate = settings.value.blockHotSearch.find(
+    (item, itemIndex) => item.keyword === editingFilter.value.keyword.trim() && itemIndex !== index,
+  )
+  if (hasDuplicate) {
+    toast.warning(t('settings.filter_item_already_exist'))
+    return
+  }
+  settings.value.blockHotSearch[index] = { ...editingFilter.value }
+  if (index !== -1)
+    editingIndex.value = -1
+}
+
+function handleDeleteFilter(index: number) {
+  settings.value.blockHotSearch.splice(index, 1)
+}
+
+onKeyStroke('Escape', (e: KeyboardEvent) => {
+  e.preventDefault()
+  editingIndex.value = -1
+})
+</script>
+
+<template>
+  <div>
+    <div flex="~ gap-1" bg="$bew-fill-1" p-2 mb-2 rounded="$bew-radius">
+      <Input
+        v-model="addingFilter.keyword"
+        size="small"
+        :placeholder="$t('common.table.keyword')"
+        w-full
+        @click="editingIndex = -1"
+        @enter="handleAddFilter"
+      />
+      <Input
+        v-model="addingFilter.remark"
+        size="small"
+        :placeholder="$t('common.table.remark')"
+        w-full
+        @click="editingIndex = -1"
+        @enter="handleAddFilter"
+      />
+
+      <Button
+        size="small" type="primary"
+        style="--b-button-width: 80px"
+        shrink-0
+        @click="handleAddFilter"
+      >
+        <template #left>
+          <i i-mingcute:add-line />
+        </template>
+        {{ $t('common.operation.add') }}
+      </Button>
+    </div>
+
+    <List
+      highlight-first
+      pin-top
+      w-full max-h-400px overflow-overlay
+    >
+      <ListItem min-h-44px>
+        <div max-w-50px>
+          {{ $t('common.table.index') }}
+        </div>
+        <div>{{ $t('common.table.keyword') }}</div>
+        <div>{{ $t('common.table.remark') }}</div>
+        <div max-w-80px>
+          {{ $t('common.table.operations') }}
+        </div>
+      </ListItem>
+
+      <ListItem
+        v-for="(item, index) in settings.blockHotSearch" :key="item.keyword"
+        :style="{
+          background: editingIndex === index ? 'var(--bew-theme-color-20) !important' : '',
+        }"
+      >
+        <div max-w-50px>
+          {{ index }}
+        </div>
+        <template v-if="editingIndex === index">
+          <Input
+            ref="keywordRef"
+            v-model="editingFilter.keyword"
+            size="small"
+            :placeholder="$t('common.table.keyword')"
+            w-full
+            @enter="handleConfirmFilter(index)"
+          />
+          <Input
+            ref="remarkRef"
+            v-model="editingFilter.remark"
+            size="small"
+            :placeholder="$t('common.table.remark')"
+            w-full
+            @enter="handleConfirmFilter(index)"
+          />
+        </template>
+        <template v-else>
+          <div break-anywhere @dblclick="handleEditFilter(index, 'keyword')">
+            {{ item.keyword }}
+          </div>
+          <div break-anywhere @dblclick="handleEditFilter(index, 'remark')">
+            {{ item.remark }}
+          </div>
+        </template>
+        <div flex="~ gap-1" max-w-80px>
+          <template v-if="editingIndex === index">
+            <Button size="small" type="tertiary" @click="handleConfirmFilter(index)">
+              <template #left>
+                <i i-mingcute:check-line />
+              </template>
+            </Button>
+            <Button size="small" type="tertiary" @click="editingIndex = -2">
+              <template #left>
+                <i i-mingcute:close-line />
+              </template>
+            </Button>
+          </template>
+          <template v-else>
+            <Button size="small" type="tertiary" @click="handleEditFilter(index)">
+              <template #left>
+                <i i-mingcute:edit-2-line />
+              </template>
+            </Button>
+            <Button size="small" type="tertiary" @click="handleDeleteFilter(index)">
+              <template #left>
+                <i i-mingcute:delete-2-line />
+              </template>
+            </Button>
+          </template>
+        </div>
+      </ListItem>
+    </List>
+  </div>
+</template>

--- a/src/components/Settings/PluginComponentsAndPages/Home/components/FilterByTagTable.vue
+++ b/src/components/Settings/PluginComponentsAndPages/Home/components/FilterByTagTable.vue
@@ -1,0 +1,191 @@
+<script lang="ts" setup>
+import { onKeyStroke } from '@vueuse/core'
+import { useI18n } from 'vue-i18n'
+import { useToast } from 'vue-toastification'
+
+import { settings } from '~/logic'
+
+const { t } = useI18n()
+const toast = useToast()
+
+const addingFilter = ref<{ keyword: string, remark: string }>({ keyword: '', remark: '' })
+const editingFilter = ref<{ keyword: string, remark: string }>({ keyword: '', remark: '' })
+const editingIndex = ref<number>(-1)
+const keywordRef = ref<HTMLInputElement | null>(null)
+const remarkRef = ref<HTMLInputElement | null>(null)
+
+function handleAddFilter() {
+  if (!addingFilter.value.keyword.trim())
+    return
+
+  const hasDuplicate = settings.value.filterByTag.find(
+    (item, itemIndex) => item.keyword === addingFilter.value.keyword.trim() && itemIndex !== editingIndex.value,
+  )
+  if (hasDuplicate) {
+    toast.warning(t('settings.filter_item_already_exist'))
+    return
+  }
+  settings.value.filterByTag.unshift({ ...addingFilter.value })
+  nextTick(() => {
+    handleClearAddingFilter()
+  })
+}
+
+function handleClearAddingFilter() {
+  addingFilter.value = { keyword: '', remark: '' }
+}
+
+async function handleEditFilter(index: number, focusItem: 'keyword' | 'remark' = 'keyword') {
+  editingIndex.value = index
+  editingFilter.value = { ...settings.value.filterByTag[index] }
+  await nextTick()
+
+  const inputElement = focusItem === 'keyword' ? keywordRef.value : remarkRef.value
+  if (Array.isArray(inputElement)) {
+    inputElement[0]?.focus()
+  }
+  else {
+    inputElement?.focus()
+  }
+}
+
+function handleConfirmFilter(index: number) {
+  if (!editingFilter.value.keyword.trim())
+    return
+
+  const hasDuplicate = settings.value.filterByTag.find(
+    (item, itemIndex) => item.keyword === editingFilter.value.keyword.trim() && itemIndex !== index,
+  )
+  if (hasDuplicate) {
+    toast.warning(t('settings.filter_item_already_exist'))
+    return
+  }
+  settings.value.filterByTag[index] = { ...editingFilter.value }
+  if (index !== -1)
+    editingIndex.value = -1
+}
+
+function handleDeleteFilter(index: number) {
+  settings.value.filterByTag.splice(index, 1)
+}
+
+onKeyStroke('Escape', (e: KeyboardEvent) => {
+  e.preventDefault()
+  editingIndex.value = -1
+})
+</script>
+
+<template>
+  <div>
+    <div flex="~ gap-1" bg="$bew-fill-1" p-2 mb-2 rounded="$bew-radius">
+      <Input
+        v-model="addingFilter.keyword"
+        size="small"
+        :placeholder="$t('common.table.tag')"
+        w-full
+        @click="editingIndex = -1"
+        @enter="handleAddFilter"
+      />
+      <Input
+        v-model="addingFilter.remark"
+        size="small"
+        :placeholder="$t('common.table.remark')"
+        w-full
+        @click="editingIndex = -1"
+        @enter="handleAddFilter"
+      />
+
+      <Button
+        size="small" type="primary"
+        style="--b-button-width: 80px"
+        shrink-0
+        @click="handleAddFilter"
+      >
+        <template #left>
+          <i i-mingcute:add-line />
+        </template>
+        {{ $t('common.operation.add') }}
+      </Button>
+    </div>
+
+    <List
+      highlight-first
+      pin-top
+      w-full max-h-400px overflow-overlay
+    >
+      <ListItem min-h-44px>
+        <div max-w-50px>
+          {{ $t('common.table.index') }}
+        </div>
+        <div>{{ $t('common.table.tag') }}</div>
+        <div>{{ $t('common.table.remark') }}</div>
+        <div max-w-80px>
+          {{ $t('common.table.operations') }}
+        </div>
+      </ListItem>
+
+      <ListItem
+        v-for="(item, index) in settings.filterByTag" :key="item.keyword"
+        :style="{
+          background: editingIndex === index ? 'var(--bew-theme-color-20) !important' : '',
+        }"
+      >
+        <div max-w-50px>
+          {{ index }}
+        </div>
+        <template v-if="editingIndex === index">
+          <Input
+            ref="keywordRef"
+            v-model="editingFilter.keyword"
+            size="small"
+            :placeholder="$t('common.table.tag')"
+            w-full
+            @enter="handleConfirmFilter(index)"
+          />
+          <Input
+            ref="remarkRef"
+            v-model="editingFilter.remark"
+            size="small"
+            :placeholder="$t('common.table.remark')"
+            w-full
+            @enter="handleConfirmFilter(index)"
+          />
+        </template>
+        <template v-else>
+          <div break-anywhere @dblclick="handleEditFilter(index, 'keyword')">
+            {{ item.keyword }}
+          </div>
+          <div break-anywhere @dblclick="handleEditFilter(index, 'remark')">
+            {{ item.remark }}
+          </div>
+        </template>
+        <div flex="~ gap-1" max-w-80px>
+          <template v-if="editingIndex === index">
+            <Button size="small" type="tertiary" @click="handleConfirmFilter(index)">
+              <template #left>
+                <i i-mingcute:check-line />
+              </template>
+            </Button>
+            <Button size="small" type="tertiary" @click="editingIndex = -2">
+              <template #left>
+                <i i-mingcute:close-line />
+              </template>
+            </Button>
+          </template>
+          <template v-else>
+            <Button size="small" type="tertiary" @click="handleEditFilter(index)">
+              <template #left>
+                <i i-mingcute:edit-2-line />
+              </template>
+            </Button>
+            <Button size="small" type="tertiary" @click="handleDeleteFilter(index)">
+              <template #left>
+                <i i-mingcute:delete-2-line />
+              </template>
+            </Button>
+          </template>
+        </div>
+      </ListItem>
+    </List>
+  </div>
+</template>

--- a/src/composables/useUpInfoCache.ts
+++ b/src/composables/useUpInfoCache.ts
@@ -1,0 +1,83 @@
+import { settings } from '~/logic'
+import api from '~/utils/api'
+
+interface UpInfo {
+  fans: number
+  level: number
+}
+
+// Shared reactive cache of mid -> UpInfo
+const upInfoCache = reactive(new Map<number, UpInfo>())
+// Track in-flight requests to avoid duplicate fetches
+const pendingFetches = new Set<number>()
+
+async function fetchUpInfo(mids: number[]): Promise<void> {
+  const toFetch = mids.filter(mid => mid > 0 && !upInfoCache.has(mid) && !pendingFetches.has(mid))
+  if (toFetch.length === 0)
+    return
+
+  for (const mid of toFetch)
+    pendingFetches.add(mid)
+
+  // Fetch individually — bilibili card API does not support batch for other users
+  await Promise.allSettled(
+    toFetch.map(async (mid) => {
+      try {
+        const res = await api.user.getUpCardInfo({ mid })
+        if (res?.code === 0 && res.data?.card) {
+          upInfoCache.set(mid, {
+            fans: res.data.follower ?? res.data.card?.fans ?? 0,
+            level: res.data.card?.level_info?.current_level ?? 0,
+          })
+        }
+      }
+      catch {
+        // ignore individual fetch errors
+      }
+      finally {
+        pendingFetches.delete(mid)
+      }
+    }),
+  )
+}
+
+/**
+ * Given a list of video items (each having owner.mid), fetch UP info in the
+ * background and return a reactive filtered list that removes videos whose UP's
+ * fans count is below the threshold once UP info is known.
+ */
+export function useUpInfoFilter<T>(
+  videoList: Ref<T[]>,
+  getMid: (item: T) => number,
+) {
+  // Trigger background fetches whenever the list changes
+  watch(
+    videoList,
+    (items: T[]) => {
+      if (!settings.value.enableFilterByUpFansCount)
+        return
+      const mids: number[] = [...new Set(items.map(getMid).filter(m => m > 0))]
+      if (mids.length > 0)
+        fetchUpInfo(mids)
+    },
+    { immediate: true },
+  )
+
+  const filteredList = computed<T[]>(() => {
+    if (!settings.value.enableFilterByUpFansCount)
+      return videoList.value
+
+    const threshold = settings.value.filterByUpFansCount
+    return videoList.value.filter((item) => {
+      const mid = getMid(item)
+      if (mid <= 0)
+        return true // non-user items pass through
+      const info = upInfoCache.get(mid)
+      if (!info)
+        return true // not yet fetched — show optimistically
+      return info.fans >= threshold
+    })
+  })
+
+  return { filteredList }
+}

--- a/src/composables/useVideoTagCache.ts
+++ b/src/composables/useVideoTagCache.ts
@@ -1,0 +1,94 @@
+import { settings } from '~/logic'
+import api from '~/utils/api'
+
+// Shared reactive cache of bvid -> tag name list
+const videoTagCache = reactive(new Map<string, string[]>())
+// Track in-flight requests to avoid duplicate fetches
+const pendingFetches = new Set<string>()
+
+async function fetchVideoTags(bvids: string[]): Promise<void> {
+  const toFetch = bvids.filter(bvid => bvid && !videoTagCache.has(bvid) && !pendingFetches.has(bvid))
+  if (toFetch.length === 0)
+    return
+
+  for (const bvid of toFetch)
+    pendingFetches.add(bvid)
+
+  await Promise.allSettled(
+    toFetch.map(async (bvid) => {
+      try {
+        const res = await api.video.getVideoTags({ bvid })
+        if (res?.code === 0 && Array.isArray(res.data)) {
+          videoTagCache.set(bvid, res.data.map((t: any) => t.tag_name as string))
+        }
+      }
+      catch {
+        // ignore individual fetch errors
+      }
+      finally {
+        pendingFetches.delete(bvid)
+      }
+    }),
+  )
+}
+
+/**
+ * Given a list of video items (each having a bvid), fetch video tags in the
+ * background and return a reactive filtered list that removes videos whose tags
+ * match any of the blocked tag keywords once tags are known.
+ *
+ * Videos are shown optimistically until their tags arrive.
+ */
+export function useVideoTagFilter<T>(
+  videoList: Ref<T[]>,
+  getBvid: (item: T) => string,
+) {
+  // Trigger background fetches whenever the list changes
+  watch(
+    videoList,
+    (items: T[]) => {
+      if (!settings.value.enableFilterByTag)
+        return
+      const bvids: string[] = [...new Set(items.map(getBvid).filter(b => !!b))]
+      if (bvids.length > 0)
+        fetchVideoTags(bvids)
+    },
+    { immediate: true },
+  )
+
+  const filteredList = computed<T[]>(() => {
+    if (!settings.value.enableFilterByTag || settings.value.filterByTag.length === 0)
+      return videoList.value
+
+    // Pre-build match predicates from blocked keyword list
+    const stringKeywords: string[] = []
+    const regexKeywords: RegExp[] = []
+    for (const entry of settings.value.filterByTag) {
+      const kw = entry.keyword
+      if (kw.startsWith('/') && kw.endsWith('/')) {
+        regexKeywords.push(new RegExp(kw.slice(1, -1), 'i'))
+      }
+      else {
+        stringKeywords.push(kw.toUpperCase())
+      }
+    }
+
+    return videoList.value.filter((item) => {
+      const bvid = getBvid(item)
+      if (!bvid)
+        return true // non-bvid items pass through
+      const tags = videoTagCache.get(bvid)
+      if (!tags)
+        return true // not yet fetched — show optimistically
+
+      // Block if ANY tag matches ANY blocked keyword
+      const blocked = tags.some(tag =>
+        stringKeywords.some(kw => tag.toUpperCase().includes(kw))
+        || regexKeywords.some(rx => rx.test(tag)),
+      )
+      return !blocked
+    })
+  })
+
+  return { filteredList }
+}

--- a/src/contentScripts/views/Home/components/ForYou.vue
+++ b/src/contentScripts/views/Home/components/ForYou.vue
@@ -5,6 +5,8 @@ import { useToast } from 'vue-toastification'
 import VideoCardGrid from '~/components/VideoCardGrid.vue'
 import { UndoForwardState, useBewlyApp } from '~/composables/useAppProvider'
 import { FilterType, useFilter } from '~/composables/useFilter'
+import { useUpInfoFilter } from '~/composables/useUpInfoCache'
+import { useVideoTagFilter } from '~/composables/useVideoTagCache'
 import { LanguageType } from '~/enums/appEnums'
 import type { GridLayoutType } from '~/logic'
 import { appAuthTokens, settings } from '~/logic'
@@ -78,9 +80,17 @@ const { handleReachBottom, handlePageRefresh, haveScrollbar, undoForwardState, h
 const videoList = ref<VideoElement[]>([])
 const appVideoList = ref<AppVideoElement[]>([])
 
+// UP fans count filter — async, applied reactively
+const { filteredList: fansFilteredWebVideoList } = useUpInfoFilter<VideoElement>(videoList, el => el.item?.owner?.mid ?? 0)
+const { filteredList: fansFilteredAppVideoList } = useUpInfoFilter<AppVideoElement>(appVideoList, el => el.item?.args?.up_id ?? 0)
+
+// Video tag filter — async, applied on top of fans filter
+const { filteredList: filteredWebVideoList } = useVideoTagFilter<VideoElement>(fansFilteredWebVideoList, el => el.item?.bvid ?? '')
+const { filteredList: filteredAppVideoList } = useVideoTagFilter<AppVideoElement>(fansFilteredAppVideoList, el => el.item?.bvid ?? '')
+
 // 当前使用的视频列表（根据推荐模式）
 const currentVideoList = computed(() =>
-  settings.value.recommendationMode === 'web' ? videoList.value : appVideoList.value,
+  settings.value.recommendationMode === 'web' ? filteredWebVideoList.value : filteredAppVideoList.value,
 )
 
 const isLoading = ref<boolean>(false)

--- a/src/contentScripts/views/Home/components/Trending.vue
+++ b/src/contentScripts/views/Home/components/Trending.vue
@@ -2,6 +2,9 @@
 import type { Video } from '~/components/VideoCard/types'
 import VideoCardGrid from '~/components/VideoCardGrid.vue'
 import { useBewlyApp } from '~/composables/useAppProvider'
+import { FilterType, useFilter } from '~/composables/useFilter'
+import { useUpInfoFilter } from '~/composables/useUpInfoCache'
+import { useVideoTagFilter } from '~/composables/useVideoTagCache'
 import type { GridLayoutType } from '~/logic'
 import type { List as VideoItem, TrendingResult } from '~/models/video/trending'
 import api from '~/utils/api'
@@ -27,6 +30,15 @@ const isLoading = ref<boolean>(false)
 const pn = ref<number>(1)
 const noMoreContent = ref<boolean>(false)
 const { handleReachBottom, handlePageRefresh } = useBewlyApp()
+
+const filterFunc = useFilter(
+  [], // Trending has no "followed" concept
+  [FilterType.viewCount, FilterType.likeCount, FilterType.duration, FilterType.title, FilterType.user, FilterType.user, FilterType.publishTime],
+  [['stat', 'view'], ['stat', 'like'], ['duration'], ['title'], ['owner', 'name'], ['owner', 'mid'], ['pubdate']],
+)
+
+const { filteredList: fansFilteredList } = useUpInfoFilter<VideoElement>(videoList, el => el.item?.owner?.mid ?? 0)
+const { filteredList } = useVideoTagFilter<VideoElement>(fansFilteredList, el => el.item?.bvid ?? '')
 
 onMounted(() => {
   initData()
@@ -147,11 +159,11 @@ defineExpose({ initData })
 
 <template>
   <VideoCardGrid
-    :items="videoList"
+    :items="filteredList"
     :grid-layout="gridLayout"
     :loading="isLoading"
     :no-more-content="noMoreContent"
-    :transform-item="(item: VideoElement) => item.displayData"
+    :transform-item="(item: VideoElement) => filterFunc.value && item.item ? filterFunc.value(item.item) ? item.displayData : undefined : item.displayData"
     :get-item-key="(item: VideoElement) => item.uniqueId"
     show-preview
     @refresh="initData"

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="vite/client" />
+
 declare const __DEV__: boolean
 
 declare module '*.vue' {

--- a/src/logic/storage.ts
+++ b/src/logic/storage.ts
@@ -287,6 +287,18 @@ export interface Settings {
   enableFilterByPublishTime: boolean
   filterByPublishTime: number // 单位：天
 
+  // video tag (标签) filter — requires async /x/web-interface/view/detail/tag API fetch
+  enableFilterByTag: boolean
+  filterByTag: { keyword: string, remark: string }[]
+
+  // UP fans count filter — requires async API fetch, applied in ForYou
+  enableFilterByUpFansCount: boolean
+  filterByUpFansCount: number
+
+  // hot search keyword blocklist — applied in SearchBar
+  enableBlockHotSearch: boolean
+  blockHotSearch: { keyword: string, remark: string }[]
+
   followingTabShowLivestreamingVideos: boolean
   followingFilterChargingVideos: boolean // 过滤充电专属视频
   followingFilterDynamicVideos: boolean // 过滤动态视频
@@ -504,6 +516,15 @@ export const originalSettings: Settings = {
   filterByUser: [],
   enableFilterByPublishTime: false,
   filterByPublishTime: 30, // 默认30天
+
+  enableFilterByTag: false,
+  filterByTag: [],
+
+  enableFilterByUpFansCount: false,
+  filterByUpFansCount: 10000,
+
+  enableBlockHotSearch: false,
+  blockHotSearch: [],
 
   followingTabShowLivestreamingVideos: false,
   followingFilterChargingVideos: false, // 默认不过滤充电视频

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,9 +10,6 @@
       "~/*": ["./src/*"]
     },
     "resolveJsonModule": true,
-    "types": [
-      "vite/client"
-    ],
     "strict": true,
     "noImplicitAny": false,
     "noUnusedLocals": true,


### PR DESCRIPTION
## Summary

Fixes a TypeScript error reported by `vue-tsc`:
> Cannot find type definition file for 'vite/client'. The file is in the program because: Entry point of type library 'vite/client' specified in compilerOptions

## Changes

- **`tsconfig.json`**: Removed `"vite/client"` from the `types` array. The `types` array is intended for `@types/xxx` packages, not subpath entries like `vite/client`.
- **`src/global.d.ts`**: Added `/// <reference types="vite/client" />` triple-slash directive, which is the correct way to include Vite's client-side type augmentations (`import.meta.env`, `import.meta.hot`, etc.) — especially with `moduleResolution: "bundler"` and Vite 7.