### PR TITLE
fix: 同步设置页侧栏语言切换

### DIFF
--- a/src/components/Settings/BilibiliFeaturesEnhancement/BilibiliFeaturesEnhancement.vue
+++ b/src/components/Settings/BilibiliFeaturesEnhancement/BilibiliFeaturesEnhancement.vue
@@ -1,38 +1,35 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-import { useI18n } from 'vue-i18n'
 
 import { BilibiliFeaturesPage } from '../types'
-
-const { t } = useI18n()
 
 const activePage = ref<BilibiliFeaturesPage>(BilibiliFeaturesPage.Comments)
 
 const pages = [
   {
     value: BilibiliFeaturesPage.Comments,
-    title: t('settings.bilibili_features.comments'),
+    titleKey: 'settings.bilibili_features.comments',
     icon: 'i-mingcute:comment-line',
     iconActivated: 'i-mingcute:comment-fill',
     component: defineAsyncComponent(() => import('./Comments/Comments.vue')),
   },
   {
     value: BilibiliFeaturesPage.VideoPlayback,
-    title: t('settings.bilibili_features.video_playback'),
+    titleKey: 'settings.bilibili_features.video_playback',
     icon: 'i-mingcute:play-circle-line',
     iconActivated: 'i-mingcute:play-circle-fill',
     component: defineAsyncComponent(() => import('./VideoPlayback/VideoPlayback.vue')),
   },
   {
     value: BilibiliFeaturesPage.AutoPlay,
-    title: t('settings.bilibili_features.auto_play'),
+    titleKey: 'settings.bilibili_features.auto_play',
     icon: 'i-mingcute:list-check-line',
     iconActivated: 'i-mingcute:list-check-fill',
     component: defineAsyncComponent(() => import('./AutoPlay/AutoPlay.vue')),
   },
   {
     value: BilibiliFeaturesPage.VipFeatures,
-    title: t('settings.bilibili_features.vip_features'),
+    titleKey: 'settings.bilibili_features.vip_features',
     icon: 'i-mingcute:vip-1-line',
     iconActivated: 'i-mingcute:vip-1-fill',
     component: defineAsyncComponent(() => import('./VipFeatures/VipFeatures.vue')),
@@ -56,7 +53,7 @@ const pages = [
           >
             <div class="flex items-center">
               <div :class="activePage === page.value ? page.iconActivated : page.icon" class="mr-2 text-lg" />
-              <span>{{ page.title }}</span>
+              <span>{{ $t(page.titleKey) }}</span>
             </div>
           </li>
         </ul>

--- a/src/components/Settings/PluginComponentsAndPages/PluginComponentsAndPages.vue
+++ b/src/components/Settings/PluginComponentsAndPages/PluginComponentsAndPages.vue
@@ -1,59 +1,56 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-import { useI18n } from 'vue-i18n'
 
 import { PluginPage } from '../types'
-
-const { t } = useI18n()
 
 const activePage = ref<PluginPage>(PluginPage.General)
 
 const pages = [
   {
     value: PluginPage.General,
-    title: t('settings.plugin.general'),
+    titleKey: 'settings.plugin.general',
     icon: 'i-mingcute:settings-3-line',
     iconActivated: 'i-mingcute:settings-3-fill',
     component: defineAsyncComponent(() => import('./General/General.vue')),
   },
   {
     value: PluginPage.VideoCard,
-    title: t('settings.plugin.video_card'),
+    titleKey: 'settings.plugin.video_card',
     icon: 'i-mingcute:video-camera-line',
     iconActivated: 'i-mingcute:video-camera-fill',
     component: defineAsyncComponent(() => import('./VideoCard/VideoCard.vue')),
   },
   {
     value: PluginPage.TopBar,
-    title: t('settings.plugin.topbar'),
+    titleKey: 'settings.plugin.topbar',
     icon: 'i-mingcute:layout-top-line',
     iconActivated: 'i-mingcute:layout-top-fill',
     component: defineAsyncComponent(() => import('./TopBar/TopBar.vue')),
   },
   {
     value: PluginPage.DockAndSidebar,
-    title: t('settings.plugin.dock_and_sidebar'),
+    titleKey: 'settings.plugin.dock_and_sidebar',
     icon: 'i-mingcute:navigation-line',
     iconActivated: 'i-mingcute:navigation-fill',
     component: defineAsyncComponent(() => import('./DockAndSidebar/DockAndSidebar.vue')),
   },
   {
     value: PluginPage.Home,
-    title: t('settings.plugin.home'),
+    titleKey: 'settings.plugin.home',
     icon: 'i-mingcute:home-5-line',
     iconActivated: 'i-mingcute:home-5-fill',
     component: defineAsyncComponent(() => import('./Home/Home.vue')),
   },
   {
     value: PluginPage.Search,
-    title: t('settings.plugin.search'),
+    titleKey: 'settings.plugin.search',
     icon: 'i-mingcute:search-2-line',
     iconActivated: 'i-mingcute:search-2-fill',
     component: defineAsyncComponent(() => import('./SearchPage/SearchPage.vue')),
   },
   {
     value: PluginPage.VolumeBalance,
-    title: t('settings.plugin.volume_balance'),
+    titleKey: 'settings.plugin.volume_balance',
     icon: 'i-mingcute:volume-line',
     iconActivated: 'i-mingcute:volume-fill',
     component: defineAsyncComponent(() => import('./VolumeBalance/VolumeBalance.vue')),
@@ -79,7 +76,7 @@ const pages = [
               <div class="mr-2 w-5 h-5 shrink-0 flex items-center justify-center">
                 <div :class="activePage === page.value ? page.iconActivated : page.icon" class="text-lg leading-none" />
               </div>
-              <span class="flex-1 min-w-0" leading-5 whitespace-normal break-normal>{{ page.title }}</span>
+              <span class="flex-1 min-w-0" leading-5 whitespace-normal break-normal>{{ $t(page.titleKey) }}</span>
             </div>
           </li>
         </ul>

--- a/src/components/Settings/Settings.vue
+++ b/src/components/Settings/Settings.vue
@@ -21,7 +21,6 @@ const settingsMenu = {
   [MenuType.About]: defineAsyncComponent(() => import('./About/About.vue')),
 }
 const activatedMenuItem = ref<MenuType>(MenuType.PluginComponentsAndPages)
-const title = ref<string>(t('settings.title'))
 const settingsWindow = ref<HTMLDivElement>()
 
 useEventListener(window, 'resize', () => {
@@ -45,56 +44,48 @@ watch(
   },
 )
 
-const settingsMenuItems = computed((): MenuItem[] => {
-  return [
-    {
-      value: MenuType.PluginComponentsAndPages,
-      icon: 'i-mingcute:plugin-2-line',
-      iconActivated: 'i-mingcute:plugin-2-fill',
-      title: t('settings.menu_plugin_components_and_pages'),
-    },
-    {
-      value: MenuType.BilibiliFeaturesEnhancement,
-      icon: 'i-mingcute:tv-2-line',
-      iconActivated: 'i-mingcute:tv-2-fill',
-      title: t('settings.menu_bilibili_features_enhancement'),
-    },
-    {
-      value: MenuType.Appearance,
-      title: t('settings.menu_appearance'),
-      icon: 'i-mingcute:paint-brush-line',
-      iconActivated: 'i-mingcute:paint-brush-fill',
-    },
-    {
-      value: MenuType.Shortcuts,
-      icon: 'i-mingcute:keyboard-line',
-      iconActivated: 'i-mingcute:keyboard-fill',
-      title: t('settings.shortcuts.title'),
-    },
-    {
-      value: MenuType.Compatibility,
-      icon: 'i-mingcute:polygon-line',
-      iconActivated: 'i-mingcute:polygon-fill',
-      title: t('settings.menu_compatibility'),
-    },
-    {
-      value: MenuType.About,
-      icon: 'i-mingcute:information-line',
-      iconActivated: 'i-mingcute:information-fill',
-      title: t('settings.menu_about'),
-    },
-  ]
-})
+const settingsMenuItems: MenuItem[] = [
+  {
+    value: MenuType.PluginComponentsAndPages,
+    icon: 'i-mingcute:plugin-2-line',
+    iconActivated: 'i-mingcute:plugin-2-fill',
+    titleKey: 'settings.menu_plugin_components_and_pages',
+  },
+  {
+    value: MenuType.BilibiliFeaturesEnhancement,
+    icon: 'i-mingcute:tv-2-line',
+    iconActivated: 'i-mingcute:tv-2-fill',
+    titleKey: 'settings.menu_bilibili_features_enhancement',
+  },
+  {
+    value: MenuType.Appearance,
+    titleKey: 'settings.menu_appearance',
+    icon: 'i-mingcute:paint-brush-line',
+    iconActivated: 'i-mingcute:paint-brush-fill',
+  },
+  {
+    value: MenuType.Shortcuts,
+    icon: 'i-mingcute:keyboard-line',
+    iconActivated: 'i-mingcute:keyboard-fill',
+    titleKey: 'settings.shortcuts.title',
+  },
+  {
+    value: MenuType.Compatibility,
+    icon: 'i-mingcute:polygon-line',
+    iconActivated: 'i-mingcute:polygon-fill',
+    titleKey: 'settings.menu_compatibility',
+  },
+  {
+    value: MenuType.About,
+    icon: 'i-mingcute:information-line',
+    iconActivated: 'i-mingcute:information-fill',
+    titleKey: 'settings.menu_about',
+  },
+]
 
-/**
- * When changing language, set current title again to ensure it switches to the corresponding language
- */
-watch(() => settings.value.language, () => {
-  setCurrentTitle()
-})
-
-onMounted(() => {
-  setCurrentTitle()
+const title = computed(() => {
+  const currentMenuItem = settingsMenuItems.find(item => item.value === activatedMenuItem.value)
+  return currentMenuItem ? t(currentMenuItem.titleKey) : t('settings.title')
 })
 
 function handleClose() {
@@ -103,14 +94,6 @@ function handleClose() {
 
 function changeMenuItem(menuItem: MenuType) {
   activatedMenuItem.value = menuItem
-  setCurrentTitle()
-}
-
-function setCurrentTitle() {
-  settingsMenuItems.value.forEach((item) => {
-    if (item.value === activatedMenuItem.value)
-      title.value = item.title
-  })
 }
 </script>
 
@@ -171,7 +154,7 @@ function setCurrentTitle() {
                 :class="menuItem.iconActivated"
               />
               <div flex="~ items-center gap-2" shrink-0>
-                <span>{{ menuItem.title }}</span>
+                <span>{{ $t(menuItem.titleKey) }}</span>
                 <span
                   v-if="menuItem.badge"
                   text="xs"

--- a/src/components/Settings/types.ts
+++ b/src/components/Settings/types.ts
@@ -34,6 +34,6 @@ export interface MenuItem {
   value: MenuType
   icon: string
   iconActivated: string
-  title: string
+  titleKey: string
   badge?: string
 }


### PR DESCRIPTION
修了设置页左侧栏的语言切换问题。之前切换界面语言后，左侧菜单不会立刻刷新，要手动点一下才会变成新语言。

这次把左侧菜单的文案改成按 i18n key 渲染，不再把翻译结果提前固化在数组里，所以切换语言后主菜单和两个二级菜单都会立即更新。

### 截图

修复前，语言切换成英语后左侧菜单不会立刻刷新：

<img width="1488" height="1339" alt="前" src="https://github.com/user-attachments/assets/32ef4250-07c1-4433-a457-55e3363a0942" />

已通过 `pnpm lint`、`pnpm typecheck`、`pnpm build`、`pnpm build-firefox` 和 `pnpm build-safari`。