### PR TITLE
feat: add video page only dark mode

### DIFF
--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -336,6 +336,8 @@ settings:
     light: 亮色
     dark: 暗色
     auto: 自动
+  video_page_dark_mode: 仅视频播放页深色模式
+  video_page_dark_mode_desc: 保持全站主题设置不变，仅在视频播放页启用 BewlyCat 深色样式。
   theme_color: 主题色
   dark_mode_base_color: 深色模式基准颜色
   gradient_theme_color_background: 在暗色模式下使用渐变主题颜色作为背景

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -279,6 +279,8 @@ settings:
     light: 淺色
     dark: 深色
     auto: 自動
+  video_page_dark_mode: 僅影片播放頁深色模式
+  video_page_dark_mode_desc: 保持全站主題設定不變，僅在影片播放頁啟用 BewlyCat 深色樣式。
   theme_color: 主題色
   dark_mode_base_color: 深色模式基準顏色
   gradient_theme_color_background: 在深色模式下使用漸層主題色作為背景

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -307,6 +307,8 @@ settings:
     light: Light
     dark: Dark
     auto: Auto
+  video_page_dark_mode: Video page dark mode only
+  video_page_dark_mode_desc: Keep the global theme unchanged and enable BewlyCat dark styles only on video playback pages.
   theme_color: Theme color
   dark_mode_base_color: Dark mode base color
   gradient_theme_color_background: Use a gradient theme color as the background in dark mode

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -261,6 +261,8 @@ settings:
     light: 淺色
     dark: 深色
     auto: 自動
+  video_page_dark_mode: 淨係影片播放頁用深色模式
+  video_page_dark_mode_desc: 保持全站色系設定唔變，淨係喺影片播放頁啟用 BewlyCat 深色樣式。
   theme_color: 主題色
   gradient_theme_color_background: 使用漸層主題色作爲深色模式嘅背景
   wallpaper_mode: 背景圖片模式

--- a/src/components/Settings/Appearance/Appearance.vue
+++ b/src/components/Settings/Appearance/Appearance.vue
@@ -120,6 +120,13 @@ function changeWallpaper(url: string) {
       <SettingsItem :title="$t('settings.theme')" right-width="auto">
         <Select v-model="settings.theme" w="160px" :options="themeOptions" />
       </SettingsItem>
+      <SettingsItem :title="$t('settings.video_page_dark_mode')" right-width="auto">
+        <template #desc>
+          {{ $t('settings.video_page_dark_mode_desc') }}
+        </template>
+
+        <Radio v-model="settings.videoPageDarkMode" />
+      </SettingsItem>
       <SettingsItem :title="$t('settings.theme_color')" right-width="auto">
         <div class="theme-color-options" flex="~ gap-2 wrap" justify-end>
           <div

--- a/src/composables/useDark.ts
+++ b/src/composables/useDark.ts
@@ -3,14 +3,33 @@ import { usePreferredDark } from '@vueuse/core'
 import { DARK_MODE_BASE_COLOR_CHANGE } from '~/constants/globalEvents'
 import { settings } from '~/logic'
 import { runWhenIdle } from '~/utils/lazyLoad'
-import { setCookie } from '~/utils/main'
+import { isVideoPlaybackPage, setCookie } from '~/utils/main'
 import { executeTimes } from '~/utils/timer'
+
+const currentUrl = ref(typeof location === 'undefined' ? '' : location.href)
+let isRouteWatcherStarted = false
 
 /**
  * Check if current page is festival page
  */
 function isFestivalPage(): boolean {
   return /https?:\/\/(?:www\.)?bilibili\.com\/festival\/.*/.test(document.URL)
+}
+
+function startRouteWatcher() {
+  if (isRouteWatcherStarted || typeof window === 'undefined')
+    return
+
+  isRouteWatcherStarted = true
+
+  const updateCurrentUrl = () => {
+    if (currentUrl.value !== location.href)
+      currentUrl.value = location.href
+  }
+
+  window.addEventListener('popstate', updateCurrentUrl)
+  window.addEventListener('hashchange', updateCurrentUrl)
+  window.setInterval(updateCurrentUrl, 800)
 }
 
 /**
@@ -29,6 +48,8 @@ function setDarkModeBaseColor(color: string) {
 }
 
 export function useDark() {
+  startRouteWatcher()
+
   const isPreferredDark = usePreferredDark()
   const currentSystemColorScheme = computed(() => isPreferredDark.value ? 'dark' : 'light')
   const currentAppColorScheme = computed((): 'dark' | 'light' => {
@@ -37,13 +58,16 @@ export function useDark() {
     else
       return currentSystemColorScheme.value
   })
-  const isDark = computed(() => currentAppColorScheme.value === 'dark')
+  const isVideoPageDark = computed(() => {
+    return settings.value.videoPageDarkMode && isVideoPlaybackPage(currentUrl.value)
+  })
+  const isDark = computed(() => currentAppColorScheme.value === 'dark' || isVideoPageDark.value)
   let themeChangeTimer: NodeJS.Timeout | null = null
 
   // Watch for changes in the 'settings.value.theme' variable and add the 'dark' class to the 'mainApp' element
   // to prevent some Unocss dark-specific styles from failing to take effect
   watch(
-    () => [settings.value.theme, isPreferredDark.value],
+    () => [settings.value.theme, settings.value.videoPageDarkMode, isPreferredDark.value, currentUrl.value],
     () => {
       setAppAppearance()
     },

--- a/src/contentScripts/index.ts
+++ b/src/contentScripts/index.ts
@@ -15,7 +15,7 @@ import { captureOriginalBilibiliTopBar, ensureOriginalBilibiliTopBarAppended, re
 import { initFavoriteDialogEnhancement } from '~/utils/favoriteDialog'
 import { runWhenIdle } from '~/utils/lazyLoad'
 import { getLocalWallpaper, hasLocalWallpaper, isLocalWallpaperUrl } from '~/utils/localWallpaper'
-import { compareVersions, injectCSS, isElectron, isHomePage, isInIframe, isNotificationPage, isVideoOrBangumiPage } from '~/utils/main'
+import { compareVersions, injectCSS, isElectron, isHomePage, isInIframe, isNotificationPage, isVideoOrBangumiPage, isVideoPlaybackPage } from '~/utils/main'
 import { applyAutoPlayByVideoType, applyDefaultDanmakuState, defaultMode, handleVideoPageNavigation, isCollectionVideo, isPlayerDisplayModeReady, isVideoPage, startAutoExitFullscreenMonitoring, startAutoPlayUserChangeMonitoring, webFullscreen, widescreen } from '~/utils/player'
 import { initRandomPlay, resetRandomPlayInitialization } from '~/utils/randomPlay'
 import { setupShortcutHandlers } from '~/utils/shortcuts'
@@ -155,15 +155,32 @@ else {
   let playerModeRetryTimer: ReturnType<typeof setTimeout> | undefined
   let watchLaterButtonAdded = false // 标记稍后再看按钮是否已添加
 
-  if (isSupportedPages() || isSupportedIframePages()) {
-  // Always use dark mode if enabled, but let useDark() handle selective application
+  function shouldApplyBewlyDesign() {
     if (settings.value.adaptToOtherPageStyles)
+      return !isFestivalPage()
+
+    return settings.value.videoPageDarkMode && isVideoPlaybackPage()
+  }
+
+  function shouldApplyVideoPageDarkOnly() {
+    return !settings.value.adaptToOtherPageStyles
+      && settings.value.videoPageDarkMode
+      && isVideoPlaybackPage()
+  }
+
+  function applyBewlyDesignClasses() {
+    const shouldApply = shouldApplyBewlyDesign()
+    document.documentElement.classList.toggle('bewly-design', shouldApply)
+    document.documentElement.classList.toggle('bewly-video-dark-only', shouldApplyVideoPageDarkOnly())
+    return shouldApply
+  }
+
+  if (isSupportedPages() || isSupportedIframePages()) {
+    if (settings.value.adaptToOtherPageStyles || settings.value.videoPageDarkMode)
       useDark()
 
-    const shouldApplyFullStyles = settings.value.adaptToOtherPageStyles && !isFestivalPage()
+    const shouldApplyFullStyles = applyBewlyDesignClasses()
     if (shouldApplyFullStyles) {
-      document.documentElement.classList.add('bewly-design')
-
       // Setup iframe photo viewer detector (only in iframe)
       if (isInIframe())
         setupIframePhotoViewerDetector()
@@ -174,10 +191,6 @@ else {
         if (darkModeStyle)
           document.head.removeChild(darkModeStyle)
       })
-    }
-
-    else {
-      document.documentElement.classList.remove('bewly-design')
     }
   }
 
@@ -373,6 +386,7 @@ else {
 
       lastUrl = location.href
       lastVideoNavigationKey = currentVideoNavigationKey
+      applyBewlyDesignClasses()
 
       if (isVideoOrBangumiPage()) {
         if (!isMeaningfulVideoNavigation) {

--- a/src/contentScripts/views/App.vue
+++ b/src/contentScripts/views/App.vue
@@ -28,10 +28,9 @@ const mainStore = useMainStore()
 const settingsStore = useSettingsStore()
 const topBarStore = useTopBarStore()
 
-// Conditionally use dark mode (skip on festival pages)
+// Conditionally use dark mode. `useDark()` handles the video-page-only route gate.
 let isDark: Ref<boolean>
-// Always use dark mode if enabled, but let useDark() handle selective application
-const shouldUseDark = settings.value.adaptToOtherPageStyles
+const shouldUseDark = settings.value.adaptToOtherPageStyles || settings.value.videoPageDarkMode
 
 if (shouldUseDark) {
   const darkResult = useDark()

--- a/src/contentScripts/views/necessarySettingsWatchers.ts
+++ b/src/contentScripts/views/necessarySettingsWatchers.ts
@@ -5,11 +5,16 @@ import { setUselessFeedCardBlockerEnabled } from '~/contentScripts/features/bloc
 import { LanguageType } from '~/enums/appEnums'
 import { appAuthTokens, FROSTED_GLASS_BLUR_MAX_PX, FROSTED_GLASS_BLUR_MIN_PX, localSettings, originalSettings, settings } from '~/logic'
 import { resetBilibiliTopBarInlineStyles } from '~/utils/bilibiliTopBar'
-import { cleanBilibiliShareText, getUserID, injectCSS, isHomePage, isInIframe } from '~/utils/main'
+import { cleanBilibiliShareText, getUserID, injectCSS, isHomePage, isInIframe, isVideoPlaybackPage } from '~/utils/main'
+
+function isFestivalPage(): boolean {
+  return /https?:\/\/(?:www\.)?bilibili\.com\/festival\/.*/.test(location.href)
+}
 
 export function setupNecessarySettingsWatchers() {
   const { locale } = useI18n()
   let syncingTopBarSettings = false
+  let lastBewlyDesignHref = location.href
 
   const DEFAULT_FROSTED_GLASS_BLUR_PX = originalSettings.frostedGlassBlurIntensity
   const FROSTED_GLASS_DIALOG_OFFSET_PX = 10
@@ -392,16 +397,38 @@ export function setupNecessarySettingsWatchers() {
     }
   }
 
+  const applyBewlyDesignClasses = () => {
+    const shouldApply = settings.value.adaptToOtherPageStyles
+      ? !isFestivalPage()
+      : settings.value.videoPageDarkMode && isVideoPlaybackPage()
+    const shouldApplyVideoDarkOnly = !settings.value.adaptToOtherPageStyles
+      && settings.value.videoPageDarkMode
+      && isVideoPlaybackPage()
+
+    document.documentElement.classList.toggle('bewly-design', shouldApply)
+    document.documentElement.classList.toggle('bewly-video-dark-only', shouldApplyVideoDarkOnly)
+  }
+
   watch(
-    () => settings.value.adaptToOtherPageStyles,
-    () => {
-      if (settings.value.adaptToOtherPageStyles)
-        document.documentElement.classList.add('bewly-design')
-      else
-        document.documentElement.classList.remove('bewly-design')
-    },
+    [
+      () => settings.value.adaptToOtherPageStyles,
+      () => settings.value.videoPageDarkMode,
+    ],
+    applyBewlyDesignClasses,
     { immediate: true },
   )
+
+  const refreshBewlyDesignOnRouteChange = () => {
+    if (lastBewlyDesignHref === location.href)
+      return
+
+    lastBewlyDesignHref = location.href
+    applyBewlyDesignClasses()
+  }
+
+  window.addEventListener('popstate', refreshBewlyDesignOnRouteChange)
+  window.addEventListener('hashchange', refreshBewlyDesignOnRouteChange)
+  window.setInterval(refreshBewlyDesignOnRouteChange, 800)
 
   // Clean Share Link - intercept clipboard copy events
   let cleanShareLinkCopyHandler: ((e: ClipboardEvent) => void) | null = null

--- a/src/logic/storage.ts
+++ b/src/logic/storage.ts
@@ -236,6 +236,7 @@ export interface Settings {
   autoHideSidebar: boolean
 
   theme: 'light' | 'dark' | 'auto'
+  videoPageDarkMode: boolean
   themeColor: string
   darkModeBaseColor: string // 深色模式基准颜色
   useLinearGradientThemeColorBackground: boolean
@@ -454,6 +455,7 @@ export const originalSettings: Settings = {
   autoHideSidebar: false,
 
   theme: 'auto',
+  videoPageDarkMode: false,
   themeColor: '#00a1d6',
   darkModeBaseColor: '#2a2d32', // 默认深色模式基准颜色
   useLinearGradientThemeColorBackground: false,

--- a/src/styles/adaptedStyles/pages/videoPage.scss
+++ b/src/styles/adaptedStyles/pages/videoPage.scss
@@ -693,3 +693,52 @@
   }
   //  #endregion
 }
+
+.bewly-design.videoPage.bewly-video-dark-only {
+  .up-detail .up-detail-top .up-name.is_vip,
+  .up-detail .up-detail-top .up-name.small-vip,
+  .up-detail .up-detail-top .up-name.vip,
+  .up-detail .up-detail-top .up-name[style*="color: rgb(251, 114, 153)"],
+  .up-detail .up-detail-top .up-name[style*="color:#FB7299;"] {
+    color: var(--brand_pink) !important;
+  }
+
+  .up-detail .up-detail-top .up-name.is_vip:hover,
+  .up-detail .up-detail-top .up-name.small-vip:hover,
+  .up-detail .up-detail-top .up-name.vip:hover,
+  .up-detail .up-detail-top .up-name[style*="color: rgb(251, 114, 153)"]:hover,
+  .up-detail .up-detail-top .up-name[style*="color:#FB7299;"]:hover {
+    color: var(--brand_pink_hover) !important;
+  }
+
+  .upinfo-btn-panel .not-follow-charge-btn,
+  .upinfo-btn-panel .new-charge-btn {
+    color: var(--brand_pink) !important;
+    border-color: var(--brand_pink) !important;
+  }
+
+  .upinfo-btn-panel .not-follow-charge-btn:hover,
+  .upinfo-btn-panel .new-charge-btn:hover {
+    color: var(--brand_pink_hover) !important;
+    border-color: var(--brand_pink_hover) !important;
+  }
+
+  .upinfo-btn-panel .new-charge-btn .charge-btn-icon img {
+    filter: none !important;
+  }
+
+  &.dark {
+    .bpx-player-container[data-revision="1"]
+      .bpx-player-sending-bar
+      .bpx-player-video-inputbar
+      .bpx-player-dm-btn-send.bui-disabled
+      .bui-button-blue,
+    .bpx-player-container[data-revision="2"]
+      .bpx-player-sending-bar
+      .bpx-player-video-inputbar
+      .bpx-player-dm-btn-send.bui-disabled
+      .bui-button-blue {
+      background-color: var(--Ga3);
+    }
+  }
+}

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -418,6 +418,59 @@
   --Lb10: color-mix(in oklab, var(--bew-theme-color), white 75%);
 }
 
+:root.bewly-video-dark-only,
+:root.bewly-video-dark-only * {
+  --brand_pink: #ff6699;
+  --brand_pink_thin: #ffecf1;
+  --brand_blue: #00aeec;
+  --brand_blue_thin: #dff6fd;
+
+  --brand_pink_hover: #e84b85;
+  --brand_pink_active: #e84b85;
+  --brand_pink_disabled: #ffb3ca;
+  --brand_blue_hover: #008ac5;
+  --brand_blue_active: #008ac5;
+  --brand_blue_disabled: #80daf6;
+
+  --text_link: #00699d;
+
+  --bpx-fn-color: #00aeec;
+  --bpx-primary-color: #00aeec;
+  --bpx-fn-hover-color: #008ac5;
+  --bpx-toast-fn-color: #00aeec;
+  --bpx-toast-fn-hover-color: #008ac5;
+}
+
+:root.dark.bewly-video-dark-only,
+:root.dark.bewly-video-dark-only * {
+  --brand_pink: #d44e7d;
+  --brand_pink_thin: #2f1a22;
+  --brand_blue: #0087bd;
+  --brand_blue_thin: #0b202a;
+
+  --brand_pink_hover: #dc6d94;
+  --brand_pink_active: #dc6d94;
+  --brand_pink_disabled: #76304b;
+  --brand_blue_hover: #2c9cc8;
+  --brand_blue_active: #2c9cc8;
+  --brand_blue_disabled: #064a69;
+
+  --text_link: #58b1d4;
+
+  --bpx-fn-color: #0087bd;
+  --bpx-primary-color: #0087bd;
+  --bpx-fn-hover-color: #2c9cc8;
+  --bpx-toast-fn-color: #0087bd;
+  --bpx-toast-fn-hover-color: #2c9cc8;
+
+  --bpx-dmsend-main-bg: var(--Ga0);
+  --bpx-dmsend-input-bg: var(--Ga1_s);
+  --bpx-dmsend-info-font: var(--Ga7);
+  --bpx-dmsend-switch-icon: var(--Ga7);
+  --bpx-dmsend-border: var(--Ga2);
+  --bpx-dmsend-input-font: var(--Ga10);
+}
+
 // #region Bilibili original css variables
 :root.bewly-design {
   --Ga0: #f6f7f8;

--- a/src/utils/main.ts
+++ b/src/utils/main.ts
@@ -197,6 +197,24 @@ export function isVideoOrBangumiPage(url: string = location.href): boolean {
 }
 
 /**
+ * Check if the current page is a playback page that should use video-page-only dark mode.
+ * This intentionally excludes festival pages because they already use selective dark handling.
+ *
+ * @param url the url to check
+ * @returns true if the current page is a video playback page
+ */
+export function isVideoPlaybackPage(url: string = location.href): boolean {
+  return (
+    // normal video page and playlist video page
+    /https?:\/\/(?:www\.)?bilibili\.com\/(?:video|list)\/.*/.test(url)
+    // anime, movie, and course playback pages
+    || /https?:\/\/(?:www\.)?bilibili\.com\/(?:bangumi|cheese)\/play\/.*/.test(url)
+    // media playlist playback pages
+    || /https?:\/\/(?:www\.)?bilibili\.com\/medialist\/play\/.*/.test(url)
+  )
+}
+
+/**
  * Check if the current page is the notifications page
  * @param url the url to check
  * @returns true if the current page is the notifications page


### PR DESCRIPTION
## Summary

Adds an optional `videoPageDarkMode` setting that enables BewlyCat dark styling only on Bilibili video playback pages.

This keeps the existing `adaptToOtherPageStyles` behavior unchanged while allowing users to darken video pages without applying BewlyCat page adaptation globally.

## Details

- Adds a `videoPageDarkMode` setting, defaulting to `false`.
- Reuses existing video page dark styling through `bewly-design`.
- Adds a narrower `bewly-video-dark-only` class for the video-only mode.
- Detects video playback routes including `/video/`, `/list/`, `/bangumi/play/`, `/cheese/play/`, and `/medialist/play/`.
- Handles Bilibili SPA route changes so the mode is applied or removed when entering or leaving playback pages.
- Restores Bilibili semantic brand colors for video-only dark mode, including current UP name, charge button, and player danmaku send bar variables.

## Validation

- `git diff --check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knip`
- `pnpm build`
- `pnpm build-firefox`

## Screenshots

Video page only dark mode disabled:

<img width="1512" height="893" alt="light" src="https://github.com/user-attachments/assets/ec791faa-e946-4d5a-a902-e4d34139ce7b" />

Video page only dark mode enabled in settings:

<img width="1512" height="896" alt="dark-on" src="https://github.com/user-attachments/assets/c8122458-dcf4-49ee-b3c3-124873a0df13" />

Video page result:

<img width="1512" height="893" alt="dark-on-video" src="https://github.com/user-attachments/assets/d8870379-e2aa-4916-bef0-15c51f3ef024" />
