### PR TITLE
feat(bewly-widescreen): 支持侧边栏左侧/右侧位置配置

### DIFF
--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -192,6 +192,10 @@ settings:
     web_fullscreen: 网页全屏
     widescreen: 宽屏
     bewly_widescreen: Bewly宽屏
+    bewly_widescreen_sidebar_position: Bewly宽屏侧边栏位置
+    bewly_widescreen_sidebar_position_desc: 选择 Bewly 宽屏模式下侧边栏的显示位置
+    bewly_widescreen_sidebar_position_left: 左侧
+    bewly_widescreen_sidebar_position_right: 右侧
   video_player_scroll: 调整显示模式后滚动
   video_player_scroll_desc: 启用后，在默认模式为宽屏和默认时，会自动滚动到合适位置。
   enlarge_favorite_dialog: 放大收藏弹窗

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -227,6 +227,10 @@ settings:
     web_fullscreen: 網頁全螢幕
     widescreen: 寬螢幕
     bewly_widescreen: Bewly寬螢幕
+    bewly_widescreen_sidebar_position: Bewly寬螢幕側邊欄位置
+    bewly_widescreen_sidebar_position_desc: 選擇 Bewly 寬螢幕模式下側邊欄的顯示位置
+    bewly_widescreen_sidebar_position_left: 左側
+    bewly_widescreen_sidebar_position_right: 右側
   enable_video_preview: 啟用影片預覽功能（如果可以的話）
   enable_video_ctrl_bar_on_video_card: 在影片卡片上顯示影片控制欄
   hover_video_card_delayed: 將滑鼠懸停在影片卡片上時延遲影片預覽

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -205,6 +205,10 @@ settings:
     web_fullscreen: Web Fullscreen
     widescreen: Widescreen
     bewly_widescreen: Bewly Widescreen
+    bewly_widescreen_sidebar_position: Bewly Widescreen Sidebar Position
+    bewly_widescreen_sidebar_position_desc: Choose the sidebar position in Bewly Widescreen mode
+    bewly_widescreen_sidebar_position_left: Left
+    bewly_widescreen_sidebar_position_right: Right
   enable_video_preview: Enable video preview feature (if possible)
   enable_video_ctrl_bar_on_video_card: Display the video control bar on the video card
   hover_video_card_delayed: Delayed video preview on hover over the video card

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -553,6 +553,10 @@ settings:
     web_fullscreen: 網頁全螢幕
     widescreen: 闊螢幕
     bewly_widescreen: Bewly闊螢幕
+    bewly_widescreen_sidebar_position: Bewly闊螢幕側邊欄位置
+    bewly_widescreen_sidebar_position_desc: 選擇 Bewly 闊螢幕模式下側邊欄嘅顯示位置
+    bewly_widescreen_sidebar_position_left: 左側
+    bewly_widescreen_sidebar_position_right: 右側
   show_ip_location: 顯示 IP 歸屬地
   show_ip_location_desc: 喺影片/動向頁留言區顯示 IP 歸屬地。
   show_sex: 顯示用戶性別

--- a/src/components/Settings/BilibiliFeaturesEnhancement/VideoPlayback/VideoPlayback.vue
+++ b/src/components/Settings/BilibiliFeaturesEnhancement/VideoPlayback/VideoPlayback.vue
@@ -10,6 +10,19 @@ import SettingsItemGroup from '../../components/SettingsItemGroup.vue'
 
 const { t } = useI18n()
 
+const bewlyWidescreenSidebarPositionOptions = computed(() => {
+  return [
+    {
+      label: t('settings.video_player_mode.bewly_widescreen_sidebar_position_left'),
+      value: 'left',
+    },
+    {
+      label: t('settings.video_player_mode.bewly_widescreen_sidebar_position_right'),
+      value: 'right',
+    },
+  ]
+})
+
 // 视频播放器模式选项
 const videoPlayerModeOptions = computed(() => {
   return [
@@ -55,6 +68,15 @@ const videoDanmakuDefaultStateOptions = computed(() => {
     <SettingsItemGroup :title="$t('settings.group_player_settings')">
       <SettingsItem :title="$t('settings.video_default_player_mode')" right-width="auto">
         <Select v-model="settings.defaultVideoPlayerMode" :options="videoPlayerModeOptions" w="160px" />
+      </SettingsItem>
+
+      <SettingsItem
+        v-if="settings.defaultVideoPlayerMode === 'bewlyWidescreen'"
+        :title="t('settings.video_player_mode.bewly_widescreen_sidebar_position')"
+        :desc="t('settings.video_player_mode.bewly_widescreen_sidebar_position_desc')"
+        right-width="auto"
+      >
+        <Select v-model="settings.bewlyWidescreenSidebarPosition" :options="bewlyWidescreenSidebarPositionOptions" w="160px" />
       </SettingsItem>
 
       <SettingsItem

--- a/src/contentScripts/index.ts
+++ b/src/contentScripts/index.ts
@@ -276,7 +276,7 @@ else {
     else {
       switch (targetPlayerMode) {
         case 'bewlyWidescreen':
-          applyBewlyWidescreen()
+          applyBewlyWidescreen(settings.value.bewlyWidescreenSidebarPosition || 'right')
           break
         case 'webFullscreen':
           webFullscreen()

--- a/src/logic/storage.ts
+++ b/src/logic/storage.ts
@@ -118,6 +118,7 @@ export type VideoCardFontSizeSetting = 'xs' | 'sm' | 'base' | 'lg'
 export type VideoCardLayoutSetting = 'modern' | 'compact' | 'old'
 export type AutoPlayMode = 'default' | 'autoPlay' | 'autoPlayWithRecommend' | 'pauseAtEnd' | 'loop'
 export type DefaultVideoPlayerMode = 'default' | 'webFullscreen' | 'widescreen' | 'bewlyWidescreen'
+export type BewlyWidescreenSidebarPosition = 'left' | 'right'
 export type RecommendationMode = 'web' | 'app' | 'webNoCookie'
 
 export interface ShadowCurvePoint {
@@ -338,6 +339,7 @@ export interface Settings {
 
   // Video Player
   defaultVideoPlayerMode: DefaultVideoPlayerMode
+  bewlyWidescreenSidebarPosition: BewlyWidescreenSidebarPosition
   defaultDanmakuState: 'system' | 'on' | 'off'
   keepCollectionVideoDefaultMode: boolean // 合集视频保持默认模式
   autoExitFullscreenOnEnd: boolean // 全屏播放完毕后自动退出
@@ -556,6 +558,7 @@ export const originalSettings: Settings = {
 
   // Video Player
   defaultVideoPlayerMode: 'default',
+  bewlyWidescreenSidebarPosition: 'right',
   defaultDanmakuState: 'system',
   keepCollectionVideoDefaultMode: false, // 合集视频保持默认模式，默认关闭
   autoExitFullscreenOnEnd: false, // 全屏播放完毕后自动退出，默认关闭

--- a/src/utils/bewlyWidescreen.ts
+++ b/src/utils/bewlyWidescreen.ts
@@ -25,6 +25,7 @@ interface BewlyWidescreenState {
   styleEl: HTMLStyleElement
   activeTab: BewlyWidescreenTab
   sidebarMode: BewlyWidescreenSidebarMode
+  sidebarPosition: 'left' | 'right'
   resizeObserver?: ResizeObserver
   mutationObserver?: MutationObserver
   metadataListener?: () => void
@@ -54,6 +55,7 @@ let sidebarRefreshTimer: ReturnType<typeof setTimeout> | undefined
 let readyRetryCount = 0
 let sidebarRefreshCount = 0
 let waitingForLoad = false
+let pendingSidebarPosition: 'left' | 'right' = 'right'
 
 const selectors = {
   player: [
@@ -234,8 +236,13 @@ function setSidebarMode(nextMode: BewlyWidescreenSidebarMode) {
   state.sidebarMode = nextMode
   state.root.dataset.sidebarMode = nextMode
   const isFit = nextMode === 'fit'
-  state.sidebarToggleButton.textContent = isFit ? '‹' : '›'
-  state.sidebarToggleButton.title = isFit ? '显示窄右栏' : '收起右栏'
+  const isRight = state.sidebarPosition === 'right'
+  state.sidebarToggleButton.textContent = isRight
+    ? (isFit ? '‹' : '›')
+    : (isFit ? '›' : '‹')
+  state.sidebarToggleButton.title = isFit
+    ? (isRight ? '显示窄右栏' : '显示窄左栏')
+    : (isRight ? '收起右栏' : '收起左栏')
   state.sidebarToggleButton.setAttribute('aria-label', state.sidebarToggleButton.title)
   updateSidebarToggleState()
   schedulePlayerResizeSync(state)
@@ -292,9 +299,10 @@ function createSidebarToggleButton() {
   return button
 }
 
-function createRoot() {
+function createRoot(sidebarPosition: 'left' | 'right' = 'right') {
   const root = document.createElement('div')
   root.id = ROOT_ID
+  root.dataset.sidebarPosition = sidebarPosition
 
   const stage = document.createElement('div')
   stage.className = 'bewly-widescreen-stage'
@@ -346,7 +354,10 @@ function createRoot() {
   }
 
   sidebar.append(sidebarTop, tablist, panelWrap)
-  stage.append(playerSlot, sidebar)
+  if (sidebarPosition === 'left')
+    stage.append(sidebar, playerSlot)
+  else
+    stage.append(playerSlot, sidebar)
   root.appendChild(stage)
   document.body.appendChild(root)
 
@@ -617,6 +628,29 @@ function injectLayoutStyle() {
       transform: translateX(0);
     }
 
+    #${ROOT_ID}[data-sidebar-position="left"] .bewly-widescreen-stage {
+      grid-template-columns:
+        minmax(0, var(--bewly-widescreen-sidebar-column-width))
+        minmax(0, calc(100vw - var(--bewly-widescreen-sidebar-column-width)));
+    }
+
+    #${ROOT_ID}[data-sidebar-position="left"] .bewly-widescreen-sidebar {
+      justify-self: start;
+      border-left: none;
+      border-right: 1px solid var(--bewly-widescreen-sidebar-border);
+      box-shadow: 12px 0 28px rgba(0, 0, 0, 0.28);
+    }
+
+    #${ROOT_ID}[data-sidebar-position="left"][data-sidebar-mode="narrow"] .bewly-widescreen-sidebar {
+      box-shadow: none;
+    }
+
+    #${ROOT_ID}[data-sidebar-position="left"][data-sidebar-mode="fit"] {
+      --bewly-widescreen-sidebar-offset: calc(
+        var(--bewly-widescreen-sidebar-column-width) - var(--bewly-widescreen-sidebar-panel-width)
+      );
+    }
+
     #${ROOT_ID} .bewly-widescreen-sidebar-toggle {
       position: absolute;
       right: 0;
@@ -642,6 +676,12 @@ function injectLayoutStyle() {
       pointer-events: none;
       transform: translateY(-50%);
       transition: opacity 160ms ease, background-color 160ms ease, border-color 160ms ease;
+    }
+
+    #${ROOT_ID}[data-sidebar-position="left"] .bewly-widescreen-sidebar-toggle {
+      right: auto;
+      left: 0;
+      border-radius: 0 8px 8px 0;
     }
 
     #${ROOT_ID}[data-sidebar-toggle-visible="true"][data-pointer-active="true"] .bewly-widescreen-player-slot:hover .bewly-widescreen-sidebar-toggle,
@@ -1514,14 +1554,14 @@ function isReadyForLayout() {
   return !!player.querySelector('video, bwp-video, .bpx-player-video-area, .bilibili-player-video-wrap')
 }
 
-function applyNow() {
+function applyNow(sidebarPosition: 'left' | 'right' = 'right') {
   exitBewlyWidescreen()
 
   const player = findMovable(selectors.player)
   if (!player)
     return false
 
-  const { root, playerSlot, playerFrame, danmakuDock, sidebarEl, sidebarTop, upSlot, toolbarSlot, panels, tabButtons, sidebarToggleButton } = createRoot()
+  const { root, playerSlot, playerFrame, danmakuDock, sidebarEl, sidebarTop, upSlot, toolbarSlot, panels, tabButtons, sidebarToggleButton } = createRoot(sidebarPosition)
   const styleEl = injectLayoutStyle()
   const movedNodes: MovedNode[] = []
 
@@ -1541,6 +1581,7 @@ function applyNow() {
     styleEl,
     activeTab: 'comment',
     sidebarMode: 'fit',
+    sidebarPosition,
   }
 
   state = nextState
@@ -1589,7 +1630,7 @@ function scheduleReadyRetry(delay = READY_RETRY_INTERVAL) {
       return
 
     if (isReadyForLayout()) {
-      applyNow()
+      applyNow(pendingSidebarPosition)
       return
     }
 
@@ -1599,13 +1640,14 @@ function scheduleReadyRetry(delay = READY_RETRY_INTERVAL) {
   }, delay)
 }
 
-function startAfterPageLoad() {
+function startAfterPageLoad(sidebarPosition: 'left' | 'right' = 'right') {
   if (state)
     return
 
   waitingForLoad = false
   clearLoadFallbackTimer()
   readyRetryCount = 0
+  pendingSidebarPosition = sidebarPosition
   scheduleReadyRetry(LOAD_SETTLE_DELAY)
 }
 
@@ -1623,19 +1665,21 @@ function scheduleSidebarRefresh() {
   }, SIDEBAR_REFRESH_DELAY)
 }
 
-export function applyBewlyWidescreen() {
+export function applyBewlyWidescreen(sidebarPosition: 'left' | 'right' = 'right') {
   if (state || waitingForLoad || readyRetryTimer)
     return
 
   sidebarRefreshCount = 0
+  pendingSidebarPosition = sidebarPosition
 
   if (document.readyState === 'complete') {
-    startAfterPageLoad()
+    startAfterPageLoad(sidebarPosition)
     return
   }
 
   waitingForLoad = true
-  window.addEventListener('load', startAfterPageLoad, { once: true })
+  const loadHandler = () => startAfterPageLoad(sidebarPosition)
+  window.addEventListener('load', loadHandler, { once: true })
 
   clearLoadFallbackTimer()
   loadFallbackTimer = setTimeout(() => {


### PR DESCRIPTION
## 概述

为 Bewly 宽屏模式新增可配置的侧边栏位置选项，用户可以在设置中选择将侧边栏（评论区/弹幕/选集）显示在左侧或右侧。

## 变更内容

- **storage.ts**: 新增 `BewlyWidescreenSidebarPosition` 类型和 `Settings.bewlyWidescreenSidebarPosition` 配置项，默认值 `'right'`
- **bewlyWidescreen.ts**:
  - 调整 `createRoot` 根据 `sidebarPosition` 切换 DOM 顺序以匹配 CSS Grid 列定义
  - 为 `applyBewlyWidescreen` 等函数增加 `sidebarPosition` 参数
  - 调整 `setSidebarMode` 中的切换按钮箭头和提示文字以适配位置
  - 新增 `data-sidebar-position="left"` 的 CSS 覆盖：grid 列序、border、阴影、切换按钮位置、fit 模式偏移量
- **contentScripts/index.ts**: 调用 `applyBewlyWidescreen()` 时传入设置值
- **VideoPlayback.vue**: 在视频播放模式选择框下方增加侧边栏位置下拉选择框（条件显示）
- **_locales/**: 在 4 个语言文件中添加 i18n 翻译

## 关键修复

之前只调整了 CSS Grid 列定义但没有调整 DOM 子元素顺序，导致播放器被挤到 sidebar 列。在 `createRoot` 中根据 `sidebarPosition` 切换 `stage.append` 顺序以匹配 grid 列定义。

## 默认行为

保持向后兼容，默认值为右侧。

## 测试

- [x] TypeScript 类型检查通过
- [x] Chrome 加载 `extension/` 后，"Bewly 宽屏侧边栏位置" 控件可见
- [x] 切换为左侧后，视频保持宽屏比例居中、侧边栏正常显示在左侧
- [x] 切换为右侧后行为与原有版本一致
- [x] fit / narrow 两种模式下切换按钮箭头方向正确