### PR TITLE
feat: Dock 栏自动隐藏时支持始终显示操作按钮

### DIFF
--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -333,6 +333,7 @@ settings:
   disable_dock_glowing_effect: 关闭 Dock 栏发光效果
   disable_light_dark_mode_switcher: 禁用亮/暗色模式切换按钮
   back_to_top_and_refresh_buttons_are_separated: 分离回到顶部和刷新按钮
+  always_show_dock_actions_when_auto_hide: 自动隐藏 Dock 栏时始终显示操作按钮
   sidebar_position: 侧边栏位置
   auto_hide_sidebar: 自动隐藏侧边栏
   theme: 主题

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -276,6 +276,7 @@ settings:
   disable_dock_glowing_effect: 關閉 Dock 發光效果
   disable_light_dark_mode_switcher: 關閉淺/深色模式切換按鈕
   back_to_top_and_refresh_buttons_are_separated: 分離回到頂部列和重新整理按鈕
+  always_show_dock_actions_when_auto_hide: 自動隱藏 Dock 時始終顯示操作按鈕
   sidebar_position: 側邊欄位置
   auto_hide_sidebar: 自動隱藏側邊欄
   theme: 主題

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -304,6 +304,7 @@ settings:
   disable_dock_glowing_effect: Disable the dock glowing effect
   disable_light_dark_mode_switcher: Disable light/dark mode switcher
   back_to_top_and_refresh_buttons_are_separated: Separate Back to Top and Refresh Buttons
+  always_show_dock_actions_when_auto_hide: Always show action buttons when the dock auto-hides
   sidebar_position: Sidebar position
   auto_hide_sidebar: Automatically hide the sidebar
   theme: Theme

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -254,6 +254,7 @@ settings:
   disable_dock_glowing_effect: 熄咗 Dock 發光效果去
   disable_light_dark_mode_switcher: 閂咗淺 / 深色主題切換粒掣去
   back_to_top_and_refresh_buttons_are_separated: 分離返到最篤同重新整理掣
+  always_show_dock_actions_when_auto_hide: 自動收埋 Dock 時照顯示操作掣
   sidebar_position: 側邊欄位置
   auto_hide_sidebar: 自動收埋側邊欄
   theme: 色系

--- a/src/components/Dock/Dock.vue
+++ b/src/components/Dock/Dock.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { Icon } from '@iconify/vue'
 import { useElementSize, useWindowSize } from '@vueuse/core'
+import type { CSSProperties } from 'vue'
 import { computed, ref } from 'vue'
 
 import { UndoForwardState, useBewlyApp } from '~/composables/useAppProvider'
@@ -150,6 +151,26 @@ const showBackToTopOrRefreshActions = computed((): boolean => {
  */
 const shouldShowUndoForwardButtons = computed((): boolean => {
   return props.activatedPage === AppPage.Home && homeActivatedPage.value === HomeSubPage.ForYou
+})
+
+const showUndoForwardActions = computed((): boolean => {
+  return shouldShowUndoForwardButtons.value && (showUndo.value || showForward.value) && settings.value.enableUndoRefreshButton
+})
+
+const showDockActionButtons = computed((): boolean => {
+  return showBackToTopOrRefreshActions.value || showUndoForwardActions.value
+})
+
+const detachDockActionButtons = computed((): boolean => {
+  return settings.value.autoHideDock && settings.value.alwaysShowDockActionsWhenAutoHide
+})
+
+const showInlineDockActionButtons = computed((): boolean => {
+  return showDockActionButtons.value && !detachDockActionButtons.value
+})
+
+const showDetachedDockActionButtons = computed((): boolean => {
+  return showDockActionButtons.value && detachDockActionButtons.value
 })
 
 watch(() => settings.value.autoHideDock, (newValue) => {
@@ -312,7 +333,11 @@ const dockScale = computed((): number => {
   let additionalHeight = 0
   let additionalWidth = 0
 
-  if (settings.value.dockPosition === 'bottom') {
+  if (detachDockActionButtons.value) {
+    additionalHeight = 0
+    additionalWidth = 0
+  }
+  else if (settings.value.dockPosition === 'bottom') {
     const maxButtonCount = settings.value.backToTopAndRefreshButtonsAreSeparated ? 2 : 1
     const maxUndoForwardButtonCount = settings.value.enableUndoRefreshButton ? 1 : 0
     additionalWidth = (maxButtonCount + maxUndoForwardButtonCount) * buttonSize + maxButtonCount * buttonGap
@@ -337,6 +362,41 @@ const dockScale = computed((): number => {
 
   // Use the smaller scale to ensure dock fits in both dimensions
   return Math.min(heightScale, widthScale)
+})
+
+const dockActionButtonsStyle = computed<CSSProperties>(() => {
+  return {
+    bottom: settings.value.dockPosition === 'bottom' ? 'unset' : 0,
+    right: settings.value.dockPosition === 'bottom' ? 0 : 'unset',
+    transform: settings.value.dockPosition === 'bottom' ? 'translate(100%, 0)' : 'translateY(100%)',
+    flexDirection: settings.value.dockPosition === 'bottom' ? 'row' : 'column',
+  }
+})
+
+const detachedDockActionButtonsStyle = computed<CSSProperties>(() => {
+  const scale = dockScale.value
+  const gap = 8
+  const actionButtonSize = windowWidth.value >= 1024 ? 45 : 35
+  const sideActionInset = `${gap + Math.max(0, ((dockWidth.value - actionButtonSize) * scale) / 2)}px`
+
+  if (settings.value.dockPosition === 'bottom') {
+    return {
+      left: `calc(50% + ${(dockWidth.value * scale) / 2 + gap}px)`,
+      bottom: '8px',
+      transform: `scale(${scale})`,
+      transformOrigin: 'left bottom',
+      flexDirection: 'row',
+    }
+  }
+
+  return {
+    top: `calc(50% + ${(dockHeight.value * scale) / 2 + gap}px)`,
+    left: settings.value.dockPosition === 'left' ? sideActionInset : 'unset',
+    right: settings.value.dockPosition === 'right' ? sideActionInset : 'unset',
+    transform: `scale(${scale})`,
+    transformOrigin: settings.value.dockPosition === 'left' ? 'left top' : 'right top',
+    flexDirection: 'column',
+  }
 })
 
 const dockTransformStyle = computed((): { transform: string, transformOrigin: string } => {
@@ -565,13 +625,8 @@ onUnmounted(() => {
 
       <!-- Back to top & refresh buttons -->
       <div
-        v-if="showBackToTopOrRefreshActions"
-        :style="{
-          bottom: settings.dockPosition === 'bottom' ? 'unset' : 0,
-          right: settings.dockPosition === 'bottom' ? 0 : 'unset',
-          transform: settings.dockPosition === 'bottom' ? 'translate(100%, 0)' : 'translateY(100%)',
-          flexDirection: settings.dockPosition === 'bottom' ? 'row' : 'column',
-        }"
+        v-if="showInlineDockActionButtons"
+        :style="dockActionButtonsStyle"
         pos="absolute"
         flex="~ gap-2"
       >
@@ -627,7 +682,7 @@ onUnmounted(() => {
         <!-- 将原来的两个按钮替换为一个 -->
         <Transition name="fade">
           <button
-            v-if="shouldShowUndoForwardButtons && (showUndo || showForward) && settings.enableUndoRefreshButton"
+            v-if="showUndoForwardActions"
             class="back-to-top-or-refresh-btn"
             :class="{
               inactive: hoveringDockItem.themeMode && isDark,
@@ -647,6 +702,58 @@ onUnmounted(() => {
           </button>
         </Transition>
       </div>
+    </div>
+
+    <!-- Detached action buttons stay visible when the dock itself is auto-hidden. -->
+    <div
+      v-if="showDetachedDockActionButtons"
+      class="detached-dock-actions"
+      :style="detachedDockActionButtonsStyle"
+      pos="absolute"
+      flex="~ gap-2"
+    >
+      <Transition name="fade">
+        <button
+          v-if="showBackToTopOrRefreshButton && canRefreshCurrentPage"
+          class="back-to-top-or-refresh-btn"
+          @click="handleBackToTopOrRefresh('refresh')"
+        >
+          <Icon
+            icon="line-md:rotate-270"
+            shrink-0 rotate-90 absolute text-2xl
+          />
+        </button>
+      </Transition>
+      <Transition name="fade">
+        <button
+          v-if="showBackToTopOrRefreshButton && !reachTop"
+          class="back-to-top-or-refresh-btn"
+          @click="handleBackToTopOrRefresh('backToTop')"
+        >
+          <Icon
+            icon="line-md:arrow-small-up"
+            shrink-0 absolute text-2xl
+          />
+        </button>
+      </Transition>
+      <Transition name="fade">
+        <button
+          v-if="showUndoForwardActions"
+          class="back-to-top-or-refresh-btn"
+          @click="handleHistoryNavigation"
+        >
+          <Icon
+            v-if="showUndo"
+            icon="mdi:undo-variant"
+            shrink-0 absolute text-2xl
+          />
+          <Icon
+            v-else-if="showForward"
+            icon="mdi:redo-variant"
+            shrink-0 absolute text-2xl
+          />
+        </button>
+      </Transition>
     </div>
   </aside>
 </template>
@@ -675,6 +782,28 @@ onUnmounted(() => {
 
   &-bottom {
     --uno: "left-0 bottom-0 w-full h-14px hover-h-60px";
+  }
+}
+
+.detached-dock-actions {
+  --uno: "pointer-events-auto z-1";
+
+  .back-to-top-or-refresh-btn {
+    --uno: "transform active:important-scale-90 hover:scale-110";
+    --uno: "lg:w-45px w-35px lg:h-45px h-35px";
+    --uno: "grid place-items-center";
+    --uno: "filter-$bew-filter-glass-1";
+    --uno: "bg-$bew-elevated hover:bg-$bew-content-hover";
+    --uno: "rounded-full shadow-$bew-shadow-2 border-1 border-$bew-border-color";
+
+    backdrop-filter: var(--bew-filter-glass-1);
+    transition:
+      transform 300ms cubic-bezier(0.34, 2, 0.6, 1),
+      background 300ms ease,
+      color 300ms ease,
+      box-shadow 300ms ease,
+      opacity 600ms ease;
+    box-shadow: var(--bew-shadow-edge-glow-1), var(--bew-shadow-2);
   }
 }
 

--- a/src/components/Settings/PluginComponentsAndPages/DockAndSidebar/DockAndSidebar.vue
+++ b/src/components/Settings/PluginComponentsAndPages/DockAndSidebar/DockAndSidebar.vue
@@ -165,6 +165,9 @@ function handleToggleDockItem(dockItem: any) {
       <SettingsItem :title="$t('settings.back_to_top_and_refresh_buttons_are_separated')" right-width="auto">
         <Radio v-model="settings.backToTopAndRefreshButtonsAreSeparated" />
       </SettingsItem>
+      <SettingsItem :title="$t('settings.always_show_dock_actions_when_auto_hide')" right-width="auto">
+        <Radio v-model="settings.alwaysShowDockActionsWhenAutoHide" />
+      </SettingsItem>
       <SettingsItem :title="$t('settings.enable_undo_refresh_button')" :desc="$t('settings.enable_undo_refresh_button_desc')" right-width="auto">
         <Radio v-model="settings.enableUndoRefreshButton" />
       </SettingsItem>

--- a/src/logic/storage.ts
+++ b/src/logic/storage.ts
@@ -242,6 +242,7 @@ export interface Settings {
   disableDockGlowingEffect: boolean
   disableLightDarkModeSwitcherOnDock: boolean
   backToTopAndRefreshButtonsAreSeparated: boolean
+  alwaysShowDockActionsWhenAutoHide: boolean
   enableUndoRefreshButton: boolean // 添加撤销刷新按钮配置项
 
   sidebarPosition: 'left' | 'right'
@@ -465,6 +466,7 @@ export const originalSettings: Settings = {
   disableDockGlowingEffect: false,
   disableLightDarkModeSwitcherOnDock: false,
   backToTopAndRefreshButtonsAreSeparated: true,
+  alwaysShowDockActionsWhenAutoHide: false,
   enableUndoRefreshButton: true, // 默认开启撤销刷新按钮
 
   sidebarPosition: 'right',


### PR DESCRIPTION
## 背景

开启「自动隐藏 Dock 栏」后，回到顶部 / 刷新 / 撤销前进等操作按钮也会随 Dock 一起隐藏，需要先唤出 Dock 才能点击。本 PR 新增一个选项，让这些操作按钮在 Dock 自动隐藏时仍保持可见。

## 改动

- 新增设置项 `alwaysShowDockActionsWhenAutoHide`（默认关闭，保持原行为）
- 开启后，操作按钮从 Dock 内联布局「脱离」为独立悬浮元素，随 Dock 缩放与位置（底部/左/右）自动对齐定位
- 设置面板「Dock 与侧边栏」新增对应开关
- 补全 4 种语言文案（cmn-CN / cmn-TW / en / jyut）

## 验证

- `pnpm typecheck`：通过
- `pnpm lint`：通过
- `pnpm test`：通过（3 文件 / 6 测试）

## 影响范围

- 新增选项默认关闭，不影响现有用户行为
