### PR TITLE
feat: 新增无 Cookie 推荐模式

### DIFF
--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -383,7 +383,8 @@ settings:
   individually_set_search_page_wallpaper: 单独设置搜索页背景
   recommendation_mode: 推荐模式
   recommendation_mode_desc: |
-    如果您想使用 app 端的推荐算法，请先授权 BewlyCat 使用 access key。
+    Web：普通网页端推荐模式。无 Cookie：请求首页推荐时不携带 Cookie。App：移动端推荐模式，需先授权 access key。
+  recommendation_mode_web_no_cookie: 无Cookie
   auto_switch_recommendation_mode: 自动切换推荐模式
   auto_switch_recommendation_mode_desc: |
     当 App 推荐失败时自动切换至 Web 模式。

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -322,7 +322,8 @@ settings:
   individually_set_search_page_wallpaper: 單獨設定搜尋頁背景
   recommendation_mode: 推薦模式
   recommendation_mode_desc: |
-    如果您想要使用手機端的推薦演算法，請先授權 BewlyBewly 使用 access key。
+    Web：普通網頁端推薦模式。無 Cookie：請求首頁推薦時不攜帶 Cookie。App：手機端推薦模式，需先授權 access key。
+  recommendation_mode_web_no_cookie: 無Cookie
   auto_switch_recommendation_mode: 自動切換推薦模式
   auto_switch_recommendation_mode_desc: |
     當手機端推薦失敗時自動切換至網頁模式。

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -359,8 +359,10 @@ settings:
   individually_set_search_page_wallpaper: Individually set search page wallpaper
   recommendation_mode: Recommendation mode
   recommendation_mode_desc: >
-    If you want to use the recommendation algorithm on the app, please ensure
-    that you authorize the BewlyBewly to use the access key first.
+    Web: normal web recommendation mode. No Cookie: request homepage
+    recommendations without cookies. App: mobile recommendation mode, requires
+    an access key first.
+  recommendation_mode_web_no_cookie: No Cookie
   auto_switch_recommendation_mode: Auto switch recommendation mode
   auto_switch_recommendation_mode_desc: >
     Automatically switch from App mode to Web mode when App recommendation fails.

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -304,7 +304,8 @@ settings:
   individually_set_search_page_wallpaper: 單獨設定搵嘢頁背景
   recommendation_mode: 推介模式
   recommendation_mode_desc: |
-    若然你想用手機版嘅推介演算法，就要俾 BewlyBewly 批准使用存取 access key。
+    Web：普通網頁版推介模式。無 Cookie：請求首頁推介時唔帶 Cookie。App：手機版推介模式，要先授權 access key。
+  recommendation_mode_web_no_cookie: 無Cookie
   auto_switch_recommendation_mode: 自動切換推介模式
   auto_switch_recommendation_mode_desc: |
     當手機版推介壞咗嗰陣自動切換到網頁模式。

--- a/src/background/messageListeners/api/video.ts
+++ b/src/background/messageListeners/api/video.ts
@@ -1,23 +1,36 @@
 import type { APIMAP } from '../../utils'
 import { AHS } from '../../utils'
 
+const WEB_RECOMMEND_URL = 'https://api.bilibili.com/x/web-interface/wbi/index/top/feed/rcmd'
+
+const WEB_RECOMMEND_PARAMS = {
+  fresh_type: 4, // 相关性控制
+  feed_version: 'V8', // Feed版本
+  homepage_ver: 1, // 首页版本
+  ps: 12, // 单页记录数，默认12，最大30（调用时可覆盖）
+  fresh_idx: 1, // 翻页号，从1开始（调用时会动态传入）
+  fresh_idx_1h: 1, // 翻页号(一小时前?)，默认与 fresh_idx 相同
+  fetch_row: undefined as number | undefined, // 本次抓取的最后一行行号（可选）
+  last_showlist: '', // 上次抓取的视频av号列表（可选）
+}
+
 const API_VIDEO = {
   // https://socialsisteryi.github.io/bilibili-API-collect/docs/video/recommend.html#%E8%8E%B7%E5%8F%96%E9%A6%96%E9%A1%B5%E8%A7%86%E9%A2%91%E6%8E%A8%E8%8D%90%E5%88%97%E8%A1%A8-web%E7%AB%AF
   getRecommendVideos: {
-    url: 'https://api.bilibili.com/x/web-interface/wbi/index/top/feed/rcmd',
+    url: WEB_RECOMMEND_URL,
     _fetch: {
       method: 'get',
     },
-    params: {
-      fresh_type: 4, // 相关性控制
-      feed_version: 'V8', // Feed版本
-      homepage_ver: 1, // 首页版本
-      ps: 12, // 单页记录数，默认12，最大30（调用时可覆盖）
-      fresh_idx: 1, // 翻页号，从1开始（调用时会动态传入）
-      fresh_idx_1h: 1, // 翻页号(一小时前?)，默认与 fresh_idx 相同
-      fetch_row: undefined as number | undefined, // 本次抓取的最后一行行号（可选）
-      last_showlist: '', // 上次抓取的视频av号列表（可选）
+    params: WEB_RECOMMEND_PARAMS,
+    afterHandle: AHS.J_D,
+  },
+  getNoCookieRecommendVideos: {
+    url: WEB_RECOMMEND_URL,
+    _fetch: {
+      method: 'get',
+      credentials: 'omit',
     },
+    params: WEB_RECOMMEND_PARAMS,
     afterHandle: AHS.J_D,
   },
   getAppRecommendVideos: {

--- a/src/background/utils.ts
+++ b/src/background/utils.ts
@@ -71,6 +71,7 @@ interface _FETCH {
     [key: string]: any
   }
   body?: any
+  credentials?: RequestCredentials
 }
 
 interface API {
@@ -102,6 +103,9 @@ function apiListenerFactory(API_MAP: APIMAP) {
 
     // eslint-disable-next-line node/prefer-global/process
     if (process.env.FIREFOX && sender && sender.tab?.id) {
+      if (api._fetch.credentials === 'omit')
+        return await doRequest(typedMessage, api)
+
       // 获取tab信息以获取正确的cookieStoreId
       const tab = await browser.tabs.get(sender.tab.id)
       const storeId = tab.cookieStoreId || 'default'
@@ -120,7 +124,7 @@ async function doRequest(message: Message, api: API, sendResponse?: (response?: 
     rest = rest || {}
 
     let { _fetch, url, params = {}, afterHandle } = api
-    const { method, headers = {}, body } = _fetch as _FETCH
+    const { method, headers = {}, body, credentials = 'include' } = _fetch as _FETCH
     const isGET = method.toLocaleLowerCase() === 'get'
     // merge params and body
     const targetParams = Object.assign({}, params)
@@ -138,7 +142,7 @@ async function doRequest(message: Message, api: API, sendResponse?: (response?: 
     // 如果需要WBI签名但没有密钥，主动获取密钥
     if (needsWbi && !getWbiKeys()) {
       try {
-        await initWbiKeys()
+        await initWbiKeys({ noCookie: credentials === 'omit' })
       }
       catch (error) {
         // 获取密钥失败，继续执行（降级到无签名请求）
@@ -179,7 +183,7 @@ async function doRequest(message: Message, api: API, sendResponse?: (response?: 
 
       // generate cookies
       const requestHeaders = { ...headers }
-      if (cookies) {
+      if (cookies && credentials !== 'omit') {
         const cookieStr = cookies.map(cookie => `${cookie.name}=${cookie.value}`).join('; ')
         requestHeaders['firefox-multi-account-cookie'] = cookieStr
       }
@@ -198,7 +202,7 @@ async function doRequest(message: Message, api: API, sendResponse?: (response?: 
       const fetchOpt: any = {
         method,
         headers: requestHeaders,
-        credentials: 'include', // 重要：在Chrome/Edge中必须添加此项才能携带Cookie
+        credentials,
       }
       if (!isGET)
         fetchOpt.body = requestBody

--- a/src/background/wbiSign.ts
+++ b/src/background/wbiSign.ts
@@ -13,6 +13,7 @@ let wbiKeysCache: WbiKeys | null = null
 
 // 正在获取密钥的Promise，用于避免并发重复获取
 let fetchingKeysPromise: Promise<boolean> | null = null
+let fetchingNoCookieKeysPromise: Promise<boolean> | null = null
 
 /**
  * 简单的MD5实现（用于WBI签名）
@@ -326,22 +327,28 @@ async function getBilibiliCookies(): Promise<string> {
  * 应该在扩展启动时调用
  * 使用单例模式避免并发重复获取
  */
-export async function initWbiKeys(): Promise<boolean> {
+export async function initWbiKeys(options: { noCookie?: boolean } = {}): Promise<boolean> {
+  const noCookie = options.noCookie === true
+
   // 如果已经有密钥且未过期，直接返回成功
   if (getWbiKeys()) {
     return true
   }
 
   // 如果正在获取中，等待当前获取完成
-  if (fetchingKeysPromise) {
+  if (noCookie) {
+    if (fetchingNoCookieKeysPromise)
+      return await fetchingNoCookieKeysPromise
+  }
+  else if (fetchingKeysPromise) {
     return await fetchingKeysPromise
   }
 
   // 开始新的获取流程
-  fetchingKeysPromise = (async () => {
+  const fetchPromise = (async () => {
     try {
       // 获取B站cookie
-      const cookieStr = await getBilibiliCookies()
+      const cookieStr = noCookie ? '' : await getBilibiliCookies()
 
       const headers: HeadersInit = {
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
@@ -356,7 +363,7 @@ export async function initWbiKeys(): Promise<boolean> {
       const navResponse = await fetch('https://api.bilibili.com/x/web-interface/nav', {
         method: 'GET',
         headers,
-        credentials: 'include',
+        credentials: noCookie ? 'omit' : 'include',
       })
       const navData = await navResponse.json()
 
@@ -385,11 +392,19 @@ export async function initWbiKeys(): Promise<boolean> {
     }
     finally {
       // 清除获取中的Promise标志
-      fetchingKeysPromise = null
+      if (noCookie)
+        fetchingNoCookieKeysPromise = null
+      else
+        fetchingKeysPromise = null
     }
   })()
 
-  return await fetchingKeysPromise
+  if (noCookie)
+    fetchingNoCookieKeysPromise = fetchPromise
+  else
+    fetchingKeysPromise = fetchPromise
+
+  return await fetchPromise
 }
 
 /**

--- a/src/components/Settings/PluginComponentsAndPages/Home/Home.vue
+++ b/src/components/Settings/PluginComponentsAndPages/Home/Home.vue
@@ -190,9 +190,10 @@ function handleToggleHomeTab(tab: any) {
         <template #desc>
           <p>{{ $t('settings.recommendation_mode_desc') }}</p>
         </template>
-        <div w-full flex rounded="$bew-radius" bg="$bew-fill-1" p-1>
+        <div class="recommendation-mode-selector" rounded="$bew-radius" bg="$bew-fill-1" p-1>
           <div
-            flex-1 py-1 cursor-pointer text-center rounded="$bew-radius"
+            class="recommendation-mode-option"
+            py-1 cursor-pointer text-center rounded="$bew-radius"
             :style="{
               background: settings.recommendationMode === 'web' ? 'var(--bew-theme-color)' : '',
               color: settings.recommendationMode === 'web' ? 'white' : '',
@@ -202,7 +203,19 @@ function handleToggleHomeTab(tab: any) {
             Web
           </div>
           <div
-            flex-1 py-1 cursor-pointer text-center rounded="$bew-radius"
+            class="recommendation-mode-option"
+            py-1 cursor-pointer text-center rounded="$bew-radius"
+            :style="{
+              background: settings.recommendationMode === 'webNoCookie' ? 'var(--bew-theme-color)' : '',
+              color: settings.recommendationMode === 'webNoCookie' ? 'white' : '',
+            }"
+            @click="settings.recommendationMode = 'webNoCookie'"
+          >
+            {{ $t('settings.recommendation_mode_web_no_cookie') }}
+          </div>
+          <div
+            class="recommendation-mode-option"
+            py-1 cursor-pointer text-center rounded="$bew-radius"
             :style="{
               background: settings.recommendationMode === 'app' ? 'var(--bew-theme-color)' : '',
               color: settings.recommendationMode === 'app' ? 'white' : '',
@@ -525,5 +538,17 @@ function handleToggleHomeTab(tab: any) {
   :deep(.right-content) {
     --uno: w-auto;
   }
+}
+
+.recommendation-mode-selector {
+  display: grid;
+  grid-template-columns: minmax(0, 0.8fr) minmax(0, 1.4fr) minmax(0, 0.8fr);
+  width: 100%;
+}
+
+.recommendation-mode-option {
+  min-width: 0;
+  padding-inline: 0.5rem;
+  white-space: nowrap;
 }
 </style>

--- a/src/composables/useFilter.ts
+++ b/src/composables/useFilter.ts
@@ -243,7 +243,7 @@ export function useFilter(isFollowedKeyPath: string[], filterOpt: FilterType[], 
   }
 
   function isAllowedContent(item: any): boolean {
-    if (settings.value.recommendationMode === 'web') {
+    if (settings.value.recommendationMode !== 'app') {
       const isFollowed = get(item, isFollowedKeyPath)
       return isFollowed && settings.value.disableFilterForFollowedUser
     }

--- a/src/contentScripts/views/Home/components/ForYou.vue
+++ b/src/contentScripts/views/Home/components/ForYou.vue
@@ -78,9 +78,12 @@ const { handleReachBottom, handlePageRefresh, haveScrollbar, undoForwardState, h
 const videoList = ref<VideoElement[]>([])
 const appVideoList = ref<AppVideoElement[]>([])
 
+const isWebRecommendationMode = computed(() => settings.value.recommendationMode !== 'app')
+let requestVersion = 0
+
 // 当前使用的视频列表（根据推荐模式）
 const currentVideoList = computed(() =>
-  settings.value.recommendationMode === 'web' ? videoList.value : appVideoList.value,
+  isWebRecommendationMode.value ? videoList.value : appVideoList.value,
 )
 
 const isLoading = ref<boolean>(false)
@@ -130,7 +133,11 @@ onMounted(() => {
   document.addEventListener('visibilitychange', handleVisibilityChange)
 
   // 如果启用状态保留且store中有数据，则恢复状态
-  if (settings.value.preserveForYouState && forYouStore.state.isInitialized) {
+  if (
+    settings.value.preserveForYouState
+    && forYouStore.state.isInitialized
+    && forYouStore.state.recommendationMode === settings.value.recommendationMode
+  ) {
     // 恢复关键状态
     const savedState = forYouStore.getCompleteState()
     videoList.value = [...savedState.videoList]
@@ -194,6 +201,7 @@ onBeforeUnmount(() => {
       refreshIdx: refreshIdx.value,
       noMoreContent: noMoreContent.value,
       isInitialized: true,
+      recommendationMode: settings.value.recommendationMode,
       scrollTop, // 保存滚动位置
     }
     forYouStore.saveCompleteState(currentState)
@@ -337,6 +345,7 @@ function getWebFetchRow(list: VideoElement[]): number {
 }
 
 watch(() => settings.value.recommendationMode, () => {
+  requestVersion++
   noMoreContent.value = false
   refreshIdx.value = 1
   consecutiveEmptyLoads.value = 0 // 重置空加载计数器
@@ -361,6 +370,7 @@ watch(() => settings.value.recommendationMode, () => {
 })
 
 async function initData() {
+  requestVersion++
   // 直接清空列表，骨架屏由 VideoCardGrid 自动处理
   videoList.value = []
   appVideoList.value = []
@@ -369,46 +379,52 @@ async function initData() {
   consecutiveEmptyLoads.value = 0 // 重置空加载计数器
   appConsecutiveEmptyLoads.value = 0 // 重置APP模式空加载计数器
   requestFailed.value = false // 重置请求失败状态
+  needToLoginFirst.value = false
   await getData()
 }
 
 async function getData() {
+  const version = requestVersion
   emit('beforeLoading')
   isLoading.value = true
   requestFailed.value = false
 
   try {
-    if (settings.value.recommendationMode === 'web') {
-      await getRecommendVideos()
+    if (isWebRecommendationMode.value) {
+      await getRecommendVideos(version)
     }
     else {
       try {
-        await getAppRecommendVideos()
+        await getAppRecommendVideos(version)
       }
       catch (error) {
+        if (version !== requestVersion || settings.value.recommendationMode !== 'app')
+          return
+
         console.error('App recommendation failed:', error)
-        requestFailed.value = true
 
         // 检查是否启用自动切换
         if (settings.value.autoSwitchRecommendationMode) {
           // 切换到 web 模式并提示用户
           settings.value.recommendationMode = 'web'
           toast.warning('App 推荐数据加载失败，已自动切换至 Web 模式')
-          requestFailed.value = false
-          await getRecommendVideos()
         }
         else {
+          requestFailed.value = true
           toast.error('App 推荐数据加载失败，请手动切换至 Web 模式或稍后重试')
         }
       }
     }
   }
   catch {
-    requestFailed.value = true
+    if (version === requestVersion)
+      requestFailed.value = true
   }
   finally {
-    isLoading.value = false
-    emit('afterLoading')
+    if (version === requestVersion) {
+      isLoading.value = false
+      emit('afterLoading')
+    }
   }
 }
 
@@ -442,7 +458,7 @@ function initPageAction() {
       return
 
     // 根据当前模式保存数据
-    if (settings.value.recommendationMode === 'web') {
+    if (isWebRecommendationMode.value) {
       // 总是保存刷新前的当前状态到后退缓存
       cachedVideoList.value = JSON.parse(JSON.stringify(videoList.value))
       cachedRefreshIdx.value = refreshIdx.value
@@ -474,7 +490,7 @@ function initPageAction() {
   // 修改撤销刷新的处理函数
   handleUndoRefresh.value = () => {
     if (hasBackState.value) {
-      if (settings.value.recommendationMode === 'web' && cachedVideoList.value.length > 0) {
+      if (isWebRecommendationMode.value && cachedVideoList.value.length > 0) {
         // 滚动到页面顶部
         handleBackToTop()
 
@@ -514,7 +530,7 @@ function initPageAction() {
   // 添加前进功能
   handleForwardRefresh.value = () => {
     if (hasForwardState.value) {
-      if (settings.value.recommendationMode === 'web' && forwardVideoList.value.length > 0) {
+      if (isWebRecommendationMode.value && forwardVideoList.value.length > 0) {
         // 滚动到页面顶部
         handleBackToTop()
 
@@ -557,7 +573,10 @@ function initPageAction() {
   }
 }
 
-async function getRecommendVideos() {
+async function getRecommendVideos(version = requestVersion) {
+  const recommendationMode = settings.value.recommendationMode
+  let canFillViewport = false
+
   try {
     // 检查是否达到最大空加载次数，防止无限递归
     if (consecutiveEmptyLoads.value >= MAX_EMPTY_LOADS) {
@@ -573,13 +592,20 @@ async function getRecommendVideos() {
     const fetchRow = getWebFetchRow(videoList.value)
     const lastShowlist = getLastShowlistFromList(videoList.value, PAGE_SIZE)
 
-    const response: forYouResult = await api.video.getRecommendVideos({
+    const getWebRecommendVideos = recommendationMode === 'webNoCookie'
+      ? api.video.getNoCookieRecommendVideos
+      : api.video.getRecommendVideos
+
+    const response: forYouResult = await getWebRecommendVideos({
       fresh_idx: currentRefreshIdx,
       fresh_idx_1h: currentRefreshIdx,
       ps: PAGE_SIZE,
       fetch_row: fetchRow > 0 ? fetchRow : undefined,
       last_showlist: lastShowlist || undefined,
     })
+
+    if (version !== requestVersion || recommendationMode !== settings.value.recommendationMode)
+      return
 
     if (!response) {
       console.error('Failed to load web recommendations: Response is undefined')
@@ -675,6 +701,7 @@ async function getRecommendVideos() {
         // 没有加载到新内容，增加空加载计数器
         consecutiveEmptyLoads.value++
       }
+      canFillViewport = true
     }
     else if (response.code === 62011) {
       needToLoginFirst.value = true
@@ -687,33 +714,37 @@ async function getRecommendVideos() {
     }
   }
   finally {
-    const filledItems = videoList.value.filter(video => video.item)
-    videoList.value = filledItems
+    if (canFillViewport && version === requestVersion && recommendationMode === settings.value.recommendationMode) {
+      const filledItems = videoList.value.filter(video => video.item)
+      videoList.value = filledItems
 
-    if (!needToLoginFirst.value && !noMoreContent.value) {
-      await nextTick()
+      if (!needToLoginFirst.value && !noMoreContent.value) {
+        await nextTick()
 
-      const hasScrollbar = await haveScrollbar()
-      if (!hasScrollbar || filledItems.length < PAGE_SIZE || filledItems.length < 1) {
-        if (isPageVisible.value && consecutiveEmptyLoads.value < MAX_EMPTY_LOADS) {
-          // 设置递归加载锁，防止 VideoCardGrid 触发额外的 loadMore
-          isRecursiveLoading.value = true
-          try {
-            await getRecommendVideos()
+        const hasScrollbar = await haveScrollbar()
+        if (!hasScrollbar || filledItems.length < PAGE_SIZE || filledItems.length < 1) {
+          if (isPageVisible.value && consecutiveEmptyLoads.value < MAX_EMPTY_LOADS) {
+            // 设置递归加载锁，防止 VideoCardGrid 触发额外的 loadMore
+            isRecursiveLoading.value = true
+            try {
+              await getRecommendVideos(version)
+            }
+            finally {
+              isRecursiveLoading.value = false
+            }
           }
-          finally {
-            isRecursiveLoading.value = false
+          else if (consecutiveEmptyLoads.value >= MAX_EMPTY_LOADS) {
+            noMoreContent.value = true
           }
-        }
-        else if (consecutiveEmptyLoads.value >= MAX_EMPTY_LOADS) {
-          noMoreContent.value = true
         }
       }
     }
   }
 }
 
-async function getAppRecommendVideos() {
+async function getAppRecommendVideos(version = requestVersion) {
+  const recommendationMode = settings.value.recommendationMode
+
   // 检查是否达到最大空加载次数，防止无限递归
   if (appConsecutiveEmptyLoads.value >= MAX_EMPTY_LOADS) {
     console.warn('APP模式达到最大连续空加载次数，停止加载')
@@ -746,6 +777,9 @@ async function getAppRecommendVideos() {
         appkey: TVAppKey.appkey,
         idx: lastIdx,
       })
+
+      if (version !== requestVersion || recommendationMode !== settings.value.recommendationMode)
+        return
 
       if (!response) {
         console.error('Failed to load batch', batch, 'Response is undefined')
@@ -790,6 +824,9 @@ async function getAppRecommendVideos() {
       }
     }
     catch (error) {
+      if (version !== requestVersion || recommendationMode !== settings.value.recommendationMode)
+        return
+
       console.error('Failed to load batch', batch, error)
       requestFailed.value = true
       break
@@ -797,6 +834,9 @@ async function getAppRecommendVideos() {
   }
 
   // 检查是否成功添加了新内容
+  if (version !== requestVersion || recommendationMode !== settings.value.recommendationMode)
+    return
+
   const afterLoadCount = appVideoList.value.length
   if (afterLoadCount > beforeLoadCount) {
     // 成功加载了新内容，重置空加载计数器
@@ -830,7 +870,7 @@ async function getAppRecommendVideos() {
       // 设置递归加载锁，防止 VideoCardGrid 触发额外的 loadMore
       isRecursiveLoading.value = true
       try {
-        await getAppRecommendVideos()
+        await getAppRecommendVideos(version)
       }
       finally {
         isRecursiveLoading.value = false
@@ -856,14 +896,14 @@ defineExpose({
     handleForwardRefresh.value?.()
   },
   canGoBack: () => {
-    if (settings.value.recommendationMode === 'web')
+    if (isWebRecommendationMode.value)
       return hasBackState.value && cachedVideoList.value.length > 0
     else if (settings.value.recommendationMode === 'app')
       return hasBackState.value && cachedAppVideoList.value.length > 0
     return false
   },
   canGoForward: () => {
-    if (settings.value.recommendationMode === 'web')
+    if (isWebRecommendationMode.value)
       return hasForwardState.value && forwardVideoList.value.length > 0
     else if (settings.value.recommendationMode === 'app')
       return hasForwardState.value && forwardAppVideoList.value.length > 0
@@ -884,7 +924,7 @@ defineExpose({
       :request-failed="requestFailed"
       :transform-item="(item: VideoElement | AppVideoElement) => item.displayData"
       :get-item-key="(item: VideoElement | AppVideoElement, index?: number) => `${item.uniqueId}-${index ?? 0}`"
-      :video-type="settings.recommendationMode === 'web' ? 'rcmd' : 'appRcmd'"
+      :video-type="isWebRecommendationMode ? 'rcmd' : 'appRcmd'"
       show-preview
       more-btn
       @refresh="initData"

--- a/src/logic/storage.ts
+++ b/src/logic/storage.ts
@@ -106,6 +106,7 @@ export interface ShortcutsSettings {
 export type VideoCardFontSizeSetting = 'xs' | 'sm' | 'base' | 'lg'
 export type VideoCardLayoutSetting = 'modern' | 'compact' | 'old'
 export type AutoPlayMode = 'default' | 'autoPlay' | 'autoPlayWithRecommend' | 'pauseAtEnd' | 'loop'
+export type RecommendationMode = 'web' | 'app' | 'webNoCookie'
 
 export interface ShadowCurvePoint {
   position: number
@@ -268,7 +269,7 @@ export interface Settings {
   usePluginSearchResultsPage: boolean
   searchResultsPaginationMode: 'scroll' | 'pagination' // 搜索结果分页模式：滚动加载或翻页
 
-  recommendationMode: 'web' | 'app'
+  recommendationMode: RecommendationMode
   autoSwitchRecommendationMode: boolean
 
   // filter setting

--- a/src/stores/forYouStore.ts
+++ b/src/stores/forYouStore.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 
+import type { RecommendationMode } from '~/logic'
 import type { Item as AppVideoItem } from '~/models/video/appForYou'
 import type { Item as VideoItem } from '~/models/video/forYou'
 
@@ -59,6 +60,9 @@ export interface ForYouState {
 
   // 是否已初始化
   isInitialized: boolean
+
+  // 推荐模式，用于避免跨模式恢复旧推荐流
+  recommendationMode?: RecommendationMode
 }
 
 export const useForYouStore = defineStore('forYou', () => {
@@ -73,6 +77,7 @@ export const useForYouStore = defineStore('forYou', () => {
 
     // 是否已初始化
     isInitialized: false,
+    recommendationMode: undefined,
   })
 
   // 简化的API - 只保存和恢复完整状态
@@ -92,6 +97,7 @@ export const useForYouStore = defineStore('forYou', () => {
       refreshIdx: 1,
       noMoreContent: false,
       isInitialized: false,
+      recommendationMode: undefined,
     }
   }
 


### PR DESCRIPTION
给首页推荐加了一个“无 Cookie”模式，思路来自 [TabulaBili](https://github.com/wangdaodaodao/TabulaBili)。

我自己在手机端也一直关着个性化推荐。这个模式对想减少个性化推荐影响（某种程度上走出信息茧房），或者想让自己少刷一会儿 B 站的人应该会有点用。

### 改动

- 在首页设置的推荐模式里加入“无 Cookie”
- 该模式继续使用网页端推荐接口，但请求推荐列表时不携带 Cookie
- Web / 无 Cookie / App 三种模式切换时，避免复用旧模式的推荐缓存
- Firefox 下无 Cookie 请求会跳过现有的 Cookie 读取和注入逻辑

### 截图

| 调整前 | 调整后 |
| --- | --- |
| <img width="345" height="172" alt="前" src="https://github.com/user-attachments/assets/b7482df8-4b8a-4e8c-912b-347389318010" /> | <img width="344" height="172" alt="后" src="https://github.com/user-attachments/assets/beedc779-4d8d-48b8-9468-2e0c12e3b5ed" /> |

> 这里的“无 Cookie”只表示首页推荐列表请求不携带 Cookie，不是完整的匿名模式。WBI key 仍然沿用项目现有的初始化和缓存逻辑。

已通过 `pnpm lint`、`pnpm typecheck`、`pnpm build`、`pnpm build-firefox` 和 `pnpm build-safari`。