### PR TITLE
添加禁用搜索历史功能

### DIFF
--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -386,6 +386,8 @@ settings:
   show_hot_search_in_search_page_desc: 在搜索页面显示热搜排行榜
   show_search_recommendation: 显示搜索推荐
   show_search_recommendation_desc: 在搜索框中显示推荐的搜索词作为占位符，空白输入时按回车将搜索该推荐词
+  enable_search_history: 启用搜索历史
+  enable_search_history_desc: 启用后，搜索栏将记录和显示您的搜索历史记录。关闭后将清除所有历史记录
   use_plugin_search_results_page: 使用插件搜索结果页
   use_plugin_search_results_page_desc: 启用后，搜索时将使用插件内置的搜索结果页面，支持分类筛选等功能
   depersonalize_search_results: 去个性化搜索

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -329,6 +329,8 @@ settings:
   show_hot_search_in_search_page_desc: 在搜尋頁面顯示熱門搜尋排行榜
   show_search_recommendation: 顯示搜尋推薦
   show_search_recommendation_desc: 在搜尋框中顯示推薦的搜尋詞作為佔位符，空白輸入時按回車將搜尋該推薦詞
+  enable_search_history: 啟用搜尋歷史
+  enable_search_history_desc: 啟用後，搜尋欄將記錄和顯示您的搜尋歷史記錄。關閉後將清除所有歷史記錄
   depersonalize_search_results: 去除個人化搜尋
   depersonalize_search_results_desc: 啟用後，搜尋結果請求不攜帶登入 Cookie。
   individually_set_search_page_wallpaper: 單獨設定搜尋頁背景

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -362,6 +362,8 @@ settings:
   show_hot_search_in_search_page_desc: Display hot search ranking on the search page
   show_search_recommendation: Show search recommendation
   show_search_recommendation_desc: Display recommended search terms as placeholder in the search box, and search for them when pressing Enter with an empty input
+  enable_search_history: Enable search history
+  enable_search_history_desc: When enabled, the search bar will record and display your search history. Disabling this will clear all history
   use_plugin_search_results_page: Use plugin search results page
   use_plugin_search_results_page_desc: When enabled, searches will use the plugin's built-in search results page with category filtering and more features
   depersonalize_search_results: Depersonalized search

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -306,6 +306,8 @@ settings:
   show_hot_search_in_search_page_desc: 喺搵嘢頁面顯示熱搜排行榜
   show_search_recommendation: 顯示搜尋推介
   show_search_recommendation_desc: 喺搜尋框度顯示推介嘅搜尋詞做佔位符,空白輸入時撳回車會搜尋呢個推介詞
+  enable_search_history: 啓用搜尋歷史
+  enable_search_history_desc: 啓用後，搜尋欄會記同顯示你嘅搜尋歷史。關咗之後會剷晒所有歷史
   use_plugin_search_results_page: 使用插件搜尋結果頁
   use_plugin_search_results_page_desc: 開啟後，搜尋會使用插件內置嘅搜尋結果頁，支援分類篩選等功能
   depersonalize_search_results: 去個人化搜尋

--- a/src/components/SearchBar/SearchBar.vue
+++ b/src/components/SearchBar/SearchBar.vue
@@ -155,7 +155,12 @@ watch(isFocus, async (focus) => {
   // 延后加载搜索历史
   if (focus) {
     try {
-      searchHistory.value = await getSearchHistory()
+      if (settings.value.enableSearchHistory) {
+        searchHistory.value = await getSearchHistory()
+      }
+      else {
+        searchHistory.value = []
+      }
     }
     catch (error) {
       console.error('Failed to load search history:', error)
@@ -260,6 +265,14 @@ watch(() => settings.value.showSearchRecommendation, (enabled) => {
   }
 })
 
+// 监听搜索历史设置变化
+watch(() => settings.value.enableSearchHistory, async (enabled, wasEnabled) => {
+  if (wasEnabled === true && enabled === false) {
+    await clearAllSearchHistory()
+    searchHistory.value = []
+  }
+})
+
 // 组件挂载时初始化
 onMounted(() => {
   if (settings.value.showSearchRecommendation) {
@@ -360,15 +373,17 @@ async function navigateToSearchResultPage(rawKeyword: string) {
   if (!normalized)
     return
 
-  const searchItem = {
-    value: normalized,
-    timestamp: Number(new Date()),
-  }
-  try {
-    searchHistory.value = await addSearchHistory(searchItem)
-  }
-  catch (error) {
-    console.error('Failed to add search history:', error)
+  if (settings.value.enableSearchHistory) {
+    const searchItem = {
+      value: normalized,
+      timestamp: Number(new Date()),
+    }
+    try {
+      searchHistory.value = await addSearchHistory(searchItem)
+    }
+    catch (error) {
+      console.error('Failed to add search history:', error)
+    }
   }
 
   // 如果是就地搜索模式，则 emit 事件（这是组件级别的行为设置）

--- a/src/components/Settings/PluginComponentsAndPages/SearchPage/SearchPage.vue
+++ b/src/components/Settings/PluginComponentsAndPages/SearchPage/SearchPage.vue
@@ -62,6 +62,10 @@ function changeSearchBarFocusCharacter(url: string) {
         <Radio v-model="settings.showSearchRecommendation" />
       </SettingsItem>
 
+      <SettingsItem :title="$t('settings.enable_search_history')" :desc="$t('settings.enable_search_history_desc')" right-width="auto">
+        <Radio v-model="settings.enableSearchHistory" />
+      </SettingsItem>
+
       <SettingsItem :title="$t('settings.bg_darkens_when_the_search_bar_is_focused')" right-width="auto">
         <Radio v-model="settings.searchPageDarkenOnSearchFocus" />
       </SettingsItem>

--- a/src/logic/storage.ts
+++ b/src/logic/storage.ts
@@ -280,6 +280,9 @@ export interface Settings {
   // 搜索推荐功能设置
   showSearchRecommendation: boolean
 
+  // 搜索历史功能设置
+  enableSearchHistory: boolean
+
   // 搜索结果页设置
   usePluginSearchResultsPage: boolean
   depersonalizeSearchResults: boolean
@@ -503,6 +506,9 @@ export const originalSettings: Settings = {
 
   // 搜索推荐功能设置
   showSearchRecommendation: false,
+
+  // 搜索历史功能设置
+  enableSearchHistory: true,
 
   // 搜索结果页设置
   usePluginSearchResultsPage: true,


### PR DESCRIPTION
## 修改描述

添加了禁用顶栏和搜索栏搜索历史的功能，可以在设置中开启或者关闭

## 修改

- `src/logic/storage.ts`: 添加 `enableSearchHistory` 设置字段
- `src/components/SearchBar/SearchBar.vue`: 根据设置控制搜索历史的加载、保存和清理
- `src/components/Settings/PluginComponentsAndPages/SearchPage/SearchPage.vue`: 添加开关控件
- `src/_locales/*.yml`: 添加多语言翻译（中文、英文、繁体中文、粤语）

## 测试

1. 加载扩展到浏览器
2. 在搜索框中搜索内容，确认历史记录正常显示
3. 打开设置 → 搜索设置 → 关闭「启用搜索历史」
4. 确认历史记录被清空
5. 再次搜索，确认历史不再保存
6. 重新开启开关，功能恢复正常