### PR TITLE
perf: 移除视频网格的虚拟滚动，改用追加渲染

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "submit:firefox": "pnpm wxt submit --firefox-zip ./extension-firefox.zip --firefox-sources-zip ./extension-firefox-sources.zip"
   },
   "dependencies": {
-    "@tanstack/vue-virtual": "^3.13.24",
     "@types/md5": "^2.3.5",
     "dompurify": "^3.2.6",
     "flv.js": "^1.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@tanstack/vue-virtual':
-        specifier: ^3.13.24
-        version: 3.13.24(vue@3.5.19(typescript@5.9.2))
       '@types/md5':
         specifier: ^2.3.5
         version: 2.3.5
@@ -1309,14 +1306,6 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: '>=9.0.0'
-
-  '@tanstack/virtual-core@3.14.0':
-    resolution: {integrity: sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==}
-
-  '@tanstack/vue-virtual@3.13.24':
-    resolution: {integrity: sha512-A0k2qF0zFSUStXSZkGXABouXr2Tw2Ztl/cVIYG9qy84uR8W7UNjAcX3DvzBS3YnDcwvLxab8v7dbmYBZ39itDA==}
-    peerDependencies:
-      vue: ^2.7.0 || ^3.0.0
 
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
@@ -6819,13 +6808,6 @@ snapshots:
       espree: 10.4.0
       estraverse: 5.3.0
       picomatch: 4.0.3
-
-  '@tanstack/virtual-core@3.14.0': {}
-
-  '@tanstack/vue-virtual@3.13.24(vue@3.5.19(typescript@5.9.2))':
-    dependencies:
-      '@tanstack/virtual-core': 3.14.0
-      vue: 3.5.19(typescript@5.9.2)
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 

--- a/src/components/VideoCard/components/VideoCardCover.vue
+++ b/src/components/VideoCard/components/VideoCardCover.vue
@@ -442,14 +442,14 @@ onBeforeUnmount(() => {
         duration-300
       >
         <div
-          v-if="Number(video.rank) <= 3"
+          v-if="Number(video?.rank) <= 3"
           bg="$bew-theme-color" text-center lh-0 h-30px w-30px
           text-white rounded="1/2" shadow="$bew-shadow-1"
           border="1 $bew-theme-color"
           grid="~ place-content-center"
           text="xl" fw-bold
         >
-          {{ video.rank }}
+          {{ video?.rank }}
         </div>
         <div
           v-else
@@ -457,14 +457,14 @@ onBeforeUnmount(() => {
           rounded="1/2" shadow="$bew-shadow-1"
           border="1 $bew-border-color"
         >
-          {{ video.rank }}
+          {{ video?.rank }}
         </div>
       </div>
 
       <template v-if="!removed && video">
         <!-- Old layout: Video Duration (right bottom) -->
         <div
-          v-if="layout === 'old' && (video.duration || video.durationStr)"
+          v-if="layout === 'old' && (video?.duration || video?.durationStr)"
           pos="absolute bottom-0 right-0"
           z="2"
           p="x-2 y-1"
@@ -475,7 +475,7 @@ onBeforeUnmount(() => {
           :class="{ 'opacity-0': shouldHideOverlayElements }"
           duration-300
         >
-          {{ video.duration ? calcCurrentTime(video.duration) : video.durationStr }}
+          {{ video?.duration ? calcCurrentTime(video?.duration ?? 0) : video?.durationStr }}
         </div>
 
         <div
@@ -489,7 +489,7 @@ onBeforeUnmount(() => {
         </div>
 
         <div
-          v-if="video.liveStatus === 1"
+          v-if="video?.liveStatus === 1"
           :class="layout !== 'old' ? 'group-hover:opacity-0' : { 'opacity-0': shouldHideOverlayElements }"
           pos="absolute left-0 top-0" bg="$bew-theme-color" text="xs white" fw-bold
           p="x-2 y-1" m-1 inline-block rounded="$bew-radius" duration-300
@@ -499,21 +499,21 @@ onBeforeUnmount(() => {
         </div>
 
         <div
-          v-if="video.badge && Object.keys(video.badge).length > 0"
+          v-if="Object.keys(video?.badge ?? {}).length > 0"
           :class="layout !== 'old' ? 'group-hover:opacity-0' : { 'opacity-0': shouldHideOverlayElements }"
           :style="{
-            backgroundColor: video.badge.bgColor,
-            color: video.badge.color,
+            backgroundColor: video?.badge?.bgColor,
+            color: video?.badge?.color,
           }"
           pos="absolute right-0 top-0" bg="$bew-theme-color" text="xs white"
           p="x-2 y-1" m-1 inline-block rounded="$bew-radius" duration-300
         >
-          {{ video.badge.text }}
+          {{ video?.badge?.text }}
         </div>
 
-        <!-- Watcher later button -->
+        <!-- Watcher later button: mount only when needed so resting cards do not carry Tooltip/Icon/i18n cost. -->
         <div
-          v-if="showWatcherLater"
+          v-if="showWatcherLater && (isHover || isInWatchLater)"
           role="button"
           tabindex="0"
           :aria-label="isInWatchLater ? $t('common.added') : $t('common.save_to_watch_later')"

--- a/src/components/VideoCardGrid.vue
+++ b/src/components/VideoCardGrid.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts" generic="T = any">
-import { useVirtualizer } from '@tanstack/vue-virtual'
 import { useDebounceFn } from '@vueuse/core'
 
 import type { Video } from '~/components/VideoCard/types'
+import { useGridLayout } from '~/composables/useGridLayout'
 import { useVideoCardShadowStyle } from '~/composables/useVideoCardShadowStyle'
 import { OVERLAY_SCROLL_BAR_SCROLL } from '~/constants/globalEvents'
 import type { GridLayoutType } from '~/logic'
@@ -186,6 +186,9 @@ const loadMoreSentinelRef = ref<HTMLElement | null>(null)
 const isLoadMoreSentinelIntersecting = ref(false)
 const reachedLoadMoreDuringLoading = ref(false)
 
+// 使用共享的 Grid 布局 composable（CSS 媒体查询驱动，无 JS 计算开销）
+const { gridClass, gridCssVars } = useGridLayout(() => props.gridLayout)
+
 // 获取 shadow 样式变量（避免依赖外部传入）
 const { shadowStyleVars } = useVideoCardShadowStyle()
 
@@ -210,10 +213,7 @@ const lastItemsCount = ref(0)
 const consecutiveFailures = ref(0)
 const MAX_CONSECUTIVE_FAILURES = 3
 
-// 分块渲染：渲染限制（在 displayItems 定义之前声明，避免循环依赖）
-const renderLimit = ref(0)
-
-// 仅首屏空数据加载时显示骨架屏；滚动加载时不再向虚拟列表插入临时卡片。
+// 仅首屏空数据加载时显示骨架屏；滚动加载时不再向列表插入临时卡片。
 const showInitialSkeleton = computed(() => {
   if (props.needToLoginFirst)
     return false
@@ -275,12 +275,6 @@ function canLoadMore(): boolean {
 
   // 连续空加载次数超过限制时停止
   if (consecutiveEmptyLoads.value >= MAX_CONSECUTIVE_EMPTY_LOADS) {
-    return false
-  }
-
-  // 关键：避免在上一批次未渲染完成时触发 loadMore
-  // 否则 sentinel 会保持"太高"，IO/scroll 检查会链式加载
-  if (renderLimit.value < displayItems.value.length) {
     return false
   }
 
@@ -369,7 +363,6 @@ function setupIntersectionObserver() {
 
 // RAF 标志，用于批量处理 DOM 读取
 let checkPreloadRAF: number | null = null
-let containerResizeObserver: ResizeObserver | null = null
 
 // 检查是否需要预加载
 function checkShouldPreload() {
@@ -413,6 +406,10 @@ function handleScroll() {
   debouncedCheck()
 }
 
+function handleResize() {
+  debouncedCheck()
+}
+
 // 设置滚动监听
 function setupScrollListeners() {
   if (scrollListenersActive)
@@ -443,7 +440,8 @@ function cleanupScrollListeners() {
 }
 
 function getRenderedColumnCount(): number {
-  const containerWidth = gridContainerRef.value?.clientWidth || 0
+  const containerWidth = gridContainerRef.value?.clientWidth
+    || (typeof window !== 'undefined' ? window.innerWidth : 0)
   return getCurrentColumnCount(props.gridLayout, containerWidth)
 }
 
@@ -553,49 +551,12 @@ watch(loadMoreSentinelRef, () => {
   setupIntersectionObserver()
 })
 
-// 监听 displayItems 变化，触发分块渲染
-watch(
-  () => displayItems.value.length,
-  (newLen, oldLen) => {
-    // 刷新路径（数据被清空）
-    if (newLen === 0) {
-      renderLimit.value = 0
-      return
-    }
-
-    // 列表收缩，立即夹紧
-    if (newLen < renderLimit.value) {
-      renderLimit.value = newLen
-      return
-    }
-
-    // 只在追加时分块渲染
-    if (newLen > oldLen) {
-      // 虚拟滚动激活时，跳过分块渲染——虚拟窗口已经限制了 DOM 数量，
-      // 分块渲染的 requestIdleCallback 在快速滚动时反而会导致渲染滞后
-      const estimatedColumns = getCurrentColumnCount(props.gridLayout, gridContainerRef.value?.clientWidth || 0)
-      const virtualThreshold = 6 * estimatedColumns
-      if (newLen > virtualThreshold) {
-        renderLimit.value = newLen
-      }
-      else {
-        scheduleChunkRender(newLen)
-      }
-      return
-    }
-
-    // 兜底：保持同步
-    renderLimit.value = newLen
-  },
-)
-
 function activateGrid() {
   if (isGridActive)
     return
 
   isGridActive = true
   setupScrollListeners()
-  setupContainerResizeObserver()
 
   nextTick(() => {
     if (!isGridActive)
@@ -612,7 +573,6 @@ function deactivateGrid() {
 
   isGridActive = false
   cleanupScrollListeners()
-  cleanupContainerResizeObserver()
   cleanupIntersectionObserver()
 
   if (checkPreloadRAF !== null) {
@@ -622,8 +582,6 @@ function deactivateGrid() {
 }
 
 onMounted(() => {
-  // 初始化 renderLimit：对于已存在的数据，立即全部渲染（无渐进式加载）
-  renderLimit.value = displayItems.value.length
   activateGrid()
 })
 
@@ -650,59 +608,16 @@ const isHorizontal = computed(() => {
   return props.gridLayout !== 'adaptive'
 })
 
+// 合并 shadow 样式变量和 grid 列数变量
+const gridContainerStyle = computed(() => ({
+  ...shadowStyleVars.value,
+  ...gridCssVars.value,
+}))
+
 // 判断是否应该显示空状态（确认无更多内容且数据为空）
 const showEmptyState = computed(() => {
   return props.noMoreContent && props.items.length === 0 && !props.needToLoginFirst
 })
-
-// -------------------------
-// 分块渲染（Chunked Rendering）- 解决批量 DOM 插入导致的样式重算风暴
-// -------------------------
-let renderJobToken = 0
-
-function scheduleChunkRender(target: number) {
-  const token = ++renderJobToken
-
-  const useRIC = typeof window !== 'undefined' && 'requestIdleCallback' in window
-
-  const step = (deadline?: IdleDeadline) => {
-    if (token !== renderJobToken)
-      return
-
-    const remaining = target - renderLimit.value
-    if (remaining <= 0) {
-      nextTick(() => {
-        checkShouldPreload()
-      })
-      return
-    }
-
-    // 保守的默认值；如果浏览器报告有足够的空闲时间则提高
-    let chunk = 8
-    if (deadline && typeof deadline.timeRemaining === 'function') {
-      const budget = deadline.timeRemaining()
-      if (budget > 12)
-        chunk = 20
-      else if (budget > 8)
-        chunk = 12
-    }
-
-    renderLimit.value += Math.min(chunk, remaining)
-
-    if (useRIC) {
-      ;(window as any).requestIdleCallback(step, { timeout: 50 })
-    }
-    else {
-      requestAnimationFrame(() => step())
-    }
-  }
-
-  // 立即开始（但仍然通过 rIC/rAF yield）
-  step()
-}
-
-const containerWidth = ref(0)
-const viewportHeight = ref(typeof window !== 'undefined' ? window.innerHeight : 0)
 
 function normalizePositiveInt(value: unknown, fallback: number): number {
   const normalized = Number(value)
@@ -735,103 +650,6 @@ function getCurrentColumnCount(layout: GridLayoutType, width: number): number {
     return 1
   return getAdaptiveGridColumns(width)
 }
-
-function getGridGap(layout: GridLayoutType): number {
-  return layout === 'adaptive' ? 20 : 16
-}
-
-function getEstimatedRowSpan(layout: GridLayoutType): number {
-  if (layout === 'twoColumns')
-    return 236
-  if (layout === 'oneColumn')
-    return 188
-  return 352
-}
-
-function getFallbackEstimatedRowHeight(layout: GridLayoutType): number {
-  return Math.max(1, getEstimatedRowSpan(layout) - getGridGap(layout))
-}
-
-function getEstimatedAdaptiveRowHeight(width: number, columns: number): number {
-  if (width <= 0 || columns <= 0)
-    return getFallbackEstimatedRowHeight('adaptive')
-
-  const gap = getGridGap('adaptive')
-  const cardWidth = Math.max(1, (width - gap * (columns - 1)) / columns)
-  const coverHeight = cardWidth * 9 / 16
-
-  // Keep the first virtual pass close to the actual card height so rows do
-  // not render with a large temporary gap before ResizeObserver catches up.
-  switch (settings.value.videoCardLayout) {
-    case 'compact':
-      return coverHeight + 66
-    case 'old':
-      return coverHeight + 132
-    case 'modern':
-    default:
-      return coverHeight + 112
-  }
-}
-
-function getEstimatedHorizontalItemHeight(layout: GridLayoutType, itemWidth: number): number {
-  const fallbackHeight = layout === 'twoColumns' ? 220 : 236
-
-  if (itemWidth <= 0)
-    return fallbackHeight
-
-  const coverWidth = Math.min(itemWidth, 400)
-  const coverHeight = coverWidth * 9 / 16
-
-  return Math.max(fallbackHeight, Math.ceil(coverHeight))
-}
-
-const resolvedContainerWidth = computed(() => {
-  if (containerWidth.value > 0)
-    return containerWidth.value
-
-  return 0
-})
-
-const currentColumnCount = computed(() =>
-  getCurrentColumnCount(props.gridLayout, resolvedContainerWidth.value),
-)
-
-const currentGridGap = computed(() => getGridGap(props.gridLayout))
-
-const VIRTUAL_RETAIN_SCREENS = 2
-
-const estimatedCardWidth = computed(() => {
-  const columns = currentColumnCount.value
-  const width = resolvedContainerWidth.value
-  if (columns <= 1)
-    return Math.max(1, width)
-  return Math.max(1, (width - currentGridGap.value * (columns - 1)) / columns)
-})
-
-const estimatedRowHeight = computed(() => {
-  if (props.gridLayout === 'adaptive')
-    return getEstimatedAdaptiveRowHeight(resolvedContainerWidth.value, currentColumnCount.value)
-  return getEstimatedHorizontalItemHeight(props.gridLayout, estimatedCardWidth.value)
-})
-
-const visibleRowCount = computed(() => {
-  const rowSpan = Math.max(1, estimatedRowHeight.value + currentGridGap.value)
-  return Math.max(1, Math.ceil(viewportHeight.value / rowSpan))
-})
-
-const overscanRowCount = computed(() =>
-  Math.max(2, Math.ceil(visibleRowCount.value * VIRTUAL_RETAIN_SCREENS)),
-)
-
-const totalRowCount = computed(() =>
-  Math.ceil(displayItems.value.length / currentColumnCount.value),
-)
-
-const gridContainerStyle = computed(() => ({
-  ...shadowStyleVars.value,
-  '--virtual-grid-columns': currentColumnCount.value,
-  '--virtual-grid-column-gap': `${currentGridGap.value}px`,
-}))
 
 function findScrollElement(): HTMLElement | null {
   if (settings.value.useOriginalBilibiliHomepage)
@@ -871,68 +689,6 @@ function isScrollAtBottom(): boolean {
     return false
 
   return getRemainingScroll(scrollElement) <= 2
-}
-
-function getVirtualRowKey(rowIndex: number): string {
-  const firstItemIndex = rowIndex * currentColumnCount.value
-  const firstItem = displayItems.value[firstItemIndex]
-  const firstItemKey = firstItem
-    ? getUniqueKey(firstItem, firstItemIndex)
-    : firstItemIndex
-  return `${currentColumnCount.value}:${firstItemKey}`
-}
-
-const rowVirtualizer = useVirtualizer<HTMLElement, HTMLElement>(computed(() => ({
-  count: totalRowCount.value,
-  getScrollElement: () => findScrollElement(),
-  estimateSize: () => estimatedRowHeight.value,
-  overscan: overscanRowCount.value,
-  gap: currentGridGap.value,
-  getItemKey: getVirtualRowKey,
-  measureElement: () => estimatedRowHeight.value,
-  shouldAdjustScrollPositionOnItemSizeChange: () => false,
-})))
-
-const virtualRows = computed(() => rowVirtualizer.value.getVirtualItems())
-const virtualTotalHeight = computed(() => rowVirtualizer.value.getTotalSize())
-
-function handleResize() {
-  viewportHeight.value = typeof window !== 'undefined' ? window.innerHeight : viewportHeight.value
-  rowVirtualizer.value.measure()
-  debouncedCheck()
-}
-
-function cleanupContainerResizeObserver() {
-  if (containerResizeObserver) {
-    containerResizeObserver.disconnect()
-    containerResizeObserver = null
-  }
-}
-
-function setupContainerResizeObserver() {
-  cleanupContainerResizeObserver()
-
-  const container = gridContainerRef.value
-  if (!container || typeof ResizeObserver === 'undefined')
-    return
-
-  containerWidth.value = container.clientWidth
-
-  containerResizeObserver = new ResizeObserver((entries) => {
-    const entry = entries[0]
-    if (!entry)
-      return
-
-    const nextWidth = entry.contentRect.width
-    if (Math.abs(nextWidth - containerWidth.value) <= 0.5)
-      return
-
-    containerWidth.value = nextWidth
-    viewportHeight.value = typeof window !== 'undefined' ? window.innerHeight : viewportHeight.value
-    rowVirtualizer.value.measure()
-  })
-
-  containerResizeObserver.observe(container)
 }
 
 // 类型定义：每个 VideoCard 的渲染所需数据
@@ -997,38 +753,10 @@ function createRenderItem(item: T, index: number): VideoCardRenderItem {
   return { key, index, item, skeleton, type, video }
 }
 
-interface VirtualGridRow {
-  key: string
-  index: number
-  start: number
-  items: VideoCardRenderItem[]
-}
-
-// 仅虚拟化纵向行；行内宽度和列间距完全交给 CSS Grid。
-const renderRows = computed<VirtualGridRow[]>(() => {
-  const sourceItems = displayItems.value
-  const columns = currentColumnCount.value
-
-  return virtualRows.value.flatMap((virtualRow) => {
-    const startIndex = virtualRow.index * columns
-    if (startIndex >= renderLimit.value)
-      return []
-
-    const endIndex = Math.min(startIndex + columns, renderLimit.value, sourceItems.length)
-    const rowItems = sourceItems
-      .slice(startIndex, endIndex)
-      .map((item, offset) => createRenderItem(item, startIndex + offset))
-
-    if (rowItems.length === 0)
-      return []
-
-    return [{
-      key: String(virtualRow.key),
-      index: virtualRow.index,
-      start: virtualRow.start,
-      items: rowItems,
-    }]
-  })
+// 普通追加渲染：按 displayItems 顺序保留所有已加载卡片，
+// 对齐 B 站原生首页的连续滚动体验，不做虚拟窗口回收。
+const renderItems = computed<VideoCardRenderItem[]>(() => {
+  return displayItems.value.map((item, index) => createRenderItem(item, index))
 })
 
 interface VideoTransformCacheEntry<T = any> {
@@ -1047,7 +775,7 @@ watch(() => props.transformItem, () => {
 })
 
 watch(
-  () => renderRows.value.flatMap(row => row.items.map(item => item.key)),
+  () => renderItems.value.map(item => item.key),
   (activeKeys) => {
     const activeKeySet = new Set(activeKeys)
 
@@ -1080,27 +808,6 @@ function getTransformedVideo(item: T, key: string | number): Video | undefined {
     return undefined
   }
 }
-
-watch(gridContainerRef, () => {
-  setupContainerResizeObserver()
-  rowVirtualizer.value.measure()
-})
-
-watch(
-  [currentColumnCount, () => props.gridLayout, () => settings.value.videoCardLayout],
-  () => {
-    rowVirtualizer.value.measure()
-  },
-  { flush: 'post' },
-)
-
-watch(
-  () => displayItems.value.length,
-  () => {
-    rowVirtualizer.value.measure()
-  },
-  { flush: 'post' },
-)
 
 // 处理登录
 function handleLogin() {
@@ -1158,47 +865,29 @@ function getUniqueKey(item: T, index: number): string | number {
       v-else
       ref="gridContainerRef"
       class="video-card-grid-container"
-      :class="{ 'is-firefox': isFirefox }"
+      :class="[gridClass, { 'is-firefox': isFirefox }]"
       m="b-0 t-0" relative w-full
       :style="gridContainerStyle"
     >
-      <div
-        class="virtual-rows"
-        :style="{ height: `${virtualTotalHeight}px` }"
+      <VideoCard
+        v-for="renderItem in renderItems"
+        :key="renderItem.key"
+        :data-index="renderItem.index"
+        :skeleton="renderItem.skeleton"
+        :type="renderItem.type"
+        :video="renderItem.video"
+        :show-preview="showPreview"
+        :show-watcher-later="showWatchLater"
+        :horizontal="isHorizontal"
+        :more-btn="moreBtn"
+        :is-following-page="props.isFollowingPage"
+        :custom-click-handler="props.cardClickHandler ? (event: MouseEvent) => props.cardClickHandler?.(renderItem.item, event) : undefined"
+        :cover-top-left-always-visible="props.coverTopLeftAlwaysVisible"
       >
-        <div
-          v-for="renderRow in renderRows"
-          :key="renderRow.key"
-          :ref="(el) => rowVirtualizer.measureElement(el as HTMLElement | null)"
-          :data-index="renderRow.index"
-          class="virtual-row"
-          :style="{
-            'top': `${renderRow.start}px`,
-            'height': `${estimatedRowHeight}px`,
-            'minHeight': `${estimatedRowHeight}px`,
-            '--bew-video-card-virtual-height': `${estimatedRowHeight}px`,
-          }"
-        >
-          <VideoCard
-            v-for="renderItem in renderRow.items"
-            :key="renderItem.key"
-            :skeleton="renderItem.skeleton"
-            :type="renderItem.type"
-            :video="renderItem.video"
-            :show-preview="showPreview"
-            :show-watcher-later="showWatchLater"
-            :horizontal="isHorizontal"
-            :more-btn="moreBtn"
-            :is-following-page="props.isFollowingPage"
-            :custom-click-handler="props.cardClickHandler ? (event: MouseEvent) => props.cardClickHandler?.(renderItem.item, event) : undefined"
-            :cover-top-left-always-visible="props.coverTopLeftAlwaysVisible"
-          >
-            <template v-for="(_, name) in $slots" #[name]>
-              <slot :name="name" :item="renderItem.item" />
-            </template>
-          </VideoCard>
-        </div>
-      </div>
+        <template v-for="(_, name) in $slots" #[name]>
+          <slot :name="name" :item="renderItem.item" />
+        </template>
+      </VideoCard>
 
       <div ref="loadMoreSentinelRef" class="load-more-sentinel" aria-hidden="true" />
     </div>
@@ -1221,50 +910,102 @@ function getUniqueKey(item: T, index: number): string | number {
   overflow-anchor: none;
 }
 
-.virtual-rows {
-  position: relative;
-  width: 100%;
-  min-width: 0;
-  max-width: 100%;
+// Grid 布局 - 使用 Tailwind CSS 标准媒体断点 + CSS 变量控制列数
+.grid-adaptive {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(var(--grid-cols-base, 1), 1fr);
   contain: layout style;
-  overflow-anchor: none;
+  align-items: stretch;
 }
 
-.virtual-row {
-  position: absolute;
-  left: 0;
-  width: 100%;
-  min-width: 0;
+@media (min-width: 640px) {
+  .grid-adaptive {
+    grid-template-columns: repeat(var(--grid-cols-sm, 2), 1fr);
+  }
+}
+
+@media (min-width: 768px) {
+  .grid-adaptive {
+    grid-template-columns: repeat(var(--grid-cols-md, 3), 1fr);
+  }
+}
+
+@media (min-width: 1024px) {
+  .grid-adaptive {
+    grid-template-columns: repeat(var(--grid-cols-lg, 4), 1fr);
+  }
+}
+
+@media (min-width: 1280px) {
+  .grid-adaptive {
+    grid-template-columns: repeat(var(--grid-cols-xl, 5), 1fr);
+  }
+}
+
+@media (min-width: 1536px) {
+  .grid-adaptive {
+    grid-template-columns: repeat(var(--grid-cols-xxl, 6), 1fr);
+  }
+}
+
+.grid-two-columns {
   display: grid;
-  grid-template-columns: repeat(var(--virtual-grid-columns, 1), minmax(0, 1fr));
-  column-gap: var(--virtual-grid-column-gap, 20px);
-  align-items: stretch;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
   contain: layout style;
-  overflow-anchor: none;
-  overflow: visible;
+  align-items: stretch;
+}
 
-  &:hover,
-  &:focus-within {
-    z-index: 2;
+@supports (container-type: inline-size) {
+  .video-card-grid-root {
+    container-type: inline-size;
   }
 
-  :deep(.video-card-container) {
-    content-visibility: visible;
-    contain-intrinsic-size: auto none;
-    min-height: var(--bew-video-card-virtual-height);
+  .grid-adaptive {
+    grid-template-columns: repeat(var(--grid-cols-base, 1), 1fr);
   }
 
-  :deep(.video-card-container--skeleton) {
-    box-sizing: border-box;
-    height: var(--bew-video-card-virtual-height);
-    max-height: var(--bew-video-card-virtual-height);
-    overflow: hidden;
+  @container (min-width: 640px) {
+    .grid-adaptive {
+      grid-template-columns: repeat(var(--grid-cols-sm, 2), 1fr);
+    }
   }
+
+  @container (min-width: 768px) {
+    .grid-adaptive {
+      grid-template-columns: repeat(var(--grid-cols-md, 3), 1fr);
+    }
+  }
+
+  @container (min-width: 1024px) {
+    .grid-adaptive {
+      grid-template-columns: repeat(var(--grid-cols-lg, 4), 1fr);
+    }
+  }
+
+  @container (min-width: 1280px) {
+    .grid-adaptive {
+      grid-template-columns: repeat(var(--grid-cols-xl, 5), 1fr);
+    }
+  }
+
+  @container (min-width: 1536px) {
+    .grid-adaptive {
+      grid-template-columns: repeat(var(--grid-cols-xxl, 6), 1fr);
+    }
+  }
+}
+
+.grid-one-column {
+  display: grid;
+  grid-template-columns: repeat(1, 1fr);
+  gap: 16px;
+  contain: layout style;
+  align-items: stretch;
 }
 
 .video-card-grid-container {
-  min-width: 0;
-  max-width: 100%;
   overflow-anchor: none;
 
   &.is-firefox :deep(.video-card-container) {
@@ -1282,6 +1023,7 @@ function getUniqueKey(item: T, index: number): string | number {
 }
 
 .load-more-sentinel {
+  grid-column: 1 / -1;
   width: 100%;
   height: 1px;
   overflow-anchor: none;

--- a/src/composables/useGridLayout.ts
+++ b/src/composables/useGridLayout.ts
@@ -1,0 +1,27 @@
+import type { CSSProperties } from 'vue'
+import { computed } from 'vue'
+
+import type { GridLayoutType } from '~/logic'
+import { settings } from '~/logic'
+
+export function useGridLayout(gridLayout: () => GridLayoutType) {
+  const gridCssVars = computed<CSSProperties>(() => ({
+    '--grid-cols-base': settings.value.gridColumns.base,
+    '--grid-cols-sm': settings.value.gridColumns.sm,
+    '--grid-cols-md': settings.value.gridColumns.md,
+    '--grid-cols-lg': settings.value.gridColumns.lg,
+    '--grid-cols-xl': settings.value.gridColumns.xl,
+    '--grid-cols-xxl': settings.value.gridColumns.xxl,
+  }))
+
+  const gridClass = computed((): string => {
+    const layout = gridLayout()
+    if (layout === 'adaptive')
+      return 'grid-adaptive'
+    if (layout === 'twoColumns')
+      return 'grid-two-columns'
+    return 'grid-one-column'
+  })
+
+  return { gridClass, gridCssVars }
+}


### PR DESCRIPTION
## 背景

首页推荐流快速滚动时存在明显掉帧、卡顿与可见的「整块跳动」。经排查（Chrome trace + 逐项 bisection），确认虚拟滚动（@tanstack/vue-virtual）的窗口频繁增删、卡片反复挂载/卸载是主要开销来源，且分段加载在快速滚动时产生分块跳动感。

参考原生 B 站首页：使用普通 CSS Grid + 近底部追加加载，并未使用虚拟列表/回收。本 PR 据此移除虚拟滚动。

## 改动

- 移除 `@tanstack/vue-virtual` 依赖
- `VideoCardGrid` 改为追加渲染：按顺序保留所有已加载卡片，配合 `content-visibility: auto` 让浏览器自动跳过屏幕外卡片的渲染/绘制成本
- 所有网格调用方（首页推荐、关注、直播、入站必刷、排行、订阅合集、收藏等）统一行为
- 抽出 `useGridLayout` 复用网格布局计算
- 关键性能修复：`VideoCardCover` 的稍后再看控件改为按 `isHover || isInWatchLater` 懒挂载，避免每张静止卡片都为 Tooltip/Icon/i18n 付出常驻渲染成本（bisection 定位到这是 always-mounted 开销的主要来源）

## 验证

- `pnpm typecheck`：通过
- `pnpm lint`：通过
- `pnpm test`：通过（3 文件 / 6 测试）

## 影响范围

- 所有使用 `VideoCardGrid` 的页面统一从虚拟滚动改为追加渲染
- 卡片功能完整保留（封面、统计、稍后再看、预览、菜单等），仅延迟稍后再看控件挂载时机
- 移除一个生产依赖（@tanstack/vue-virtual）
