### PR TITLE
refactor: 优化设置项布局

### DIFF
--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -166,12 +166,14 @@ settings:
   disable_shadow: 禁用阴影
   link_opening_behavior_opt:
     current_tab: 当前标签页
-    current_tab_if_not_homepage: 首页新标签页，其他当前页
-    background: 后台打开（如果可以的话）
+    current_tab_if_not_homepage: 首页外当前页
+    background: 后台打开
     new_tab: 新标签页
     drawer: 抽屉打开
   top_bar_link_opening_behavior: 顶栏链接打开行为
   video_card_link_opening_behavior: 视频卡片和番剧卡片链接打开行为
+  link_opening_behavior_desc: 控制点击链接后的打开位置。“首页外当前页”表示：当前页为首页时使用新标签页打开，其他页面使用当前标签页打开；“后台打开”会在浏览器允许时打开到后台标签页。
+  video_card_link_opening_behavior_desc: 控制点击视频卡片和番剧卡片后的打开位置，可选择当前标签页、抽屉、后台标签页或新标签页。
   search_bar_link_opening_behavior: 搜索栏链接打开行为
   close_drawer_without_pressing_esc_again: 关闭抽屉时不用再次按 <kbd>Esc</kbd> 关闭
   block_ads: 屏蔽广告
@@ -207,17 +209,17 @@ settings:
   use_bilibili_default_auto_play_desc: 启用后将使用B站的默认自动播放行为，下方的自定义自动播放设置将被隐藏且无效
   auto_play_mode_default: B站默认
   auto_play_mode_auto_play: 自动连播
-  auto_play_mode_auto_play_with_recommend: 自动连播(含推荐)
+  auto_play_mode_auto_play_with_recommend: 连播推荐
   auto_play_mode_pause_at_end: 播完暂停
   auto_play_mode_loop: 单集循环
   auto_play_multipart: 分P视频
-  auto_play_multipart_desc: 选择分P视频的自动播放行为
+  auto_play_multipart_desc: 选择分P视频的自动播放行为。“连播推荐”表示当前视频结束后继续播放推荐视频。
   auto_play_collection: 合集视频
-  auto_play_collection_desc: 选择合集视频的自动播放行为
+  auto_play_collection_desc: 选择合集视频的自动播放行为。“连播推荐”表示当前视频结束后继续播放推荐视频。
   auto_play_recommend: 单视频推荐
-  auto_play_recommend_desc: 选择单视频播放结束后的自动播放行为
+  auto_play_recommend_desc: 选择单视频播放结束后的自动播放行为。“连播推荐”表示当前视频结束后继续播放推荐视频。
   auto_play_playlist: 收藏列表
-  auto_play_playlist_desc: 选择收藏列表的自动播放行为
+  auto_play_playlist_desc: 选择收藏列表的自动播放行为。“连播推荐”表示当前视频结束后继续播放推荐视频。
   enable_random_play: 启用视频合集随机播放
   enable_random_play_desc: 为多P视频或合集添加随机播放功能
   random_play_mode: 随机播放模式
@@ -239,7 +241,7 @@ settings:
   show_video_card_recommend_tag_desc: 显示插件计算的标签，如"高赞"、"高互动"、"百万播放"等
   auto_hide_top_bar: 自动隐藏顶栏
   video_page_top_bar_config: 视频页顶栏配置
-  video_page_top_bar_config_desc: 配置在视频页面顶栏的显示行为
+  video_page_top_bar_config_desc: 控制视频页顶栏的显示时机。“鼠标显示”表示鼠标移入页面顶部时显示；“滚动显示”表示页面滚动时显示。
   video_page_top_bar_config_opt:
     alwaysShow: 总是显示
     alwaysHide: 总是隐藏
@@ -384,7 +386,7 @@ settings:
   recommendation_mode: 推荐模式
   recommendation_mode_desc: |
     Web：普通网页端推荐模式。无 Cookie：请求首页推荐时不携带 Cookie。App：移动端推荐模式，需先授权 access key。
-  recommendation_mode_web_no_cookie: 无Cookie
+  recommendation_mode_web_no_cookie: 无 Cookie
   auto_switch_recommendation_mode: 自动切换推荐模式
   auto_switch_recommendation_mode_desc: |
     当 App 推荐失败时自动切换至 Web 模式。

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -164,12 +164,14 @@ settings:
   disable_shadow: 停用陰影
   link_opening_behavior_opt:
     current_tab: 目前索引標籤
-    current_tab_if_not_homepage: 首頁新分頁，其他目前分頁
+    current_tab_if_not_homepage: 首頁外目前分頁
     background: 後台打開
     new_tab: 新索引標籤
     drawer: 抽屜開啟
   top_bar_link_opening_behavior: 頂欄連結開啟行為
   video_card_link_opening_behavior: 影片和番劇卡片連結開啟行為
+  link_opening_behavior_desc: 控制點擊連結後的開啟位置。「首頁外目前分頁」表示：目前頁面為首頁時使用新索引標籤開啟，其他頁面使用目前索引標籤開啟；「後台打開」會在瀏覽器允許時開到背景索引標籤。
+  video_card_link_opening_behavior_desc: 控制點擊影片和番劇卡片後的開啟位置，可選擇目前索引標籤、抽屜、背景索引標籤或新索引標籤。
   search_bar_link_opening_behavior: 搜尋欄連結開啟行為
   close_drawer_without_pressing_esc_again: 關閉抽屜時不用再次按 <kbd>Esc</kbd> 關閉
   block_ads: 封鎖廣告
@@ -232,7 +234,7 @@ settings:
   show_video_card_recommend_tag_desc: 顯示插件計算的標籤，如「高讚」、「高互動」、「百萬播放」等
   auto_hide_top_bar: 自動隱藏頂欄
   video_page_top_bar_config: 影片頁頂欄配置
-  video_page_top_bar_config_desc: 配置在影片頁面頂欄的顯示行為
+  video_page_top_bar_config_desc: 控制影片頁頂欄的顯示時機。「滑鼠顯示」表示滑鼠移入頁面頂部時顯示；「滾動顯示」表示頁面滾動時顯示。
   video_page_top_bar_config_opt:
     alwaysShow: 總是顯示
     alwaysHide: 總是隱藏
@@ -323,7 +325,7 @@ settings:
   recommendation_mode: 推薦模式
   recommendation_mode_desc: |
     Web：普通網頁端推薦模式。無 Cookie：請求首頁推薦時不攜帶 Cookie。App：手機端推薦模式，需先授權 access key。
-  recommendation_mode_web_no_cookie: 無Cookie
+  recommendation_mode_web_no_cookie: 無 Cookie
   auto_switch_recommendation_mode: 自動切換推薦模式
   auto_switch_recommendation_mode_desc: |
     當手機端推薦失敗時自動切換至網頁模式。
@@ -428,17 +430,17 @@ settings:
   use_bilibili_default_auto_play_desc: 啟用後將使用B站的預設自動播放行為，下方的自訂自動播放設定將被隱藏且無效
   auto_play_mode_default: B站預設
   auto_play_mode_auto_play: 自動連播
-  auto_play_mode_auto_play_with_recommend: 自動連播(含推薦)
+  auto_play_mode_auto_play_with_recommend: 連播推薦
   auto_play_mode_pause_at_end: 播完暫停
   auto_play_mode_loop: 單集循環
   auto_play_multipart: 分P影片
-  auto_play_multipart_desc: 選擇分P影片的自動播放行為
+  auto_play_multipart_desc: 選擇分P影片的自動播放行為。「連播推薦」表示目前影片結束後繼續播放推薦影片。
   auto_play_collection: 合集影片
-  auto_play_collection_desc: 選擇合集影片的自動播放行為
+  auto_play_collection_desc: 選擇合集影片的自動播放行為。「連播推薦」表示目前影片結束後繼續播放推薦影片。
   auto_play_recommend: 單影片推薦
-  auto_play_recommend_desc: 選擇單影片播放結束後的自動播放行為
+  auto_play_recommend_desc: 選擇單影片播放結束後的自動播放行為。「連播推薦」表示目前影片結束後繼續播放推薦影片。
   auto_play_playlist: 收藏列表
-  auto_play_playlist_desc: 選擇收藏列表的自動播放行為
+  auto_play_playlist_desc: 選擇收藏列表的自動播放行為。「連播推薦」表示目前影片結束後繼續播放推薦影片。
   enable_random_play: 啟用影片合集隨機播放
   enable_random_play_desc: 為多P影片或合集添加隨機播放功能
   random_play_mode: 隨機播放模式

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -177,12 +177,14 @@ settings:
   disable_shadow: Disable shadow
   link_opening_behavior_opt:
     current_tab: Current tab
-    current_tab_if_not_homepage: New tab on homepage, otherwise current tab
-    background: New tab,but in background
+    current_tab_if_not_homepage: Current outside home
+    background: Background tab
     new_tab: New tab
     drawer: Open in drawer
   top_bar_link_opening_behavior: Top bar link opening behavior
   video_card_link_opening_behavior: Video card and bangumi card link opening behavior
+  link_opening_behavior_desc: 'Controls where links open. "Current outside home" means: use a new tab on the home page, and use the current tab on other pages; "Background tab" opens in the background when the browser allows it.'
+  video_card_link_opening_behavior_desc: Controls where video and bangumi cards open. You can choose the current tab, drawer, background tab, or new tab.
   search_bar_link_opening_behavior: Search bar link opening behavior
   close_drawer_without_pressing_esc_again: Close the drawer without pressing <kbd>Esc</kbd> again
   block_ads: Block ads
@@ -210,12 +212,12 @@ settings:
   show_video_card_recommend_tag_desc: Display tags calculated by the plugin, such as "High Engagement", "Popular", etc.
   auto_hide_top_bar: Auto-hide top bar
   video_page_top_bar_config: Video page top bar configuration
-  video_page_top_bar_config_desc: Configure the display behavior of the top bar on video pages
+  video_page_top_bar_config_desc: 'Controls when the top bar appears on video pages. "On hover" shows it when the pointer enters the top of the page; "On scroll" shows it while the page scrolls.'
   video_page_top_bar_config_opt:
     alwaysShow: Always show
     alwaysHide: Always hide
-    showOnMouse: Show on mouse
-    showOnScroll: Show on scroll
+    showOnMouse: On hover
+    showOnScroll: On scroll
   always_use_transparent_top_bar: Always use transparent (legacy) style for top bar
   show_top_bar_theme_color_gradient: Show theme color gradient in top bar (only works in dark mode)
   show_bewly_or_bili_top_bar_switcher: Show BewlyBewly/Bilibili top bar switcher
@@ -500,17 +502,17 @@ settings:
     When enabled, Bilibili's default auto-play behavior will be used, and custom auto-play settings below will be hidden and disabled
   auto_play_mode_default: Bilibili Default
   auto_play_mode_auto_play: Auto-play
-  auto_play_mode_auto_play_with_recommend: Auto-play (with Recommendations)
+  auto_play_mode_auto_play_with_recommend: Play recommendations
   auto_play_mode_pause_at_end: Pause at End
   auto_play_mode_loop: Single Loop
   auto_play_multipart: Multi-part Videos
-  auto_play_multipart_desc: Choose auto-play behavior for multi-part videos
+  auto_play_multipart_desc: Choose auto-play behavior for multi-part videos. "Play recommendations" continues with recommended videos after the current video ends.
   auto_play_collection: Collection Videos
-  auto_play_collection_desc: Choose auto-play behavior for collection videos
+  auto_play_collection_desc: Choose auto-play behavior for collection videos. "Play recommendations" continues with recommended videos after the current video ends.
   auto_play_recommend: Recommended Videos
-  auto_play_recommend_desc: Choose auto-play behavior when video ends
+  auto_play_recommend_desc: Choose auto-play behavior when video ends. "Play recommendations" continues with recommended videos after the current video ends.
   auto_play_playlist: Playlist Videos
-  auto_play_playlist_desc: Choose auto-play behavior for playlist videos
+  auto_play_playlist_desc: Choose auto-play behavior for playlist videos. "Play recommendations" continues with recommended videos after the current video ends.
   enable_random_play: Enable video collection random play
   enable_random_play_desc: Add random play feature for multi-part videos or collections
   random_play_mode: Random play mode

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -164,12 +164,14 @@ settings:
   disable_shadow: 閂咗陰影
   link_opening_behavior_opt:
     current_tab: 目前分頁
-    current_tab_if_not_homepage: 主頁開新分頁，其他用目前分頁
+    current_tab_if_not_homepage: 主頁外目前分頁
     new_tab: 新開分頁
     drawer: 喺櫃桶度開啓
-    background: 後臺打開（若然得嘅話）
+    background: 後臺打開
   top_bar_link_opening_behavior: 頂欄連結開啓行爲
   video_card_link_opening_behavior: 影片同番劇卡片連結開啓行爲
+  link_opening_behavior_desc: 控制撳連結之後喺邊度開。「主頁外目前分頁」表示：目前頁面係主頁時用新分頁開，其他頁面用目前分頁開；「後臺打開」會喺瀏覽器容許時開到背景分頁。
+  video_card_link_opening_behavior_desc: 控制撳影片同番劇卡片之後喺邊度開，可以揀目前分頁、櫃桶、背景分頁或者新分頁。
   search_bar_link_opening_behavior: 搜尋欄連結開啓行爲
   close_drawer_without_pressing_esc_again: 閂櫃桶嗰陣唔使再撳多次 <kbd>Esc</kbd>
   block_ads: 封鎖廣告
@@ -305,7 +307,7 @@ settings:
   recommendation_mode: 推介模式
   recommendation_mode_desc: |
     Web：普通網頁版推介模式。無 Cookie：請求首頁推介時唔帶 Cookie。App：手機版推介模式，要先授權 access key。
-  recommendation_mode_web_no_cookie: 無Cookie
+  recommendation_mode_web_no_cookie: 無 Cookie
   auto_switch_recommendation_mode: 自動切換推介模式
   auto_switch_recommendation_mode_desc: |
     當手機版推介壞咗嗰陣自動切換到網頁模式。
@@ -397,12 +399,12 @@ settings:
     噉做冇得返轉頭噃，你確定要重設你之前嘅設定？
   contributors: 貢獻者
   video_page_top_bar_config: 影片頁頂欄配置
-  video_page_top_bar_config_desc: 設定頂欄喺影片頁嘅顯示方式。
+  video_page_top_bar_config_desc: 控制影片頁頂欄嘅顯示時機。「滑鼠顯示」表示滑鼠移入頁面頂部時顯示；「捲動顯示」表示頁面捲動時顯示。
   video_page_top_bar_config_opt:
     alwaysShow: 一直顯示
     alwaysHide: 一直隱藏
-    showOnMouse: 滑鼠移入嗰陣顯示
-    showOnScroll: 捲動嗰陣顯示
+    showOnMouse: 滑鼠顯示
+    showOnScroll: 捲動顯示
   clean_url_argument: 清理 URL 追蹤參數
   clean_url_argument_desc: 自動清理 URL 嘅最終參數，令到連結更加企理。
 
@@ -429,17 +431,17 @@ settings:
   use_bilibili_default_auto_play_desc: 啟用後會用B站嘅預設自動播放行為，下面嘅自訂自動播放設定會隱藏同埋無效
   auto_play_mode_default: B站預設
   auto_play_mode_auto_play: 自動連播
-  auto_play_mode_auto_play_with_recommend: 自動連播(含推薦)
+  auto_play_mode_auto_play_with_recommend: 連播推薦
   auto_play_mode_pause_at_end: 播完暫停
   auto_play_mode_loop: 單集循環
   auto_play_multipart: 分P影片
-  auto_play_multipart_desc: 揀分P影片嘅自動播放行為
+  auto_play_multipart_desc: 揀分P影片嘅自動播放行為。「連播推薦」表示目前影片完咗之後繼續播推薦影片。
   auto_play_collection: 合集影片
-  auto_play_collection_desc: 揀合集影片嘅自動播放行為
+  auto_play_collection_desc: 揀合集影片嘅自動播放行為。「連播推薦」表示目前影片完咗之後繼續播推薦影片。
   auto_play_recommend: 單影片推薦
-  auto_play_recommend_desc: 揀單影片睇完之後嘅自動播放行為
+  auto_play_recommend_desc: 揀單影片睇完之後嘅自動播放行為。「連播推薦」表示目前影片完咗之後繼續播推薦影片。
   auto_play_playlist: 收藏列表
-  auto_play_playlist_desc: 揀收藏列表嘅自動播放行為
+  auto_play_playlist_desc: 揀收藏列表嘅自動播放行為。「連播推薦」表示目前影片完咗之後繼續播推薦影片。
   enable_settings_sync: 允許同步設定
   enable_settings_sync_desc: 喺唔同設備度同步延伸功能設定 (需要登入瀏覽器帳戶)。
   enable_undo_refresh_button: 啓用復原更新掣（淨係得 Web 推介模式下有效）

--- a/src/components/Settings/Appearance/Appearance.vue
+++ b/src/components/Settings/Appearance/Appearance.vue
@@ -117,11 +117,11 @@ function changeWallpaper(url: string) {
 <template>
   <div>
     <SettingsItemGroup :title="$t('settings.group_color')">
-      <SettingsItem :title="$t('settings.theme')">
-        <Select v-model="settings.theme" w-full :options="themeOptions" />
+      <SettingsItem :title="$t('settings.theme')" right-width="auto">
+        <Select v-model="settings.theme" w="160px" :options="themeOptions" />
       </SettingsItem>
-      <SettingsItem :title="$t('settings.theme_color')">
-        <div flex="~ gap-2 wrap" justify-end>
+      <SettingsItem :title="$t('settings.theme_color')" right-width="auto">
+        <div class="theme-color-options" flex="~ gap-2 wrap" justify-end>
           <div
             v-for="color in themeColorOptions" :key="color"
             w-20px h-20px rounded-8 cursor-pointer transition
@@ -159,8 +159,8 @@ function changeWallpaper(url: string) {
         </div>
       </SettingsItem>
 
-      <SettingsItem :title="$t('settings.dark_mode_base_color')">
-        <div flex="~ gap-2 wrap" justify-end>
+      <SettingsItem :title="$t('settings.dark_mode_base_color')" right-width="auto">
+        <div class="dark-mode-base-color-options" flex="~ gap-2 wrap" justify-end>
           <div
             v-for="color in darkModeBaseColorOptions" :key="color"
             w-20px h-20px rounded-8 cursor-pointer transition
@@ -198,7 +198,7 @@ function changeWallpaper(url: string) {
         </div>
       </SettingsItem>
 
-      <SettingsItem :title="$t('settings.gradient_theme_color_background')">
+      <SettingsItem :title="$t('settings.gradient_theme_color_background')" right-width="auto">
         <Radio v-model="settings.useLinearGradientThemeColorBackground" />
       </SettingsItem>
     </SettingsItemGroup>
@@ -206,7 +206,7 @@ function changeWallpaper(url: string) {
     <ChangeWallpaper type="global" />
 
     <SettingsItemGroup :title="$t('settings.group_visual_effects')">
-      <SettingsItem :title="$t('settings.enable_frosted_glass')">
+      <SettingsItem :title="$t('settings.enable_frosted_glass')" right-width="auto">
         <template #desc>
           <span color="$bew-warning-color">{{ $t('common.performance_impact_warn') }}</span>
         </template>
@@ -216,41 +216,44 @@ function changeWallpaper(url: string) {
       <SettingsItem
         v-if="settings.enableFrostedGlass"
         :title="$t('settings.frosted_glass_blur_intensity')"
+        right-width="auto"
       >
-        <Slider
-          v-model="settings.frostedGlassBlurIntensity"
-          :min="FROSTED_GLASS_BLUR_MIN_PX"
-          :max="FROSTED_GLASS_BLUR_MAX_PX"
-          :label="`${settings.frostedGlassBlurIntensity}`"
-        />
+        <div class="slider-control">
+          <Slider
+            v-model="settings.frostedGlassBlurIntensity"
+            :min="FROSTED_GLASS_BLUR_MIN_PX"
+            :max="FROSTED_GLASS_BLUR_MAX_PX"
+            :label="`${settings.frostedGlassBlurIntensity}`"
+          />
+        </div>
       </SettingsItem>
-      <SettingsItem :title="$t('settings.disable_shadow')">
+      <SettingsItem :title="$t('settings.disable_shadow')" right-width="auto">
         <Radio v-model="settings.disableShadow" />
       </SettingsItem>
     </SettingsItemGroup>
 
     <SettingsItemGroup :title="$t('settings.group_fonts')">
-      <SettingsItem :title="$t('settings.customize_font')">
+      <SettingsItem :title="$t('settings.customize_font')" right-width="auto">
         <Select
           v-model="settings.customizeFont"
           :options="fontPreferenceOptions"
-          w="full"
+          w="160px"
         />
         <template v-if="settings.customizeFont === 'custom'" #bottom>
           <Input v-model="settings.fontFamily" @keydown.stop.passive="() => {}" />
           <div text="sm $bew-text-2" mt-1 v-html="t('settings.customize_font_desc')" />
         </template>
       </SettingsItem>
-      <SettingsItem :title="$t('settings.remove_the_indent_from_chinese_punctuation')" :desc="$t('settings.remove_the_indent_from_chinese_punctuation_desc')">
+      <SettingsItem :title="$t('settings.remove_the_indent_from_chinese_punctuation')" :desc="$t('settings.remove_the_indent_from_chinese_punctuation_desc')" right-width="auto">
         <Radio v-model="settings.removeTheIndentFromChinesePunctuation" />
       </SettingsItem>
-      <SettingsItem :title="$t('settings.override_danmaku_font')" :desc="$t('settings.override_danmaku_font_desc')">
+      <SettingsItem :title="$t('settings.override_danmaku_font')" :desc="$t('settings.override_danmaku_font_desc')" right-width="auto">
         <Radio v-model="settings.overrideDanmakuFont" />
       </SettingsItem>
     </SettingsItemGroup>
 
     <SettingsItemGroup>
-      <SettingsItem :title="$t('settings.customize_css')">
+      <SettingsItem :title="$t('settings.customize_css')" right-width="auto">
         <Radio v-model="localSettings.customizeCSS" />
         <template #desc>
           <span text="$bew-error-color">
@@ -266,4 +269,15 @@ function changeWallpaper(url: string) {
 </template>
 
 <style lang="scss" scoped>
+.theme-color-options {
+  width: 312px;
+}
+
+.dark-mode-base-color-options {
+  width: 252px;
+}
+
+.slider-control {
+  width: 220px;
+}
 </style>

--- a/src/components/Settings/BilibiliFeaturesEnhancement/AutoPlay/AutoPlay.vue
+++ b/src/components/Settings/BilibiliFeaturesEnhancement/AutoPlay/AutoPlay.vue
@@ -40,6 +40,7 @@ const randomPlayModeOptions = computed(() => {
       <SettingsItem
         :title="t('settings.use_bilibili_default_auto_play')"
         :desc="t('settings.use_bilibili_default_auto_play_desc')"
+        right-width="auto"
       >
         <Radio v-model="settings.useBilibiliDefaultAutoPlay" />
       </SettingsItem>
@@ -48,40 +49,48 @@ const randomPlayModeOptions = computed(() => {
         <SettingsItem
           :title="t('settings.auto_play_multipart')"
           :desc="t('settings.auto_play_multipart_desc')"
+          right-width="auto"
         >
           <Select
             v-model="settings.autoPlayMultipart"
             :options="autoPlayModes.map(m => ({ label: $t(`settings.${m.label}`), value: m.value }))"
+            w="160px"
           />
         </SettingsItem>
 
         <SettingsItem
           :title="t('settings.auto_play_collection')"
           :desc="t('settings.auto_play_collection_desc')"
+          right-width="auto"
         >
           <Select
             v-model="settings.autoPlayCollection"
             :options="autoPlayModes.map(m => ({ label: $t(`settings.${m.label}`), value: m.value }))"
+            w="160px"
           />
         </SettingsItem>
 
         <SettingsItem
           :title="t('settings.auto_play_recommend')"
           :desc="t('settings.auto_play_recommend_desc')"
+          right-width="auto"
         >
           <Select
             v-model="settings.autoPlayRecommend"
             :options="autoPlayModes.map(m => ({ label: $t(`settings.${m.label}`), value: m.value }))"
+            w="160px"
           />
         </SettingsItem>
 
         <SettingsItem
           :title="t('settings.auto_play_playlist')"
           :desc="t('settings.auto_play_playlist_desc')"
+          right-width="auto"
         >
           <Select
             v-model="settings.autoPlayPlaylist"
             :options="autoPlayModes.map(m => ({ label: $t(`settings.${m.label}`), value: m.value }))"
+            w="160px"
           />
         </SettingsItem>
       </template>
@@ -91,6 +100,7 @@ const randomPlayModeOptions = computed(() => {
       <SettingsItem
         :title="t('settings.enable_random_play')"
         :desc="t('settings.enable_random_play_desc')"
+        right-width="auto"
       >
         <Radio v-model="settings.enableRandomPlay" />
       </SettingsItem>
@@ -99,18 +109,20 @@ const randomPlayModeOptions = computed(() => {
         <SettingsItem
           :title="t('settings.random_play_mode')"
           :desc="t('settings.random_play_mode_desc')"
+          right-width="auto"
         >
-          <Select v-model="settings.randomPlayMode" :options="randomPlayModeOptions" w="full" />
+          <Select v-model="settings.randomPlayMode" :options="randomPlayModeOptions" w="160px" />
         </SettingsItem>
 
         <SettingsItem
           :title="t('settings.min_videos_for_random')"
           :desc="t('settings.min_videos_for_random_desc')"
+          right-width="auto"
         >
           <Input
             v-model="settings.minVideosForRandom"
             type="number"
-            w="full"
+            w="120px"
           />
         </SettingsItem>
       </template>

--- a/src/components/Settings/BilibiliFeaturesEnhancement/Comments/Comments.vue
+++ b/src/components/Settings/BilibiliFeaturesEnhancement/Comments/Comments.vue
@@ -9,19 +9,19 @@ import SettingsItemGroup from '../../components/SettingsItemGroup.vue'
 <template>
   <div>
     <SettingsItemGroup :title="$t('settings.group_comments')">
-      <SettingsItem :title="$t('settings.show_ip_location')" :desc="$t('settings.show_ip_location_desc')">
+      <SettingsItem :title="$t('settings.show_ip_location')" :desc="$t('settings.show_ip_location_desc')" right-width="auto">
         <Radio v-model="settings.showIPLocation" />
       </SettingsItem>
 
-      <SettingsItem :title="$t('settings.show_sex')" :desc="$t('settings.show_sex_desc')">
+      <SettingsItem :title="$t('settings.show_sex')" :desc="$t('settings.show_sex_desc')" right-width="auto">
         <Radio v-model="settings.showSex" />
       </SettingsItem>
 
-      <SettingsItem :title="$t('settings.show_comment_host_tag')" :desc="$t('settings.show_comment_host_tag_desc')">
+      <SettingsItem :title="$t('settings.show_comment_host_tag')" :desc="$t('settings.show_comment_host_tag_desc')" right-width="auto">
         <Radio v-model="settings.showCommentHostTag" />
       </SettingsItem>
 
-      <SettingsItem :title="$t('settings.adjust_comment_image_height')" :desc="$t('settings.adjust_comment_image_height_desc')">
+      <SettingsItem :title="$t('settings.adjust_comment_image_height')" :desc="$t('settings.adjust_comment_image_height_desc')" right-width="auto">
         <Radio v-model="settings.adjustCommentImageHeight" />
       </SettingsItem>
     </SettingsItemGroup>

--- a/src/components/Settings/BilibiliFeaturesEnhancement/VideoPlayback/VideoPlayback.vue
+++ b/src/components/Settings/BilibiliFeaturesEnhancement/VideoPlayback/VideoPlayback.vue
@@ -49,13 +49,14 @@ const videoDanmakuDefaultStateOptions = computed(() => {
 <template>
   <div>
     <SettingsItemGroup :title="$t('settings.group_player_settings')">
-      <SettingsItem :title="$t('settings.video_default_player_mode')">
-        <Select v-model="settings.defaultVideoPlayerMode" :options="videoPlayerModeOptions" w="full" />
+      <SettingsItem :title="$t('settings.video_default_player_mode')" right-width="auto">
+        <Select v-model="settings.defaultVideoPlayerMode" :options="videoPlayerModeOptions" w="160px" />
       </SettingsItem>
 
       <SettingsItem
         :title="t('settings.keep_collection_video_default_mode')"
         :desc="t('settings.keep_collection_video_default_mode_desc')"
+        right-width="auto"
       >
         <Radio v-model="settings.keepCollectionVideoDefaultMode" />
       </SettingsItem>
@@ -63,6 +64,7 @@ const videoDanmakuDefaultStateOptions = computed(() => {
       <SettingsItem
         :title="t('settings.video_player_scroll')"
         :desc="t('settings.video_player_scroll_desc')"
+        right-width="auto"
       >
         <Radio v-model="settings.videoPlayerScroll" />
       </SettingsItem>
@@ -70,6 +72,7 @@ const videoDanmakuDefaultStateOptions = computed(() => {
       <SettingsItem
         :title="t('settings.auto_exit_fullscreen_on_end')"
         :desc="t('settings.auto_exit_fullscreen_on_end_desc')"
+        right-width="auto"
       >
         <Radio v-model="settings.autoExitFullscreenOnEnd" />
       </SettingsItem>
@@ -78,6 +81,7 @@ const videoDanmakuDefaultStateOptions = computed(() => {
         <SettingsItem
           :title="t('settings.auto_exit_fullscreen_exclude_auto_play')"
           :desc="t('settings.auto_exit_fullscreen_exclude_auto_play_desc')"
+          right-width="auto"
         >
           <Radio v-model="settings.autoExitFullscreenExcludeAutoPlay" />
         </SettingsItem>
@@ -88,13 +92,15 @@ const videoDanmakuDefaultStateOptions = computed(() => {
       <SettingsItem
         :title="t('settings.video_danmaku_default_state')"
         :desc="t('settings.video_danmaku_default_state_desc')"
+        right-width="auto"
       >
-        <Select v-model="settings.defaultDanmakuState" :options="videoDanmakuDefaultStateOptions" w="full" />
+        <Select v-model="settings.defaultDanmakuState" :options="videoDanmakuDefaultStateOptions" w="160px" />
       </SettingsItem>
 
       <SettingsItem
         :title="t('settings.remember_playback_rate')"
         :desc="t('settings.remember_playback_rate_desc')"
+        right-width="auto"
       >
         <Radio v-model="settings.rememberPlaybackRate" />
       </SettingsItem>
@@ -102,6 +108,7 @@ const videoDanmakuDefaultStateOptions = computed(() => {
       <SettingsItem
         :title="t('settings.enlarge_favorite_dialog')"
         :desc="t('settings.enlarge_favorite_dialog_desc')"
+        right-width="auto"
       >
         <Radio v-model="settings.enlargeFavoriteDialog" />
       </SettingsItem>
@@ -109,6 +116,7 @@ const videoDanmakuDefaultStateOptions = computed(() => {
       <SettingsItem
         :title="t('settings.external_watch_later_button')"
         :desc="t('settings.external_watch_later_button_desc')"
+        right-width="auto"
       >
         <Radio v-model="settings.externalWatchLaterButton" />
       </SettingsItem>

--- a/src/components/Settings/BilibiliFeaturesEnhancement/VipFeatures/VipFeatures.vue
+++ b/src/components/Settings/BilibiliFeaturesEnhancement/VipFeatures/VipFeatures.vue
@@ -9,19 +9,21 @@ import SettingsItemGroup from '../../components/SettingsItemGroup.vue'
 <template>
   <div>
     <SettingsItemGroup :title="$t('settings.bilibili_features.vip_features')">
-      <SettingsItem :title="$t('settings.show_bcoin_receive_reminder')">
+      <SettingsItem :title="$t('settings.show_bcoin_receive_reminder')" right-width="auto">
         <Radio v-model="settings.showBCoinReceiveReminder" />
       </SettingsItem>
       <SettingsItem
         v-if="settings.showBCoinReceiveReminder"
         :title="$t('settings.auto_receive_bcoin_coupon')"
         :desc="$t('settings.auto_receive_bcoin_coupon_desc')"
+        right-width="auto"
       >
         <Radio v-model="settings.autoReceiveBCoinCoupon" />
       </SettingsItem>
       <SettingsItem
         :title="$t('settings.auto_receive_vip_exp')"
         :desc="$t('settings.auto_receive_vip_exp_desc')"
+        right-width="auto"
       >
         <Radio v-model="settings.autoReceiveVipExp" />
       </SettingsItem>

--- a/src/components/Settings/Compatibility/Compatibility.vue
+++ b/src/components/Settings/Compatibility/Compatibility.vue
@@ -23,25 +23,25 @@ function changeThemeColor(color: string) {
 <template>
   <div>
     <SettingsItemGroup :title="$t('settings.group_common')">
-      <SettingsItem :title="$t('settings.topbar_visibility')" :desc="$t('settings.topbar_visibility_desc')">
+      <SettingsItem :title="$t('settings.topbar_visibility')" :desc="$t('settings.topbar_visibility_desc')" right-width="auto">
         <Radio v-model="settings.showTopBar" :label="settings.showTopBar ? $t('settings.chk_box.show') : $t('settings.chk_box.hidden')" />
       </SettingsItem>
-      <SettingsItem :title="$t('settings.use_original_bilibili_topbar')">
+      <SettingsItem :title="$t('settings.use_original_bilibili_topbar')" right-width="auto">
         <Radio v-model="settings.useOriginalBilibiliTopBar" />
       </SettingsItem>
-      <SettingsItem :title="$t('settings.use_original_bilibili_homepage')">
+      <SettingsItem :title="$t('settings.use_original_bilibili_homepage')" right-width="auto">
         <template #desc>
           <span color="$bew-error-color" v-text="$t('settings.use_original_bilibili_homepage_desc')" />
         </template>
         <Radio v-model="settings.useOriginalBilibiliHomepage" />
       </SettingsItem>
-      <SettingsItem :title="$t('settings.adapt_to_other_page_styles')" :desc="$t('settings.adapt_to_other_page_styles_desc')">
+      <SettingsItem :title="$t('settings.adapt_to_other_page_styles')" :desc="$t('settings.adapt_to_other_page_styles_desc')" right-width="auto">
         <Radio v-model="settings.adaptToOtherPageStyles" />
       </SettingsItem>
     </SettingsItemGroup>
 
     <SettingsItemGroup title="Bilibili Evolved">
-      <SettingsItem :title="$t('settings.follow_bilibili_evolved_color')" :desc="$t('settings.follow_bilibili_evolved_color_desc')">
+      <SettingsItem :title="$t('settings.follow_bilibili_evolved_color')" :desc="$t('settings.follow_bilibili_evolved_color_desc')" right-width="auto">
         <div
           w-20px h-20px rounded-8 cursor-pointer transition
           duration-300 box-border

--- a/src/components/Settings/PluginComponentsAndPages/DockAndSidebar/DockAndSidebar.vue
+++ b/src/components/Settings/PluginComponentsAndPages/DockAndSidebar/DockAndSidebar.vue
@@ -88,20 +88,20 @@ function handleToggleDockItem(dockItem: any) {
 <template>
   <div>
     <SettingsItemGroup :title="$t('settings.group_dock')">
-      <SettingsItem :title="$t('settings.always_use_dock')" :desc="$t('settings.always_use_dock_desc')">
+      <SettingsItem :title="$t('settings.always_use_dock')" :desc="$t('settings.always_use_dock_desc')" right-width="auto">
         <Radio v-model="settings.alwaysUseDock" />
       </SettingsItem>
-      <SettingsItem :title="$t('settings.auto_hide_dock')">
+      <SettingsItem :title="$t('settings.auto_hide_dock')" right-width="auto">
         <Radio v-model="settings.autoHideDock" />
       </SettingsItem>
-      <SettingsItem :title="$t('settings.half_hide_dock')">
+      <SettingsItem :title="$t('settings.half_hide_dock')" right-width="auto">
         <Radio v-model="settings.halfHideDock" />
       </SettingsItem>
-      <SettingsItem :title="$t('settings.dock_position')" :desc="$t('settings.dock_position_desc')">
+      <SettingsItem :title="$t('settings.dock_position')" :desc="$t('settings.dock_position_desc')" right-width="auto">
         <Select
           v-model="settings.dockPosition"
           :options="dockPositions"
-          w="full"
+          w="160px"
         />
       </SettingsItem>
       <SettingsItem :desc="$t('settings.dock_content_adjustment_desc')">
@@ -156,25 +156,25 @@ function handleToggleDockItem(dockItem: any) {
           </draggable>
         </template>
       </SettingsItem>
-      <SettingsItem :title="$t('settings.disable_dock_glowing_effect')">
+      <SettingsItem :title="$t('settings.disable_dock_glowing_effect')" right-width="auto">
         <Radio v-model="settings.disableDockGlowingEffect" />
       </SettingsItem>
-      <SettingsItem :title="$t('settings.disable_light_dark_mode_switcher')">
+      <SettingsItem :title="$t('settings.disable_light_dark_mode_switcher')" right-width="auto">
         <Radio v-model="settings.disableLightDarkModeSwitcherOnDock" />
       </SettingsItem>
-      <SettingsItem :title="$t('settings.back_to_top_and_refresh_buttons_are_separated')">
+      <SettingsItem :title="$t('settings.back_to_top_and_refresh_buttons_are_separated')" right-width="auto">
         <Radio v-model="settings.backToTopAndRefreshButtonsAreSeparated" />
       </SettingsItem>
-      <SettingsItem :title="$t('settings.enable_undo_refresh_button')" :desc="$t('settings.enable_undo_refresh_button_desc')">
+      <SettingsItem :title="$t('settings.enable_undo_refresh_button')" :desc="$t('settings.enable_undo_refresh_button_desc')" right-width="auto">
         <Radio v-model="settings.enableUndoRefreshButton" />
       </SettingsItem>
     </SettingsItemGroup>
 
     <SettingsItemGroup :title="$t('settings.group_sidebar')" :desc="$t('settings.group_sidebar_desc')">
-      <SettingsItem :title="$t('settings.sidebar_position')">
-        <Select v-model="settings.sidebarPosition" :options="sidebarPositions" w="full" />
+      <SettingsItem :title="$t('settings.sidebar_position')" right-width="auto">
+        <Select v-model="settings.sidebarPosition" :options="sidebarPositions" w="160px" />
       </SettingsItem>
-      <SettingsItem :title="$t('settings.auto_hide_sidebar')">
+      <SettingsItem :title="$t('settings.auto_hide_sidebar')" right-width="auto">
         <Radio v-model="settings.autoHideSidebar" />
       </SettingsItem>
     </SettingsItemGroup>

--- a/src/components/Settings/PluginComponentsAndPages/General/General.vue
+++ b/src/components/Settings/PluginComponentsAndPages/General/General.vue
@@ -81,48 +81,48 @@ watch(() => settings.value.language, (newValue) => {
 <template>
   <div>
     <SettingsItemGroup :title="$t('settings.group_common')">
-      <SettingsItem :title="$t('settings.touch_screen_optimization')" :desc="$t('settings.touch_screen_optimization_desc')">
+      <SettingsItem :title="$t('settings.touch_screen_optimization')" :desc="$t('settings.touch_screen_optimization_desc')" right-width="auto">
         <Radio v-model="settings.touchScreenOptimization" />
       </SettingsItem>
 
-      <SettingsItem :title="$t('settings.enable_grid_layout_switcher')">
+      <SettingsItem :title="$t('settings.enable_grid_layout_switcher')" right-width="auto">
         <Radio v-model="settings.enableGridLayoutSwitcher" />
       </SettingsItem>
 
-      <SettingsItem :title="$t('settings.enable_horizontal_scrolling')" :desc="$t('settings.enable_horizontal_scrolling_desc')">
+      <SettingsItem :title="$t('settings.enable_horizontal_scrolling')" :desc="$t('settings.enable_horizontal_scrolling_desc')" right-width="auto">
         <Radio v-model="settings.enableHorizontalScrolling" />
       </SettingsItem>
     </SettingsItemGroup>
 
     <SettingsItemGroup :title="$t('settings.group_language')">
-      <SettingsItem :title="$t('settings.select_language')">
+      <SettingsItem :title="$t('settings.select_language')" right-width="auto">
         <Select
           v-model="settings.language"
           :options="langOptions"
-          w="full"
+          w="160px"
         />
       </SettingsItem>
     </SettingsItemGroup>
 
     <SettingsItemGroup :title="$t('settings.group_link_opening_behavior')">
-      <SettingsItem :title="$t('settings.top_bar_link_opening_behavior')">
-        <Select v-model="settings.topBarLinkOpenMode" :options="openModeOptions" w="full" />
+      <SettingsItem :title="$t('settings.top_bar_link_opening_behavior')" :desc="$t('settings.link_opening_behavior_desc')" right-width="auto">
+        <Select v-model="settings.topBarLinkOpenMode" :options="openModeOptions" w="160px" />
       </SettingsItem>
-      <SettingsItem :title="$t('settings.video_card_link_opening_behavior')">
+      <SettingsItem :title="$t('settings.video_card_link_opening_behavior')" :desc="$t('settings.video_card_link_opening_behavior_desc')" right-width="auto">
         <Select
           v-model="settings.videoCardLinkOpenMode"
           :options="videoCardOpenModeOptions"
-          w="full"
+          w="160px"
         />
       </SettingsItem>
-      <SettingsItem :title="$t('settings.search_bar_link_opening_behavior')">
+      <SettingsItem :title="$t('settings.search_bar_link_opening_behavior')" :desc="$t('settings.link_opening_behavior_desc')" right-width="auto">
         <Select
           v-model="settings.searchBarLinkOpenMode"
           :options="openModeOptions"
-          w="full"
+          w="160px"
         />
       </SettingsItem>
-      <SettingsItem>
+      <SettingsItem right-width="auto">
         <template #title>
           <div v-html="$t('settings.close_drawer_without_pressing_esc_again')" />
         </template>
@@ -131,26 +131,26 @@ watch(() => settings.value.language, (newValue) => {
     </SettingsItemGroup>
 
     <SettingsItemGroup :title="$t('settings.group_ad_blocking')">
-      <SettingsItem :title="$t('settings.block_ads')">
+      <SettingsItem :title="$t('settings.block_ads')" right-width="auto">
         <Radio v-model="settings.blockAds" />
       </SettingsItem>
-      <SettingsItem :title="$t('settings.block_top_search_page_ads')" :desc="$t('settings.block_top_search_page_ads_desc')">
+      <SettingsItem :title="$t('settings.block_top_search_page_ads')" :desc="$t('settings.block_top_search_page_ads_desc')" right-width="auto">
         <Radio v-model="settings.blockTopSearchPageAds" />
       </SettingsItem>
-      <SettingsItem :title="$t('settings.clean_url_argument')" :desc="$t('settings.clean_url_argument_desc')">
+      <SettingsItem :title="$t('settings.clean_url_argument')" :desc="$t('settings.clean_url_argument_desc')" right-width="auto">
         <Radio v-model="settings.cleanUrlArgument" />
       </SettingsItem>
     </SettingsItemGroup>
 
     <SettingsItemGroup :title="$t('settings.group_clean_share_link')">
-      <SettingsItem :title="$t('settings.enable_clean_share_link')" :desc="$t('settings.enable_clean_share_link_desc')">
+      <SettingsItem :title="$t('settings.enable_clean_share_link')" :desc="$t('settings.enable_clean_share_link_desc')" right-width="auto">
         <Radio v-model="settings.enableCleanShareLink" />
       </SettingsItem>
       <template v-if="settings.enableCleanShareLink">
-        <SettingsItem :title="$t('settings.clean_share_link_include_title')" :desc="$t('settings.clean_share_link_include_title_desc')">
+        <SettingsItem :title="$t('settings.clean_share_link_include_title')" :desc="$t('settings.clean_share_link_include_title_desc')" right-width="auto">
           <Radio v-model="settings.cleanShareLinkIncludeTitle" />
         </SettingsItem>
-        <SettingsItem :title="$t('settings.clean_share_link_remove_tracking_params')" :desc="$t('settings.clean_share_link_remove_tracking_params_desc')">
+        <SettingsItem :title="$t('settings.clean_share_link_remove_tracking_params')" :desc="$t('settings.clean_share_link_remove_tracking_params_desc')" right-width="auto">
           <Radio v-model="settings.cleanShareLinkRemoveTrackingParams" />
         </SettingsItem>
       </template>

--- a/src/components/Settings/PluginComponentsAndPages/Home/Home.vue
+++ b/src/components/Settings/PluginComponentsAndPages/Home/Home.vue
@@ -186,7 +186,7 @@ function handleToggleHomeTab(tab: any) {
 <template>
   <div>
     <SettingsItemGroup :title="$t('settings.group_recommendation_mode')">
-      <SettingsItem :title="$t('settings.recommendation_mode')">
+      <SettingsItem :title="$t('settings.recommendation_mode')" right-width="auto">
         <template #desc>
           <p>{{ $t('settings.recommendation_mode_desc') }}</p>
         </template>
@@ -227,7 +227,7 @@ function handleToggleHomeTab(tab: any) {
         </div>
       </SettingsItem>
 
-      <SettingsItem v-if="settings.recommendationMode === 'app'" :title="$t('settings.authorize_app')">
+      <SettingsItem v-if="settings.recommendationMode === 'app'" :title="$t('settings.authorize_app')" right-width="auto">
         <template #desc>
           {{ $t('settings.authorize_app_desc') }}
           <br>
@@ -237,11 +237,11 @@ function handleToggleHomeTab(tab: any) {
         </template>
 
         <div w-full>
-          <Button v-if="!appAccessToken" type="primary" center block @click="handleAuthorize">
+          <Button v-if="!appAccessToken" type="primary" center @click="handleAuthorize">
             {{ $t('settings.btn.authorize') }}...
           </Button>
           <Button
-            v-else type="secondary" center block style="--b-button-text-color: var(--bew-error-color)"
+            v-else type="secondary" center style="--b-button-text-color: var(--bew-error-color)"
             @click="handleRevoke"
           >
             {{ $t('settings.btn.revoke') }}
@@ -249,11 +249,11 @@ function handleToggleHomeTab(tab: any) {
         </div>
       </SettingsItem>
 
-      <SettingsItem :title="$t('settings.auto_switch_recommendation_mode')" :desc="$t('settings.auto_switch_recommendation_mode_desc')">
+      <SettingsItem :title="$t('settings.auto_switch_recommendation_mode')" :desc="$t('settings.auto_switch_recommendation_mode_desc')" right-width="auto">
         <Radio v-model="settings.autoSwitchRecommendationMode" />
       </SettingsItem>
 
-      <SettingsItem :title="$t('settings.preserve_for_you_state')" :desc="$t('settings.preserve_for_you_state_desc')">
+      <SettingsItem :title="$t('settings.preserve_for_you_state')" :desc="$t('settings.preserve_for_you_state_desc')" right-width="auto">
         <Radio v-model="settings.preserveForYouState" />
       </SettingsItem>
 
@@ -299,14 +299,14 @@ function handleToggleHomeTab(tab: any) {
       :title="$t('settings.group_recommendation_filters')"
       :desc="$t('settings.group_recommendation_filters_desc')"
     >
-      <SettingsItem :title="$t('settings.disable_filters_for_followed_users')" :desc="$t('settings.disable_filters_for_followed_users_desc')">
+      <SettingsItem :title="$t('settings.disable_filters_for_followed_users')" :desc="$t('settings.disable_filters_for_followed_users_desc')" right-width="auto">
         <Radio v-model="settings.disableFilterForFollowedUser" />
       </SettingsItem>
-      <SettingsItem :title="$t('settings.filter_out_vertical_videos')">
+      <SettingsItem :title="$t('settings.filter_out_vertical_videos')" right-width="auto">
         <Radio v-model="settings.filterOutVerticalVideos" />
       </SettingsItem>
-      <SettingsItem :title="$t('settings.filter_by_view_count')" :desc="$t('settings.filter_by_view_count_desc')">
-        <div flex="~ justify-end" w-full>
+      <SettingsItem :title="$t('settings.filter_by_view_count')" :desc="$t('settings.filter_by_view_count_desc')" right-width="auto">
+        <div class="filter-control" :class="{ 'filter-control--enabled': settings.enableFilterByViewCount }" flex="~ justify-end">
           <Input
             v-if="settings.enableFilterByViewCount"
             v-model="settings.filterByViewCount" type="number" :min="1" :max="1000000"
@@ -319,8 +319,8 @@ function handleToggleHomeTab(tab: any) {
           <Radio v-model="settings.enableFilterByViewCount" />
         </div>
       </SettingsItem>
-      <SettingsItem :title="$t('settings.filter_by_like_count')" :desc="$t('settings.filter_by_like_count_desc')">
-        <div flex="~ justify-end" w-full>
+      <SettingsItem :title="$t('settings.filter_by_like_count')" :desc="$t('settings.filter_by_like_count_desc')" right-width="auto">
+        <div class="filter-control" :class="{ 'filter-control--enabled': settings.enableFilterByLikeCount }" flex="~ justify-end">
           <Input
             v-if="settings.enableFilterByLikeCount"
             v-model="settings.filterByLikeCount" type="number" :min="1" :max="1000000"
@@ -333,8 +333,8 @@ function handleToggleHomeTab(tab: any) {
           <Radio v-model="settings.enableFilterByLikeCount" />
         </div>
       </SettingsItem>
-      <SettingsItem :title="$t('settings.filter_by_duration')" :desc="$t('settings.filter_by_duration_desc')">
-        <div flex="~ justify-end" w-full>
+      <SettingsItem :title="$t('settings.filter_by_duration')" :desc="$t('settings.filter_by_duration_desc')" right-width="auto">
+        <div class="filter-control" :class="{ 'filter-control--enabled': settings.enableFilterByDuration }" flex="~ justify-end">
           <Input
             v-if="settings.enableFilterByDuration"
             v-model="settings.filterByDuration" type="number" :min="1" :max="1000000"
@@ -347,8 +347,8 @@ function handleToggleHomeTab(tab: any) {
           <Radio v-model="settings.enableFilterByDuration" />
         </div>
       </SettingsItem>
-      <SettingsItem :title="$t('settings.filter_by_publish_time')" :desc="$t('settings.filter_by_publish_time_desc')">
-        <div flex="~ justify-end" w-full>
+      <SettingsItem :title="$t('settings.filter_by_publish_time')" :desc="$t('settings.filter_by_publish_time_desc')" right-width="auto">
+        <div class="filter-control" :class="{ 'filter-control--enabled': settings.enableFilterByPublishTime }" flex="~ justify-end">
           <Input
             v-if="settings.enableFilterByPublishTime"
             v-model="settings.filterByPublishTime" type="number" :min="7" :max="365"
@@ -366,6 +366,7 @@ function handleToggleHomeTab(tab: any) {
         <SettingsItem
           class="unrestricted-width-settings-item"
           :title="$t('settings.filter_by_title')"
+          right-width="auto"
           border="lg:none t-1 $bew-border-color"
         >
           <Radio v-model="settings.enableFilterByTitle" />
@@ -393,6 +394,7 @@ function handleToggleHomeTab(tab: any) {
         <SettingsItem
           class="unrestricted-width-settings-item"
           :title="$t('settings.filter_by_user')"
+          right-width="auto"
           border="lg:none b-1 $bew-border-color"
         >
           <Radio v-model="settings.enableFilterByUser" />
@@ -421,14 +423,14 @@ function handleToggleHomeTab(tab: any) {
     </SettingsItemGroup>
 
     <SettingsItemGroup :title="$t('settings.group_following')">
-      <SettingsItem :title="$t('settings.use_following_new_layout')" :desc="$t('settings.use_following_new_layout_desc')">
+      <SettingsItem :title="$t('settings.use_following_new_layout')" :desc="$t('settings.use_following_new_layout_desc')" right-width="auto">
         <Radio v-model="settings.useFollowingNewLayout" />
       </SettingsItem>
-      <SettingsItem :title="$t('settings.enable_following_inactive_blacklist')" :desc="$t('settings.enable_following_inactive_blacklist_desc')">
+      <SettingsItem :title="$t('settings.enable_following_inactive_blacklist')" :desc="$t('settings.enable_following_inactive_blacklist_desc')" right-width="auto">
         <Radio v-model="settings.enableFollowingInactiveBlacklist" />
       </SettingsItem>
       <template v-if="settings.enableFollowingInactiveBlacklist">
-        <SettingsItem :title="$t('settings.following_inactive_days')" :desc="$t('settings.following_inactive_days_desc')">
+        <SettingsItem :title="$t('settings.following_inactive_days')" :desc="$t('settings.following_inactive_days_desc')" right-width="auto">
           <Input
             v-model="settings.followingInactiveDays" type="number" :min="1" :max="365"
             w-120px
@@ -439,13 +441,13 @@ function handleToggleHomeTab(tab: any) {
           </Input>
         </SettingsItem>
       </template>
-      <SettingsItem :title="$t('settings.following_tab_show_livestreaming_videos')">
+      <SettingsItem :title="$t('settings.following_tab_show_livestreaming_videos')" right-width="auto">
         <Radio v-model="settings.followingTabShowLivestreamingVideos" />
       </SettingsItem>
-      <SettingsItem :title="$t('settings.following_filter_charging_videos')" :desc="$t('settings.following_filter_charging_videos_desc')">
+      <SettingsItem :title="$t('settings.following_filter_charging_videos')" :desc="$t('settings.following_filter_charging_videos_desc')" right-width="auto">
         <Radio v-model="settings.followingFilterChargingVideos" />
       </SettingsItem>
-      <SettingsItem :title="$t('settings.following_filter_dynamic_videos')" :desc="$t('settings.following_filter_dynamic_videos_desc')">
+      <SettingsItem :title="$t('settings.following_filter_dynamic_videos')" :desc="$t('settings.following_filter_dynamic_videos_desc')" right-width="auto">
         <Radio v-model="settings.followingFilterDynamicVideos" />
       </SettingsItem>
     </SettingsItemGroup>
@@ -453,7 +455,7 @@ function handleToggleHomeTab(tab: any) {
     <SettingsItemGroup
       :title="$t('settings.group_home_tabs')"
     >
-      <SettingsItem :desc="$t('settings.home_tabs_adjustment_desc')">
+      <SettingsItem :desc="$t('settings.home_tabs_adjustment_desc')" right-width="auto">
         <template #title>
           <div flex="~ gap-4 items-center">
             {{ $t('settings.home_tabs_adjustment') }}
@@ -491,15 +493,15 @@ function handleToggleHomeTab(tab: any) {
     </SettingsItemGroup>
 
     <SettingsItemGroup :title="$t('settings.group_search_page_mode')">
-      <SettingsItem :title="$t('settings.use_search_page_mode')">
+      <SettingsItem :title="$t('settings.use_search_page_mode')" right-width="auto">
         <Radio v-model="settings.useSearchPageModeOnHomePage" />
       </SettingsItem>
       <template v-if="settings.useSearchPageModeOnHomePage">
-        <SettingsItem :title="$t('settings.settings_shared_with_the_search_page')">
+        <SettingsItem :title="$t('settings.settings_shared_with_the_search_page')" right-width="auto">
           <template #desc>
             <span color="$bew-warning-color">{{ $t('settings.settings_shared_with_the_search_page_desc') }}</span>
           </template>
-          <Button type="secondary" block center @click="showSearchPageModeSharedSettings = true">
+          <Button type="secondary" center @click="showSearchPageModeSharedSettings = true">
             {{ $t('settings.btn.open_settings') }}
           </Button>
 
@@ -521,7 +523,7 @@ function handleToggleHomeTab(tab: any) {
           </Dialog>
         </SettingsItem>
 
-        <SettingsItem :title="$t('settings.search_page_mode_wallpaper_fixed')">
+        <SettingsItem :title="$t('settings.search_page_mode_wallpaper_fixed')" right-width="auto">
           <Radio v-model="settings.searchPageModeWallpaperFixed" />
         </SettingsItem>
       </template>
@@ -542,13 +544,21 @@ function handleToggleHomeTab(tab: any) {
 
 .recommendation-mode-selector {
   display: grid;
-  grid-template-columns: minmax(0, 0.8fr) minmax(0, 1.4fr) minmax(0, 0.8fr);
-  width: 100%;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  width: 300px;
 }
 
 .recommendation-mode-option {
   min-width: 0;
   padding-inline: 0.5rem;
   white-space: nowrap;
+}
+
+.filter-control {
+  width: auto;
+}
+
+.filter-control--enabled {
+  width: 220px;
 }
 </style>

--- a/src/components/Settings/PluginComponentsAndPages/SearchPage/SearchPage.vue
+++ b/src/components/Settings/PluginComponentsAndPages/SearchPage/SearchPage.vue
@@ -21,8 +21,8 @@ function changeSearchBarFocusCharacter(url: string) {
 <template>
   <div>
     <SettingsItemGroup :title="$t('settings.group_logo')">
-      <SettingsItem :title="$t('settings.logo_color')">
-        <div w-full flex rounded="$bew-radius" bg="$bew-fill-1" p-1>
+      <SettingsItem :title="$t('settings.logo_color')" right-width="auto">
+        <div w="220px" flex rounded="$bew-radius" bg="$bew-fill-1" p-1>
           <div
             flex="1 ~" items-center justify-center py-1 cursor-pointer
             text-center rounded="$bew-radius"
@@ -48,25 +48,25 @@ function changeSearchBarFocusCharacter(url: string) {
         </div>
       </SettingsItem>
 
-      <SettingsItem :title="$t('settings.enable_logo_glowing_effect')">
+      <SettingsItem :title="$t('settings.enable_logo_glowing_effect')" right-width="auto">
         <Radio v-model="settings.searchPageLogoGlow" />
       </SettingsItem>
 
-      <SettingsItem :title="$t('settings.logo_visibility')">
+      <SettingsItem :title="$t('settings.logo_visibility')" right-width="auto">
         <Radio v-model="settings.searchPageShowLogo" />
       </SettingsItem>
     </SettingsItemGroup>
 
     <SettingsItemGroup :title="$t('settings.group_search_bar')">
-      <SettingsItem :title="$t('settings.show_search_recommendation')" :desc="$t('settings.show_search_recommendation_desc')">
+      <SettingsItem :title="$t('settings.show_search_recommendation')" :desc="$t('settings.show_search_recommendation_desc')" right-width="auto">
         <Radio v-model="settings.showSearchRecommendation" />
       </SettingsItem>
 
-      <SettingsItem :title="$t('settings.bg_darkens_when_the_search_bar_is_focused')">
+      <SettingsItem :title="$t('settings.bg_darkens_when_the_search_bar_is_focused')" right-width="auto">
         <Radio v-model="settings.searchPageDarkenOnSearchFocus" />
       </SettingsItem>
 
-      <SettingsItem :title="$t('settings.bg_blurs_when_the_search_bar_is_focused')">
+      <SettingsItem :title="$t('settings.bg_blurs_when_the_search_bar_is_focused')" right-width="auto">
         <template #desc>
           <span color="$bew-warning-color">{{ $t('common.performance_impact_warn') }}</span>
         </template>
@@ -105,7 +105,7 @@ function changeSearchBarFocusCharacter(url: string) {
     </SettingsItemGroup>
 
     <SettingsItemGroup :title="$t('settings.group_hot_search')">
-      <SettingsItem :title="$t('settings.show_hot_search_in_search_page')">
+      <SettingsItem :title="$t('settings.show_hot_search_in_search_page')" right-width="auto">
         <template #desc>
           <span>{{ $t('settings.show_hot_search_in_search_page_desc') }}</span>
         </template>
@@ -114,18 +114,18 @@ function changeSearchBarFocusCharacter(url: string) {
     </SettingsItemGroup>
 
     <SettingsItemGroup :title="$t('settings.group_search_results')">
-      <SettingsItem :title="$t('settings.use_plugin_search_results_page')">
+      <SettingsItem :title="$t('settings.use_plugin_search_results_page')" right-width="auto">
         <template #desc>
           <span>{{ $t('settings.use_plugin_search_results_page_desc') }}</span>
         </template>
         <Radio v-model="settings.usePluginSearchResultsPage" />
       </SettingsItem>
 
-      <SettingsItem :title="$t('settings.search_results_pagination_mode')">
+      <SettingsItem :title="$t('settings.search_results_pagination_mode')" right-width="auto">
         <template #desc>
           <span>{{ $t('settings.search_results_pagination_mode_desc') }}</span>
         </template>
-        <div w-full flex rounded="$bew-radius" bg="$bew-fill-1" p-1>
+        <div w="220px" flex rounded="$bew-radius" bg="$bew-fill-1" p-1>
           <div
             flex="1 ~" items-center justify-center py-1 cursor-pointer
             text-center rounded="$bew-radius"

--- a/src/components/Settings/PluginComponentsAndPages/TopBar/TopBar.vue
+++ b/src/components/Settings/PluginComponentsAndPages/TopBar/TopBar.vue
@@ -35,14 +35,14 @@ const openModeOptions = computed(() => {
 <template>
   <div>
     <SettingsItemGroup :title="$t('settings.group_link_opening_behavior')">
-      <SettingsItem :title="$t('settings.top_bar_link_opening_behavior')">
-        <Select v-model="settings.topBarLinkOpenMode" :options="openModeOptions" w="full" />
+      <SettingsItem :title="$t('settings.top_bar_link_opening_behavior')" :desc="$t('settings.link_opening_behavior_desc')" right-width="auto">
+        <Select v-model="settings.topBarLinkOpenMode" :options="openModeOptions" w="160px" />
       </SettingsItem>
-      <SettingsItem :title="$t('settings.search_bar_link_opening_behavior')">
+      <SettingsItem :title="$t('settings.search_bar_link_opening_behavior')" :desc="$t('settings.link_opening_behavior_desc')" right-width="auto">
         <Select
           v-model="settings.searchBarLinkOpenMode"
           :options="openModeOptions"
-          w="full"
+          w="160px"
         />
       </SettingsItem>
     </SettingsItemGroup>

--- a/src/components/Settings/PluginComponentsAndPages/TopBar/TopBarComponents.vue
+++ b/src/components/Settings/PluginComponentsAndPages/TopBar/TopBarComponents.vue
@@ -159,7 +159,7 @@ watchEffect(() => {
                 <Select
                   v-model="settings.topBarComponentsConfig[index].badgeType"
                   :options="badgeOptions"
-                  w="120px"
+                  w="160px"
                 />
               </div>
               <div v-else h="32px" />

--- a/src/components/Settings/PluginComponentsAndPages/TopBar/TopBarVisualConfig.vue
+++ b/src/components/Settings/PluginComponentsAndPages/TopBar/TopBarVisualConfig.vue
@@ -324,7 +324,7 @@ function toggleChannel(value: string) {
 
               <!-- Home 按钮设置（仅在触屏优化开启时显示） -->
               <div v-if="settings.touchScreenOptimization" bg="$bew-fill-1" rounded="$bew-radius" p-3>
-                <SettingsItem :title="$t('settings.show_home_button_in_touch_mode')">
+                <SettingsItem :title="$t('settings.show_home_button_in_touch_mode')" right-width="auto">
                   <Radio v-model="settings.showHomeButtonInTouchMode" />
                 </SettingsItem>
                 <div text-sm opacity-70 mt-2>
@@ -375,7 +375,7 @@ function toggleChannel(value: string) {
               </div>
 
               <div bg="$bew-fill-1" rounded="$bew-radius" p-3>
-                <SettingsItem :title="$t('settings.show_bewly_or_bili_page_switcher')">
+                <SettingsItem :title="$t('settings.show_bewly_or_bili_page_switcher')" right-width="auto">
                   <Radio v-model="settings.showBewlyOrBiliPageSwitcher" />
                 </SettingsItem>
                 <div text-sm opacity-70 mt-2>
@@ -384,7 +384,7 @@ function toggleChannel(value: string) {
               </div>
 
               <div bg="$bew-fill-1" rounded="$bew-radius" p-3>
-                <SettingsItem :title="$t('settings.show_bewly_or_bili_top_bar_switcher')">
+                <SettingsItem :title="$t('settings.show_bewly_or_bili_top_bar_switcher')" right-width="auto">
                   <Radio v-model="settings.showBewlyOrBiliTopBarSwitcher" />
                 </SettingsItem>
                 <div text-sm opacity-70 mt-2>
@@ -394,14 +394,14 @@ function toggleChannel(value: string) {
             </div>
 
             <!-- 搜索框配置 -->
-            <div v-else-if="selectedElement === 'search'" flex="~ col gap-4">
+            <div v-else-if="selectedElement === 'search'" flex="~ col">
               <div text-lg font-semibold>
                 {{ $t('settings.group_search_bar') }}
               </div>
-              <SettingsItem :title="$t('settings.show_hot_search_in_top_bar')" :desc="$t('settings.show_hot_search_in_top_bar_desc')">
+              <SettingsItem :title="$t('settings.show_hot_search_in_top_bar')" :desc="$t('settings.show_hot_search_in_top_bar_desc')" right-width="auto">
                 <Radio v-model="settings.showHotSearchInTopBar" />
               </SettingsItem>
-              <SettingsItem :title="$t('settings.show_search_recommendation')" :desc="$t('settings.show_search_recommendation_desc')">
+              <SettingsItem :title="$t('settings.show_search_recommendation')" :desc="$t('settings.show_search_recommendation_desc')" right-width="auto">
                 <Radio v-model="settings.showSearchRecommendation" />
               </SettingsItem>
             </div>
@@ -409,13 +409,13 @@ function toggleChannel(value: string) {
             <!-- PopIcon 配置 -->
             <div
               v-else-if="topBarElements.find(e => e.id === selectedElement && e.type === 'popIcon')"
-              flex="~ col gap-4"
+              flex="~ col"
             >
               <div text-lg font-semibold>
                 {{ topBarElements.find(e => e.id === selectedElement)?.label }}
               </div>
 
-              <SettingsItem :title="$t('settings.visibility')">
+              <SettingsItem :title="$t('settings.visibility')" right-width="auto">
                 <Radio
                   :model-value="getElementConfig(selectedElement)?.visible ?? true"
                   @update:model-value="toggleComponentVisibility(selectedElement)"
@@ -425,11 +425,12 @@ function toggleChannel(value: string) {
               <SettingsItem
                 v-if="topBarElements.find(e => e.id === selectedElement)?.supportsBadge"
                 :title="$t('settings.badge_type')"
+                right-width="auto"
               >
                 <Select
                   v-model="getElementConfig(selectedElement)!.badgeType"
                   :options="badgeOptions"
-                  w="full"
+                  w="160px"
                   :disabled="!getElementConfig(selectedElement)?.visible"
                 />
               </SettingsItem>
@@ -438,6 +439,7 @@ function toggleChannel(value: string) {
                 v-if="selectedElement === 'notifications'"
                 :title="$t('settings.show_like_notification_reminder')"
                 :desc="$t('settings.show_like_notification_reminder_desc')"
+                right-width="auto"
               >
                 <Radio v-model="settings.showLikeNotificationReminder" />
               </SettingsItem>
@@ -447,13 +449,14 @@ function toggleChannel(value: string) {
                 v-if="selectedElement === 'moments'"
                 title="过滤专栏"
                 desc="在动态列表中过滤掉专栏内容，仅显示视频"
+                right-width="auto"
               >
                 <Radio v-model="settings.filterArticlesInMoments" />
               </SettingsItem>
             </div>
 
             <!-- 头像配置 -->
-            <div v-else-if="selectedElement === 'avatar'" flex="~ col gap-4">
+            <div v-else-if="selectedElement === 'avatar'" flex="~ col">
               <div text-lg font-semibold>
                 {{ $t('topbar.user_dropdown.account_settings') }}
               </div>
@@ -461,6 +464,7 @@ function toggleChannel(value: string) {
               <SettingsItem
                 :title="$t('settings.hide_lv6_last_login_location_in_top_bar_user_pop')"
                 :desc="$t('settings.hide_lv6_last_login_location_in_top_bar_user_pop_desc')"
+                right-width="auto"
               >
                 <Radio v-model="settings.hideTopBarUserPanelLv6LastLoginLocation" />
               </SettingsItem>
@@ -469,28 +473,29 @@ function toggleChannel(value: string) {
         </Transition>
 
         <!-- 全局设置 -->
-        <div mt-6 pt-6 border-t="1 $bew-border-color">
-          <div flex="~ col gap-4">
-            <SettingsItem :title="$t('settings.auto_hide_top_bar')">
+        <div mt-4 border-t="1 $bew-border-color">
+          <div flex="~ col">
+            <SettingsItem :title="$t('settings.auto_hide_top_bar')" right-width="auto">
               <Radio v-model="settings.autoHideTopBar" />
             </SettingsItem>
 
             <SettingsItem
               :title="$t('settings.video_page_top_bar_config')"
               :desc="$t('settings.video_page_top_bar_config_desc')"
+              right-width="auto"
             >
-              <Select v-model="settings.videoPageTopBarConfig" :options="videoPageTopBarConfigOptions" w="full" />
+              <Select v-model="settings.videoPageTopBarConfig" :options="videoPageTopBarConfigOptions" w="160px" />
             </SettingsItem>
 
-            <SettingsItem :title="$t('settings.always_use_transparent_top_bar')">
+            <SettingsItem :title="$t('settings.always_use_transparent_top_bar')" right-width="auto">
               <Radio v-model="settings.alwaysUseTransparentTopBar" />
             </SettingsItem>
 
-            <SettingsItem :title="$t('settings.show_top_bar_theme_color_gradient')">
+            <SettingsItem :title="$t('settings.show_top_bar_theme_color_gradient')" right-width="auto">
               <Radio v-model="settings.showTopBarThemeColorGradient" />
             </SettingsItem>
 
-            <SettingsItem :title="$t('settings.open_notifications_page_as_drawer')">
+            <SettingsItem :title="$t('settings.open_notifications_page_as_drawer')" right-width="auto">
               <Radio v-model="settings.openNotificationsPageAsDrawer" />
             </SettingsItem>
 

--- a/src/components/Settings/PluginComponentsAndPages/VideoCard/VideoCard.vue
+++ b/src/components/Settings/PluginComponentsAndPages/VideoCard/VideoCard.vue
@@ -78,14 +78,14 @@ function resetColumns() {
 <template>
   <div>
     <SettingsItemGroup :title="$t('settings.group_link_opening_behavior')">
-      <SettingsItem :title="$t('settings.video_card_link_opening_behavior')">
+      <SettingsItem :title="$t('settings.video_card_link_opening_behavior')" :desc="$t('settings.video_card_link_opening_behavior_desc')" right-width="auto">
         <Select
           v-model="settings.videoCardLinkOpenMode"
           :options="videoCardOpenModeOptions"
-          w="full"
+          w="160px"
         />
       </SettingsItem>
-      <SettingsItem>
+      <SettingsItem right-width="auto">
         <template #title>
           <div v-html="$t('settings.close_drawer_without_pressing_esc_again')" />
         </template>
@@ -95,7 +95,7 @@ function resetColumns() {
 
     <!-- Video Card Grid Settings -->
     <SettingsItemGroup :title="$t('settings.group_video_card_grid')">
-      <SettingsItem :title="$t('settings.grid_breakpoints')" :desc="$t('settings.grid_breakpoints_desc')">
+      <SettingsItem :title="$t('settings.grid_breakpoints')" :desc="$t('settings.grid_breakpoints_desc')" right-width="auto">
         <template #bottom>
           <div flex="~ col gap-3" w-full>
             <div
@@ -128,61 +128,65 @@ function resetColumns() {
       <SettingsItem
         :title="$t('settings.video_card_layout')"
         :desc="$t('settings.video_card_layout_desc')"
+        right-width="auto"
       >
-        <Select v-model="settings.videoCardLayout" :options="videoCardLayoutOptions" w="full" />
+        <Select v-model="settings.videoCardLayout" :options="videoCardLayoutOptions" w="160px" />
       </SettingsItem>
 
-      <SettingsItem :title="$t('settings.enable_video_preview')">
+      <SettingsItem :title="$t('settings.enable_video_preview')" right-width="auto">
         <Radio v-model="settings.enableVideoPreview" />
       </SettingsItem>
 
       <template v-if="settings.enableVideoPreview">
-        <SettingsItem :title="$t('settings.enable_video_ctrl_bar_on_video_card')">
+        <SettingsItem :title="$t('settings.enable_video_ctrl_bar_on_video_card')" right-width="auto">
           <Radio v-model="settings.enableVideoCtrlBarOnVideoCard" />
         </SettingsItem>
 
-        <SettingsItem :title="$t('settings.hover_video_card_delayed')">
+        <SettingsItem :title="$t('settings.hover_video_card_delayed')" right-width="auto">
           <Radio v-model="settings.hoverVideoCardDelayed" />
         </SettingsItem>
 
-        <SettingsItem :title="$t('settings.only_cover_video_preview')">
+        <SettingsItem :title="$t('settings.only_cover_video_preview')" right-width="auto">
           <Radio v-model="settings.onlyCoverVideoPreview" />
         </SettingsItem>
       </template>
 
-      <SettingsItem :title="$t('settings.show_video_card_recommend_tag')" :desc="$t('settings.show_video_card_recommend_tag_desc')">
+      <SettingsItem :title="$t('settings.show_video_card_recommend_tag')" :desc="$t('settings.show_video_card_recommend_tag_desc')" right-width="auto">
         <Radio v-model="settings.showVideoCardRecommendTag" />
       </SettingsItem>
 
       <SettingsItem
         :title="$t('settings.video_card_title_font_size')"
         :desc="$t('settings.video_card_title_font_size_desc')"
+        right-width="auto"
       >
-        <Select v-model="settings.videoCardTitleFontSize" :options="videoCardFontSizeOptions" w="full" />
+        <Select v-model="settings.videoCardTitleFontSize" :options="videoCardFontSizeOptions" w="160px" />
       </SettingsItem>
 
       <SettingsItem
         :title="$t('settings.video_card_author_font_size')"
         :desc="$t('settings.video_card_author_font_size_desc')"
+        right-width="auto"
       >
-        <Select v-model="settings.videoCardAuthorFontSize" :options="videoCardFontSizeOptions" w="full" />
+        <Select v-model="settings.videoCardAuthorFontSize" :options="videoCardFontSizeOptions" w="160px" />
       </SettingsItem>
 
       <SettingsItem
         :title="$t('settings.video_card_meta_font_size')"
         :desc="$t('settings.video_card_meta_font_size_desc')"
+        right-width="auto"
       >
-        <Select v-model="settings.videoCardMetaFontSize" :options="videoCardFontSizeOptions" w="full" />
+        <Select v-model="settings.videoCardMetaFontSize" :options="videoCardFontSizeOptions" w="160px" />
       </SettingsItem>
 
       <!-- Shadow settings - only for modern layout -->
       <template v-if="isModernLayout">
-        <SettingsItem :title="$t('settings.video_card_shadow_curve')" :desc="$t('settings.video_card_shadow_curve_desc')">
+        <SettingsItem :title="$t('settings.video_card_shadow_curve')" :desc="$t('settings.video_card_shadow_curve_desc')" right-width="auto">
           <ShadowCurveEditor v-model="settings.videoCardShadowCurve" />
         </SettingsItem>
 
-        <SettingsItem :title="$t('settings.video_card_shadow_height')" :desc="$t('settings.video_card_shadow_height_desc')">
-          <div flex="~ items-center gap-2" w-full>
+        <SettingsItem :title="$t('settings.video_card_shadow_height')" :desc="$t('settings.video_card_shadow_height_desc')" right-width="auto">
+          <div class="shadow-height-control" flex="~ items-center gap-2">
             <input
               v-model.number="settings.videoCardShadowHeight"
               type="range"
@@ -196,7 +200,7 @@ function resetColumns() {
           </div>
         </SettingsItem>
 
-        <SettingsItem>
+        <SettingsItem right-width="auto">
           <Button type="secondary" center @click="resetShadowSettings">
             {{ $t('settings.video_card_shadow_reset') }}
           </Button>
@@ -207,4 +211,7 @@ function resetColumns() {
 </template>
 
 <style lang="scss" scoped>
+.shadow-height-control {
+  width: 220px;
+}
 </style>

--- a/src/components/Settings/PluginComponentsAndPages/VolumeBalance/VolumeBalance.vue
+++ b/src/components/Settings/PluginComponentsAndPages/VolumeBalance/VolumeBalance.vue
@@ -29,6 +29,7 @@ function handleVolumeChange(newValue: number) {
       <SettingsItem
         :title="t('settings.volume_normalization.enable')"
         :desc="t('settings.volume_normalization.enable_desc')"
+        right-width="auto"
       >
         <Radio v-model="settings.enableVolumeNormalization" />
       </SettingsItem>
@@ -37,8 +38,9 @@ function handleVolumeChange(newValue: number) {
         v-if="settings.enableVolumeNormalization"
         :title="t('settings.volume_normalization.target_volume')"
         :desc="t('settings.volume_normalization.target_volume_desc')"
+        right-width="auto"
       >
-        <div flex="~ justify-end items-center" w-full gap-2>
+        <div flex="~ justify-end items-center" gap-2>
           <Input
             :model-value="settings.targetVolume"
             type="number"
@@ -55,8 +57,9 @@ function handleVolumeChange(newValue: number) {
         v-if="settings.enableVolumeNormalization"
         :title="t('settings.volume_normalization.strength')"
         :desc="t('settings.volume_normalization.strength_desc')"
+        right-width="auto"
       >
-        <div flex="~ justify-end items-center" w-full gap-2>
+        <div flex="~ justify-end items-center" gap-2>
           <Input
             :model-value="settings.normalizationStrength"
             type="number"
@@ -72,8 +75,9 @@ function handleVolumeChange(newValue: number) {
         v-if="settings.enableVolumeNormalization"
         :title="t('settings.volume_normalization.adaptive_speed')"
         :desc="t('settings.volume_normalization.adaptive_speed_desc')"
+        right-width="auto"
       >
-        <div flex="~ justify-end items-center" w-full gap-2>
+        <div flex="~ justify-end items-center" gap-2>
           <Input
             v-model="settings.adaptiveGainSpeed"
             type="number"
@@ -88,8 +92,9 @@ function handleVolumeChange(newValue: number) {
         v-if="settings.enableVolumeNormalization"
         :title="t('settings.volume_normalization.voice_gate')"
         :desc="t('settings.volume_normalization.voice_gate_desc')"
+        right-width="auto"
       >
-        <div flex="~ justify-end items-center" w-full gap-2>
+        <div flex="~ justify-end items-center" gap-2>
           <Input
             v-model="settings.voiceGateDb"
             type="number"
@@ -105,6 +110,7 @@ function handleVolumeChange(newValue: number) {
         v-if="settings.enableVolumeNormalization"
         :title="t('settings.volume_normalization.debug')"
         :desc="t('settings.volume_normalization.debug_desc')"
+        right-width="auto"
       >
         <Radio v-model="settings.volumeNormalizationDebug" />
       </SettingsItem>

--- a/src/components/Settings/Settings.vue
+++ b/src/components/Settings/Settings.vue
@@ -239,6 +239,7 @@ function setCurrentTitle() {
           :style="{
             maskImage: settings.enableFrostedGlass ? 'linear-gradient(to bottom, transparent 0%, black 80px 30%)' : 'none',
             WebkitMaskImage: settings.enableFrostedGlass ? 'linear-gradient(to bottom, transparent 0%, black 80px 30%)' : 'none',
+            scrollbarGutter: 'stable',
           }"
           h-inherit of-y-auto of-x-hidden
           style="padding-top: 80px;"

--- a/src/components/Settings/Shortcuts/Shortcuts.vue
+++ b/src/components/Settings/Shortcuts/Shortcuts.vue
@@ -357,7 +357,7 @@ function resetAllShortcuts() {
   <div>
     <!-- General Keyboard Toggle -->
     <SettingsItemGroup>
-      <SettingsItem :title="t('settings.shortcuts.enable_all_shortcuts_toggle')">
+      <SettingsItem :title="t('settings.shortcuts.enable_all_shortcuts_toggle')" right-width="auto">
         <template #desc>
           <div v-html="t('settings.shortcuts.enable_all_shortcuts_toggle_desc')" />
         </template>
@@ -369,14 +369,14 @@ function resetAllShortcuts() {
     <template v-for="group in configurableShortcutsGroups" :key="group.title">
       <SettingsItemGroup :title="group.title">
         <template v-for="shortcutDef in group.shortcuts" :key="shortcutDef.id">
-          <SettingsItem :title="shortcutDef.name" :desc="shortcutDef.description">
+          <SettingsItem :title="shortcutDef.name" :desc="shortcutDef.description" right-width="auto">
             <div class="shortcut-item-config">
               <!-- Key Configuration with Enabled Toggle -->
-              <div class="flex items-center gap-2 mb-2">
+              <div class="shortcut-config-row">
                 <!-- Shortcut Key Display/Edit -->
                 <div
                   v-if="editingShortcutId === shortcutDef.id"
-                  class="shortcut-edit-box border rounded px-3 py-1 min-w-[120px] text-center text-sm"
+                  class="shortcut-edit-box border rounded px-3 py-1 text-center text-sm"
                   tabindex="0"
                   @keydown="handleKeyDown($event, shortcutDef.id)"
                   @keyup="handleKeyUp($event, shortcutDef.id)"
@@ -434,7 +434,7 @@ function resetAllShortcuts() {
 
     <!-- Global Actions -->
     <SettingsItemGroup :title="t('settings.shortcuts.group.global_actions')">
-      <SettingsItem :title="t('settings.shortcuts.reset_all_ext_shortcuts')">
+      <SettingsItem :title="t('settings.shortcuts.reset_all_ext_shortcuts')" right-width="auto">
         <Button @click="resetAllShortcuts">
           {{ t('settings.shortcuts.reset_all_button') }}
         </Button>
@@ -448,6 +448,7 @@ function resetAllShortcuts() {
         :key="shortcut.key"
         :title="shortcut.key"
         :desc="shortcut.description"
+        right-width="auto"
       >
         <div class="shortcut-key-readonly border rounded px-3 py-1 text-sm">
           {{ shortcut.key }}
@@ -463,6 +464,24 @@ function resetAllShortcuts() {
   background-color: var(--bew-elevated-solid);
   min-width: 60px; /* Ensure a minimum width for better alignment */
   text-align: center;
+}
+
+.shortcut-config-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.shortcut-key,
+.shortcut-edit-box {
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.shortcut-edit-box {
+  min-width: 120px;
 }
 
 .shortcut-edit-box {
@@ -492,6 +511,11 @@ function resetAllShortcuts() {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+}
+
+.shortcut-actions,
+.shortcut-config-row :deep(label) {
+  flex-shrink: 0;
 }
 
 // Add some spacing to SettingsItem content for better readability

--- a/src/components/Settings/components/ChangeWallpaper.vue
+++ b/src/components/Settings/components/ChangeWallpaper.vue
@@ -145,7 +145,7 @@ onMounted(() => {
 
 <template>
   <SettingsItemGroup :title="$t('settings.group_wallpaper')">
-    <SettingsItem v-if="!isGlobal" :title="$t('settings.individually_set_search_page_wallpaper')">
+    <SettingsItem v-if="!isGlobal" :title="$t('settings.individually_set_search_page_wallpaper')" right-width="auto">
       <template #desc>
         <span color="$bew-warning-color">{{ $t('common.performance_impact_warn') }}</span>
       </template>
@@ -154,8 +154,8 @@ onMounted(() => {
     </SettingsItem>
 
     <template v-if="isGlobal || (settings.individuallySetSearchPageWallpaper && !isGlobal)">
-      <SettingsItem :title="$t('settings.wallpaper_mode')" :desc="$t('settings.wallpaper_mode_desc')">
-        <div w-full flex rounded="$bew-radius" bg="$bew-fill-1" p-1>
+      <SettingsItem :title="$t('settings.wallpaper_mode')" :desc="$t('settings.wallpaper_mode_desc')" right-width="auto">
+        <div w="220px" flex rounded="$bew-radius" bg="$bew-fill-1" p-1>
           <div
             flex-1 py-1 cursor-pointer text-center rounded="$bew-radius"
             :style="{
@@ -180,7 +180,7 @@ onMounted(() => {
       </SettingsItem>
 
       <!-- 缓存时间设置 - 对所有URL壁纸生效 -->
-      <SettingsItem :title="$t('settings.wallpaper_cache_time')">
+      <SettingsItem :title="$t('settings.wallpaper_cache_time')" right-width="auto">
         <template #desc>
           {{ $t('settings.wallpaper_cache_time_desc') }}
         </template>
@@ -328,7 +328,7 @@ onMounted(() => {
         </template>
       </SettingsItem>
 
-      <SettingsItem :title="$t('settings.enable_wallpaper_masking')">
+      <SettingsItem :title="$t('settings.enable_wallpaper_masking')" right-width="auto">
         <template #desc>
           <span color="$bew-warning-color">{{ $t('common.performance_impact_warn') }}</span>
         </template>
@@ -336,13 +336,17 @@ onMounted(() => {
         <Radio v-if="isGlobal" v-model="settings.enableWallpaperMasking" />
         <Radio v-else v-model="settings.searchPageEnableWallpaperMasking" />
       </SettingsItem>
-      <SettingsItem v-if="isGlobal ? settings.enableWallpaperMasking : settings.searchPageEnableWallpaperMasking" :title="$t('settings.wallpaper_mask_opacity')">
-        <Slider v-if="isGlobal" v-model="settings.wallpaperMaskOpacity" :label="`${settings.wallpaperMaskOpacity}%`" />
-        <Slider v-else v-model="settings.searchPageWallpaperMaskOpacity" :label="`${settings.searchPageWallpaperMaskOpacity}%`" />
+      <SettingsItem v-if="isGlobal ? settings.enableWallpaperMasking : settings.searchPageEnableWallpaperMasking" :title="$t('settings.wallpaper_mask_opacity')" right-width="auto">
+        <div class="slider-control">
+          <Slider v-if="isGlobal" v-model="settings.wallpaperMaskOpacity" :label="`${settings.wallpaperMaskOpacity}%`" />
+          <Slider v-else v-model="settings.searchPageWallpaperMaskOpacity" :label="`${settings.searchPageWallpaperMaskOpacity}%`" />
+        </div>
       </SettingsItem>
-      <SettingsItem v-if="isGlobal ? settings.enableWallpaperMasking : settings.searchPageEnableWallpaperMasking" :title="$t('settings.wallpaper_blur_intensity')">
-        <Slider v-if="isGlobal" v-model="settings.wallpaperBlurIntensity" :min="0" :max="60" :label="`${settings.wallpaperBlurIntensity}px`" />
-        <Slider v-else v-model="settings.searchPageWallpaperBlurIntensity" :min="0" :max="60" :label="`${settings.searchPageWallpaperBlurIntensity}px`" />
+      <SettingsItem v-if="isGlobal ? settings.enableWallpaperMasking : settings.searchPageEnableWallpaperMasking" :title="$t('settings.wallpaper_blur_intensity')" right-width="auto">
+        <div class="slider-control">
+          <Slider v-if="isGlobal" v-model="settings.wallpaperBlurIntensity" :min="0" :max="60" :label="`${settings.wallpaperBlurIntensity}px`" />
+          <Slider v-else v-model="settings.searchPageWallpaperBlurIntensity" :min="0" :max="60" :label="`${settings.searchPageWallpaperBlurIntensity}px`" />
+        </div>
       </SettingsItem>
     </template>
   </SettingsItemGroup>
@@ -351,5 +355,9 @@ onMounted(() => {
 <style lang="scss" scoped>
 .selected-wallpaper {
   --uno: "border-$bew-theme-color-60";
+}
+
+.slider-control {
+  width: 220px;
 }
 </style>

--- a/src/components/Settings/components/SettingsItem.vue
+++ b/src/components/Settings/components/SettingsItem.vue
@@ -1,14 +1,22 @@
 <script setup lang="ts">
-defineProps<{
+type RightWidth = 'default' | 'auto'
+
+withDefaults(defineProps<{
   title?: string
   desc?: string
-}>()
+  rightWidth?: RightWidth
+}>(), {
+  rightWidth: 'default',
+})
 </script>
 
 <template>
   <div class="b-settings-item" py-4>
-    <div flex="~ gap-4" justify-between items-center text-base>
-      <div class="left-content" w="5/7">
+    <div
+      class="b-settings-item-row" :class="`right-width-${rightWidth}`" flex="~ gap-4" justify-between items-center
+      text-base
+    >
+      <div class="left-content" flex-1 min-w-0>
         <div>
           <slot name="title">
             {{ title }}
@@ -26,7 +34,7 @@ defineProps<{
         </div>
       </div>
 
-      <div class="right-content" w="2/7">
+      <div class="right-content" w-auto shrink-0>
         <slot />
       </div>
     </div>
@@ -38,6 +46,16 @@ defineProps<{
 </template>
 
 <style lang="scss" scoped>
+.right-width-auto {
+  .left-content {
+    --uno: "w-auto flex-1 min-w-0";
+  }
+
+  .right-content {
+    --uno: "w-auto shrink-0";
+  }
+}
+
 :deep(.right-content > *) {
   --uno: "float-right clear-both";
 }


### PR DESCRIPTION
这个 PR 主要优化了设置项的左右布局，避免右侧固定宽度过早挤压左侧标题和说明文案。

主要调整：

- 设置项右侧不再默认固定占用 $\frac{2}{7}$ 宽度，右侧控件按内容宽度靠右显示
- 统一设置页普通下拉框宽度，避免同类控件宽度不一致
- 将较长的下拉选项说明移到左侧描述中，保留下拉框内的短选项文本
- 调整顶栏设置页部分列表间距，避免分隔线上下间距不一致
- 为设置页滚动区域预留滚动条空间，避免展开配置项时内容宽度跳动

| 调整前 | 调整后 |
| --- | --- |
| <img width="1153" height="395" alt="屏幕截图 2026-05-25 051254" src="https://github.com/user-attachments/assets/29a50b0f-54e8-4dcc-b040-2e97b0d34f9a" /> | <img width="1154" height="365" alt="屏幕截图 2026-05-25 051307" src="https://github.com/user-attachments/assets/d1871cae-7962-4523-982a-331501bcd058" /> |
| <img width="1148" height="948" alt="屏幕截图 2026-05-25 051337" src="https://github.com/user-attachments/assets/5011788d-b2f3-4dd4-885a-b6a576caaa49" /> | <img width="1157" height="820" alt="屏幕截图 2026-05-25 051348" src="https://github.com/user-attachments/assets/d26e58b4-eb9a-4ea3-9733-98587724a766" /> |

已通过 `pnpm lint`、`pnpm typecheck`、`pnpm build`、`pnpm build-firefox` 和 `pnpm build-safari`。
