### PR TITLE
feat: 减少无 Cookie 推荐重复

### DIFF
--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -390,6 +390,8 @@ settings:
   recommendation_mode_desc: |
     Web：普通网页端推荐模式。无 Cookie：请求首页推荐时不携带 Cookie。App：移动端推荐模式，需先授权 access key。
   recommendation_mode_web_no_cookie: 无 Cookie
+  remember_no_cookie_recommendation_state: 减少无 Cookie 推荐重复
+  remember_no_cookie_recommendation_state_desc: 刷新页面后延续推荐刷新进度，并向推荐接口带上最近曝光记录，以减少重复推荐。仅无 Cookie 模式生效。
   auto_switch_recommendation_mode: 自动切换推荐模式
   auto_switch_recommendation_mode_desc: |
     当 App 推荐失败时自动切换至 Web 模式。

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -329,6 +329,8 @@ settings:
   recommendation_mode_desc: |
     Web：普通網頁端推薦模式。無 Cookie：請求首頁推薦時不攜帶 Cookie。App：手機端推薦模式，需先授權 access key。
   recommendation_mode_web_no_cookie: 無 Cookie
+  remember_no_cookie_recommendation_state: 減少無 Cookie 推薦重複
+  remember_no_cookie_recommendation_state_desc: 重新整理頁面後延續推薦刷新進度，並向推薦接口帶上最近曝光記錄，以減少重複推薦。僅無 Cookie 模式生效。
   auto_switch_recommendation_mode: 自動切換推薦模式
   auto_switch_recommendation_mode_desc: |
     當手機端推薦失敗時自動切換至網頁模式。

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -368,6 +368,8 @@ settings:
     recommendations without cookies. App: mobile recommendation mode, requires
     an access key first.
   recommendation_mode_web_no_cookie: No Cookie
+  remember_no_cookie_recommendation_state: Reduce No Cookie recommendation repeats
+  remember_no_cookie_recommendation_state_desc: After reloading the page, continue the recommendation refresh progress and send recent exposure records with recommendation requests to reduce repeats. Only applies in No Cookie mode.
   auto_switch_recommendation_mode: Auto switch recommendation mode
   auto_switch_recommendation_mode_desc: >
     Automatically switch from App mode to Web mode when App recommendation fails.

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -310,6 +310,8 @@ settings:
   recommendation_mode_desc: |
     Web：普通網頁版推介模式。無 Cookie：請求首頁推介時唔帶 Cookie。App：手機版推介模式，要先授權 access key。
   recommendation_mode_web_no_cookie: 無 Cookie
+  remember_no_cookie_recommendation_state: 減少無 Cookie 推介重複
+  remember_no_cookie_recommendation_state_desc: 重新整理頁面後，會延續推介刷新進度，並向推介接口帶上最近曝光記錄，以減少重複推介。淨係無 Cookie 模式生效。
   auto_switch_recommendation_mode: 自動切換推介模式
   auto_switch_recommendation_mode_desc: |
     當手機版推介壞咗嗰陣自動切換到網頁模式。

--- a/src/components/Settings/PluginComponentsAndPages/Home/Home.vue
+++ b/src/components/Settings/PluginComponentsAndPages/Home/Home.vue
@@ -227,6 +227,15 @@ function handleToggleHomeTab(tab: any) {
         </div>
       </SettingsItem>
 
+      <SettingsItem
+        v-if="settings.recommendationMode === 'webNoCookie'"
+        :title="$t('settings.remember_no_cookie_recommendation_state')"
+        :desc="$t('settings.remember_no_cookie_recommendation_state_desc')"
+        right-width="auto"
+      >
+        <Radio v-model="settings.rememberNoCookieRecommendationState" />
+      </SettingsItem>
+
       <SettingsItem v-if="settings.recommendationMode === 'app'" :title="$t('settings.authorize_app')" right-width="auto">
         <template #desc>
           {{ $t('settings.authorize_app_desc') }}

--- a/src/contentScripts/views/Home/components/ForYou.vue
+++ b/src/contentScripts/views/Home/components/ForYou.vue
@@ -7,7 +7,7 @@ import { UndoForwardState, useBewlyApp } from '~/composables/useAppProvider'
 import { FilterType, useFilter } from '~/composables/useFilter'
 import { LanguageType } from '~/enums/appEnums'
 import type { GridLayoutType } from '~/logic'
-import { appAuthTokens, settings } from '~/logic'
+import { appAuthTokens, noCookieForYouRecommendationState, settings } from '~/logic'
 import type { AppForYouResult, Item as AppVideoItem } from '~/models/video/appForYou'
 import { Type as ThreePointV2Type } from '~/models/video/appForYou'
 import type { forYouResult, Item as VideoItem } from '~/models/video/forYou'
@@ -80,19 +80,21 @@ const appVideoList = ref<AppVideoElement[]>([])
 
 const isWebRecommendationMode = computed(() => settings.value.recommendationMode !== 'app')
 let requestVersion = 0
+type WebRecommendRequestType = 'refresh' | 'loadMore'
 
 // 当前使用的视频列表（根据推荐模式）
 const currentVideoList = computed(() =>
   isWebRecommendationMode.value ? videoList.value : appVideoList.value,
 )
 
-const isLoading = ref<boolean>(false)
+const isLoading = ref<boolean>(true)
 const requestFailed = ref<boolean>(false)
 const needToLoginFirst = ref<boolean>(false)
 const refreshIdx = ref<number>(1)
 const noMoreContent = ref<boolean>(false)
 const activatedAppVideo = ref<AppVideoItem | null>()
 const showDislikeDialog = ref<boolean>(false)
+const hasInitializedData = ref<boolean>(false)
 
 // 页面可见性状态
 const isPageVisible = ref<boolean>(!document.hidden)
@@ -115,13 +117,24 @@ const hasBackState = ref<boolean>(false)
 const hasForwardState = ref<boolean>(false)
 
 const PAGE_SIZE = 30
+const WEB_REFRESH_PAGE_SIZE = 10
+const WEB_LOAD_MORE_PAGE_SIZE = 12
+const NO_COOKIE_RECOMMEND_STATE_MAX_SHOWLIST_GROUPS = 3
+const MAX_EMPTY_LOADS = 5 // 最大连续空加载次数
 const APP_LOAD_BATCHES = ref<number>(1) // APP模式每次加载的批次数，初始化时为1
 const scrollLoadStartLength = ref<number>(0) // 滚动加载开始时的列表长度
 const consecutiveEmptyLoads = ref<number>(0) // 连续空加载次数，用于防止无限递归（Web模式）
 const appConsecutiveEmptyLoads = ref<number>(0) // APP模式连续空加载次数
-const MAX_EMPTY_LOADS = 5 // 最大连续空加载次数
 // 递归加载锁，防止双重触发
 const isRecursiveLoading = ref<boolean>(false)
+const webFetchRow = ref<number>(1)
+const webShowlistGroups = ref<string[]>([])
+
+const cachedWebFetchRow = ref<number>(1)
+const cachedWebShowlistGroups = ref<string[]>([])
+
+const forwardWebFetchRow = ref<number>(1)
+const forwardWebShowlistGroups = ref<string[]>([])
 
 // 监听页面可见性变化
 function handleVisibilityChange() {
@@ -144,6 +157,9 @@ onMounted(() => {
     appVideoList.value = [...savedState.appVideoList]
     refreshIdx.value = savedState.refreshIdx
     noMoreContent.value = savedState.noMoreContent
+    rebuildShowlistGroupsFromList(videoList.value)
+    hasInitializedData.value = true
+    isLoading.value = false
 
     // 确保撤销按钮不显示（因为这是状态恢复，不是刷新操作）
     hasBackState.value = false
@@ -317,38 +333,96 @@ function getWebVideoKey(item: VideoItem): string {
   return `${item.id}`
 }
 
-function buildLastShowlist(items: VideoItem[]): string {
+function getWebShowlistEntry(item: VideoItem): string | undefined {
+  const goto = `${item.goto || ''}`.trim()
+  if (!goto)
+    return undefined
+
+  const id = item.id || 'undefined'
+  if (goto === 'av')
+    return `av_n_${id}`
+  if (goto === 'live')
+    return `live_n_${id}`
+  if (goto === 'ad')
+    return `ad_${id}`
+
+  return `${goto}_${id}`
+}
+
+function buildLastShowlistGroup(items: VideoItem[]): string {
   const parts: string[] = []
-  const seen = new Set<number>()
+  const seen = new Set<string>()
 
   items.forEach((item) => {
-    if (!item?.id || item.goto !== 'av' || seen.has(item.id))
+    const entry = getWebShowlistEntry(item)
+    if (!entry || seen.has(entry))
       return
 
-    seen.add(item.id)
-    const followedFlag = item.is_followed ? 'n_' : ''
-    parts.push(`av_${followedFlag}${item.id}`)
+    seen.add(entry)
+    parts.push(entry)
   })
 
-  return parts.join('_')
+  return parts.join(',')
 }
 
-function getLastShowlistFromList(list: VideoElement[], limit: number): string {
+function getLastShowlistFromGroups(): string {
+  return webShowlistGroups.value.filter(Boolean).join(';')
+}
+
+function getNoCookieStoredLastShowlist(): string {
+  if (!settings.value.rememberNoCookieRecommendationState)
+    return ''
+
+  return noCookieForYouRecommendationState.value.showlistGroups
+    .filter(Boolean)
+    .slice(-NO_COOKIE_RECOMMEND_STATE_MAX_SHOWLIST_GROUPS)
+    .join(';')
+}
+
+function getNoCookieNextFreshIdx(): number {
+  if (!settings.value.rememberNoCookieRecommendationState)
+    return refreshIdx.value
+
+  const nextFreshIdx = noCookieForYouRecommendationState.value.nextFreshIdx
+  return Number.isFinite(nextFreshIdx) && nextFreshIdx > 0 ? Math.floor(nextFreshIdx) : 1
+}
+
+function saveNoCookieRecommendationState(group: string, recommendationMode: string, nextFreshIdx?: number) {
+  if (recommendationMode !== 'webNoCookie' || !settings.value.rememberNoCookieRecommendationState)
+    return
+  if (!group && nextFreshIdx === undefined)
+    return
+
+  const groups = noCookieForYouRecommendationState.value.showlistGroups
+    .filter(storedGroup => storedGroup && storedGroup !== group)
+
+  if (group)
+    groups.push(group)
+
+  noCookieForYouRecommendationState.value = {
+    showlistGroups: groups.slice(-NO_COOKIE_RECOMMEND_STATE_MAX_SHOWLIST_GROUPS),
+    nextFreshIdx: nextFreshIdx ?? noCookieForYouRecommendationState.value.nextFreshIdx,
+  }
+}
+
+function rebuildShowlistGroupsFromList(list: VideoElement[]) {
   const items = list
     .map(video => video.item)
-    .filter((item): item is VideoItem => !!item && !!item.id)
-
-  return buildLastShowlist(items.slice(-limit))
+    .filter((item): item is VideoItem => !!item)
+  const group = buildLastShowlistGroup(items)
+  webShowlistGroups.value = group ? [group] : []
 }
 
-function getWebFetchRow(list: VideoElement[]): number {
-  return list.reduce((count, video) => (video.item ? count + 1 : count), 0)
+function resetWebRecommendState() {
+  refreshIdx.value = 1
+  webFetchRow.value = 1
+  webShowlistGroups.value = []
 }
 
 watch(() => settings.value.recommendationMode, () => {
   requestVersion++
   noMoreContent.value = false
-  refreshIdx.value = 1
+  resetWebRecommendState()
   consecutiveEmptyLoads.value = 0 // 重置空加载计数器
   appConsecutiveEmptyLoads.value = 0 // 重置APP模式空加载计数器
 
@@ -358,6 +432,10 @@ watch(() => settings.value.recommendationMode, () => {
   cachedVideoList.value = []
   forwardAppVideoList.value = []
   cachedAppVideoList.value = []
+  cachedWebFetchRow.value = 1
+  cachedWebShowlistGroups.value = []
+  forwardWebFetchRow.value = 1
+  forwardWebShowlistGroups.value = []
 
   // 重置前进后退状态
   hasBackState.value = false
@@ -372,6 +450,10 @@ watch(() => settings.value.recommendationMode, () => {
 
 async function initData() {
   requestVersion++
+  hasInitializedData.value = false
+  if (isWebRecommendationMode.value)
+    webFetchRow.value = 1
+
   // 直接清空列表，骨架屏由 VideoCardGrid 自动处理
   videoList.value = []
   appVideoList.value = []
@@ -381,10 +463,15 @@ async function initData() {
   appConsecutiveEmptyLoads.value = 0 // 重置APP模式空加载计数器
   requestFailed.value = false // 重置请求失败状态
   needToLoginFirst.value = false
-  await getData()
+  try {
+    await getData('refresh')
+  }
+  finally {
+    hasInitializedData.value = true
+  }
 }
 
-async function getData() {
+async function getData(webRequestType: WebRecommendRequestType = 'refresh') {
   const version = requestVersion
   emit('beforeLoading')
   isLoading.value = true
@@ -392,7 +479,7 @@ async function getData() {
 
   try {
     if (isWebRecommendationMode.value) {
-      await getRecommendVideos(version)
+      await getRecommendVideos(version, webRequestType)
     }
     else {
       try {
@@ -432,7 +519,7 @@ async function getData() {
 // 供 VideoCardGrid 预加载调用的函数
 function handleLoadMore() {
   // 如果正在递归加载中，跳过外部触发的加载请求
-  if (isLoading.value || noMoreContent.value || isRecursiveLoading.value)
+  if (!hasInitializedData.value || isLoading.value || noMoreContent.value || isRecursiveLoading.value)
     return
 
   // 滚动加载时，APP模式记录开始长度，触发持续加载
@@ -441,7 +528,7 @@ function handleLoadMore() {
     scrollLoadStartLength.value = appVideoList.value.length
   }
 
-  getData()
+  getData('loadMore')
 }
 
 function initPageAction() {
@@ -463,10 +550,14 @@ function initPageAction() {
       // 总是保存刷新前的当前状态到后退缓存
       cachedVideoList.value = JSON.parse(JSON.stringify(videoList.value))
       cachedRefreshIdx.value = refreshIdx.value
+      cachedWebFetchRow.value = webFetchRow.value
+      cachedWebShowlistGroups.value = [...webShowlistGroups.value]
       hasBackState.value = true
 
       // 清空前进状态（因为刷新会产生新的分支）
       forwardVideoList.value = []
+      forwardWebFetchRow.value = 1
+      forwardWebShowlistGroups.value = []
       hasForwardState.value = false
 
       // 显示撤销按钮
@@ -499,11 +590,15 @@ function initPageAction() {
         // 保存当前数据到前进状态
         forwardVideoList.value = JSON.parse(JSON.stringify(videoList.value))
         forwardRefreshIdx.value = refreshIdx.value
+        forwardWebFetchRow.value = webFetchRow.value
+        forwardWebShowlistGroups.value = [...webShowlistGroups.value]
         hasForwardState.value = true
 
         // 恢复缓存的数据
         videoList.value = JSON.parse(JSON.stringify(cachedVideoList.value))
         refreshIdx.value = cachedRefreshIdx.value
+        webFetchRow.value = cachedWebFetchRow.value
+        webShowlistGroups.value = [...cachedWebShowlistGroups.value]
 
         hasBackState.value = false
         undoForwardState.value = UndoForwardState.Hidden
@@ -539,11 +634,15 @@ function initPageAction() {
         // 保存当前数据到后退状态
         cachedVideoList.value = JSON.parse(JSON.stringify(videoList.value))
         cachedRefreshIdx.value = refreshIdx.value
+        cachedWebFetchRow.value = webFetchRow.value
+        cachedWebShowlistGroups.value = [...webShowlistGroups.value]
         hasBackState.value = true
 
         // 恢复前进状态的数据
         videoList.value = JSON.parse(JSON.stringify(forwardVideoList.value))
         refreshIdx.value = forwardRefreshIdx.value
+        webFetchRow.value = forwardWebFetchRow.value
+        webShowlistGroups.value = [...forwardWebShowlistGroups.value]
 
         // 标记为已经前进
         hasForwardState.value = false
@@ -574,7 +673,7 @@ function initPageAction() {
   }
 }
 
-async function getRecommendVideos(version = requestVersion) {
+async function getRecommendVideos(version = requestVersion, requestType: WebRecommendRequestType = 'refresh') {
   const recommendationMode = settings.value.recommendationMode
   let canFillViewport = false
 
@@ -589,19 +688,24 @@ async function getRecommendVideos(version = requestVersion) {
     const beforeLoadCount = videoList.value.filter(video => video.item).length
 
     // 使用当前的 refreshIdx，只在成功时才递增
-    const currentRefreshIdx = refreshIdx.value
-    const fetchRow = getWebFetchRow(videoList.value)
-    const lastShowlist = getLastShowlistFromList(videoList.value, PAGE_SIZE)
+    const isLoadMoreRequest = requestType === 'loadMore'
+    const shouldUseNoCookieStoredFreshIdx = !isLoadMoreRequest && recommendationMode === 'webNoCookie' && settings.value.rememberNoCookieRecommendationState
+    const currentRefreshIdx = shouldUseNoCookieStoredFreshIdx ? getNoCookieNextFreshIdx() : refreshIdx.value
+    const pageSize = isLoadMoreRequest ? WEB_LOAD_MORE_PAGE_SIZE : WEB_REFRESH_PAGE_SIZE
+    const fetchRow = isLoadMoreRequest ? webFetchRow.value + 3 : 1
+    const currentLastShowlist = getLastShowlistFromGroups()
+    const lastShowlist = currentLastShowlist || (!isLoadMoreRequest && recommendationMode === 'webNoCookie' ? getNoCookieStoredLastShowlist() : '')
 
     const getWebRecommendVideos = recommendationMode === 'webNoCookie'
       ? api.video.getNoCookieRecommendVideos
       : api.video.getRecommendVideos
 
     const response: forYouResult = await getWebRecommendVideos({
+      fresh_type: isLoadMoreRequest ? 4 : 5,
       fresh_idx: currentRefreshIdx,
       fresh_idx_1h: currentRefreshIdx,
-      ps: PAGE_SIZE,
-      fetch_row: fetchRow > 0 ? fetchRow : undefined,
+      ps: pageSize,
+      fetch_row: fetchRow,
       last_showlist: lastShowlist || undefined,
     })
 
@@ -623,7 +727,8 @@ async function getRecommendVideos(version = requestVersion) {
 
     if (response.code === 0) {
       // 只在成功时递增 refreshIdx
-      refreshIdx.value++
+      refreshIdx.value = currentRefreshIdx + 1
+      webFetchRow.value = fetchRow
 
       const resData = [] as VideoItem[]
       const existingIds = new Set<string>()
@@ -652,6 +757,10 @@ async function getRecommendVideos(version = requestVersion) {
         existingIds.add(itemKey)
         resData.push(item)
       })
+
+      const showlistGroup = buildLastShowlistGroup(resData)
+      if (showlistGroup)
+        webShowlistGroups.value.push(showlistGroup)
 
       // when videoList has length property, it means it is the first time to load
       if (!beforeLoadCount) {
@@ -692,6 +801,12 @@ async function getRecommendVideos(version = requestVersion) {
         })
       }
 
+      saveNoCookieRecommendationState(
+        showlistGroup,
+        recommendationMode,
+        shouldUseNoCookieStoredFreshIdx ? currentRefreshIdx + 1 : undefined,
+      )
+
       // 检查是否成功添加了新内容
       const afterLoadCount = videoList.value.filter(video => video.item).length
       if (afterLoadCount > beforeLoadCount) {
@@ -728,7 +843,7 @@ async function getRecommendVideos(version = requestVersion) {
             // 设置递归加载锁，防止 VideoCardGrid 触发额外的 loadMore
             isRecursiveLoading.value = true
             try {
-              await getRecommendVideos(version)
+              await getRecommendVideos(version, 'loadMore')
             }
             finally {
               isRecursiveLoading.value = false

--- a/src/logic/storage.ts
+++ b/src/logic/storage.ts
@@ -29,6 +29,17 @@ export const defaultAppAuthTokens: AppAuthTokens = {
 
 export const appAuthTokens = useStorageLocal<AppAuthTokens>('appAuthTokens', defaultAppAuthTokens, { mergeDefaults: true, writeDefaults: false })
 
+export interface NoCookieForYouRecommendationState {
+  showlistGroups: string[]
+  nextFreshIdx: number
+}
+
+export const noCookieForYouRecommendationState = useStorageLocal<NoCookieForYouRecommendationState>(
+  'noCookieForYouRecommendationState',
+  { showlistGroups: [], nextFreshIdx: 1 },
+  { mergeDefaults: true, writeDefaults: false },
+)
+
 const legacyAccessKey = useStorageLocal('accessKey', '')
 
 watch(
@@ -317,6 +328,7 @@ export interface Settings {
   useSearchPageModeOnHomePage: boolean
   searchPageModeWallpaperFixed: boolean
   preserveForYouState: boolean
+  rememberNoCookieRecommendationState: boolean
 
   adaptToOtherPageStyles: boolean
   showTopBar: boolean
@@ -533,6 +545,7 @@ export const originalSettings: Settings = {
   useSearchPageModeOnHomePage: false,
   searchPageModeWallpaperFixed: false,
   preserveForYouState: false,
+  rememberNoCookieRecommendationState: true,
 
   adaptToOtherPageStyles: true,
   showTopBar: true,


### PR DESCRIPTION
这个 PR 主要减少首页无 Cookie 推荐模式下刷新页面、连续加载时出现重复推荐的问题。

之前无 Cookie 模式刷新后会重新从初始推荐状态请求，接口缺少最近曝光记录，容易返回已经出现过的视频。现在加入了一个默认开启的开关，打开时会在本地记录最近的曝光 showlist 和下一次 fresh_idx，刷新页面后继续带上这些状态，让无 Cookie 推荐更接近连续浏览。

<img width="583" height="248" alt="image" src="https://github.com/user-attachments/assets/0521fea6-f01f-47f7-9e91-031d6742afb5" />

主要调整：

- 新增“减少无 Cookie 推荐重复”设置项，仅在无 Cookie 推荐模式下显示，默认开启
- 新增 noCookieForYouRecommendationState 本地存储，用于保存最近曝光记录和下一次刷新进度
- Web 推荐请求区分刷新和加载更多，分别调整 fresh_type、ps、fetch_row 和 last_showlist
- 刷新、撤销/前进、状态恢复时同步维护 fetchRow 和 showlist 状态
- 初始数据未加载完成前阻止 loadMore，减少重复触发
