### PR TITLE
fix: 修复搜索页模式首页顶栏点击失效

### DIFF
--- a/src/contentScripts/views/Home/Home.vue
+++ b/src/contentScripts/views/Home/Home.vue
@@ -192,6 +192,7 @@ function toggleTabContentLoading(loading: boolean) {
           items-center relative
           w-full z-10 mb-4
           h-500px
+          pointer-events-none
         >
           <Logo
             v-if="settings.searchPageShowLogo" :size="180" :color="settings.searchPageLogoColor === 'white' ? 'white' : 'var(--bew-theme-color)'"
@@ -199,6 +200,7 @@ function toggleTabContentLoading(loading: boolean) {
             m="t--70px b-12" z-1
           />
           <SearchBar
+            pointer-events-auto
             :darken-on-focus="settings.searchPageDarkenOnSearchFocus"
             :blurred-on-focus="settings.searchPageBlurredOnSearchFocus"
             :focused-character="settings.searchPageSearchBarFocusCharacter"


### PR DESCRIPTION
# fix: 修复 Search Page Mode 下首页顶栏点击失效

## 关联 Issue

Fixes #725

## 变更说明

修复开启 `Search Page Mode` 后，首页滚动经过 hero 搜索区时顶部导航栏不可点击的问题。

在 Search Page Mode 下，首页 hero 搜索区外层容器具有较高层级，并且默认会参与 pointer hit-testing。该容器高度较大，在页面滚动时会经过 fixed 顶栏区域，导致透明区域覆盖并拦截顶栏点击事件。

本 PR 将 hero 外层容器设置为 `pointer-events-none`，同时给内部实际需要交互的 `SearchBar` 设置 `pointer-events-auto`，让透明区域不再阻挡顶栏点击，并保留搜索框自身交互能力。

## 修改内容

- 为首页 `Search Page Mode` hero 外层容器添加 `pointer-events-none`
- 为 hero 内部 `SearchBar` 添加 `pointer-events-auto`