### PR TITLE
feat(player): 新增视频默认字幕状态设置

### DIFF
--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -190,6 +190,7 @@ settings:
   video_caption_default_state: 视频默认字幕状态
   video_caption_default_state_desc: 打开视频时自动调整字幕开关，或记住上次状态。
   video_caption_default_state_opt:
+    system: 不启用
     remember: 记住上次状态
     on: 默认开启
     off: 默认关闭

--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -187,6 +187,12 @@ settings:
     system: 不调整
     on: 默认开启
     off: 默认关闭
+  video_caption_default_state: 视频默认字幕状态
+  video_caption_default_state_desc: 打开视频时自动调整字幕开关，或记住上次状态。
+  video_caption_default_state_opt:
+    remember: 记住上次状态
+    on: 默认开启
+    off: 默认关闭
   video_player_mode:
     default: 默认
     web_fullscreen: 网页全屏

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -222,6 +222,12 @@ settings:
     system: 不調整
     on: 預設開啟
     off: 預設關閉
+  video_caption_default_state: 影片預設字幕狀態
+  video_caption_default_state_desc: 開啟影片時自動調整字幕開關，或記住上次狀態。
+  video_caption_default_state_opt:
+    remember: 記住上次狀態
+    on: 預設開啟
+    off: 預設關閉
   video_player_mode:
     default: 預設
     web_fullscreen: 網頁全螢幕

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -225,6 +225,7 @@ settings:
   video_caption_default_state: 影片預設字幕狀態
   video_caption_default_state_desc: 開啟影片時自動調整字幕開關，或記住上次狀態。
   video_caption_default_state_opt:
+    system: 不啟用
     remember: 記住上次狀態
     on: 預設開啟
     off: 預設關閉

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -200,6 +200,12 @@ settings:
     system: Do not adjust
     on: Always enable
     off: Always disable
+  video_caption_default_state: Default caption state
+  video_caption_default_state_desc: Automatically toggle captions when a video loads, or remember last state.
+  video_caption_default_state_opt:
+    remember: Remember last state
+    on: Always enable
+    off: Always disable
   video_player_mode:
     default: Default
     web_fullscreen: Web Fullscreen

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -203,6 +203,7 @@ settings:
   video_caption_default_state: Default caption state
   video_caption_default_state_desc: Automatically toggle captions when a video loads, or remember last state.
   video_caption_default_state_opt:
+    system: Do not enable
     remember: Remember last state
     on: Always enable
     off: Always disable

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -555,6 +555,7 @@ settings:
   video_caption_default_state: 影片預設字幕狀態
   video_caption_default_state_desc: 開片時自動幫你調整字幕開關，或記住上次狀態。
   video_caption_default_state_opt:
+    system: 唔啟用
     remember: 記住上次狀態
     on: 預設開啟
     off: 預設關閉

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -552,6 +552,12 @@ settings:
     system: 唔調整
     on: 預設開啟
     off: 預設關閉
+  video_caption_default_state: 影片預設字幕狀態
+  video_caption_default_state_desc: 開片時自動幫你調整字幕開關，或記住上次狀態。
+  video_caption_default_state_opt:
+    remember: 記住上次狀態
+    on: 預設開啟
+    off: 預設關閉
   video_player_mode:
     default: 預設
     web_fullscreen: 網頁全螢幕

--- a/src/components/Settings/BilibiliFeaturesEnhancement/VideoPlayback/VideoPlayback.vue
+++ b/src/components/Settings/BilibiliFeaturesEnhancement/VideoPlayback/VideoPlayback.vue
@@ -61,6 +61,23 @@ const videoDanmakuDefaultStateOptions = computed(() => {
     },
   ]
 })
+
+const videoCaptionDefaultStateOptions = computed(() => {
+  return [
+    {
+      label: t('settings.video_caption_default_state_opt.remember'),
+      value: 'remember',
+    },
+    {
+      label: t('settings.video_caption_default_state_opt.on'),
+      value: 'on',
+    },
+    {
+      label: t('settings.video_caption_default_state_opt.off'),
+      value: 'off',
+    },
+  ]
+})
 </script>
 
 <template>
@@ -111,6 +128,14 @@ const videoDanmakuDefaultStateOptions = computed(() => {
         right-width="auto"
       >
         <Select v-model="settings.defaultDanmakuState" :options="videoDanmakuDefaultStateOptions" w="160px" />
+      </SettingsItem>
+
+      <SettingsItem
+        :title="t('settings.video_caption_default_state')"
+        :desc="t('settings.video_caption_default_state_desc')"
+        right-width="auto"
+      >
+        <Select v-model="settings.defaultCaptionState" :options="videoCaptionDefaultStateOptions" w="160px" />
       </SettingsItem>
 
       <SettingsItem

--- a/src/components/Settings/BilibiliFeaturesEnhancement/VideoPlayback/VideoPlayback.vue
+++ b/src/components/Settings/BilibiliFeaturesEnhancement/VideoPlayback/VideoPlayback.vue
@@ -65,6 +65,10 @@ const videoDanmakuDefaultStateOptions = computed(() => {
 const videoCaptionDefaultStateOptions = computed(() => {
   return [
     {
+      label: t('settings.video_caption_default_state_opt.system'),
+      value: 'system',
+    },
+    {
       label: t('settings.video_caption_default_state_opt.remember'),
       value: 'remember',
     },

--- a/src/contentScripts/index.ts
+++ b/src/contentScripts/index.ts
@@ -253,6 +253,8 @@ else {
 
     // 如果播放器已经在全屏状态，跳过应用模式（避免互动视频退出全屏）
     if (isInFullscreen || isInWebFullscreen) {
+      applyDefaultDanmakuState()
+      applyDefaultCaptionState()
       hasAppliedPlayerMode = true // 标记已应用，避免重复检查
       return
     }

--- a/src/contentScripts/index.ts
+++ b/src/contentScripts/index.ts
@@ -16,7 +16,7 @@ import { initFavoriteDialogEnhancement } from '~/utils/favoriteDialog'
 import { runWhenIdle } from '~/utils/lazyLoad'
 import { getLocalWallpaper, hasLocalWallpaper, isLocalWallpaperUrl } from '~/utils/localWallpaper'
 import { compareVersions, injectCSS, isElectron, isHomePage, isInIframe, isNotificationPage, isVideoOrBangumiPage, isVideoPlaybackPage } from '~/utils/main'
-import { applyAutoPlayByVideoType, applyDefaultDanmakuState, defaultMode, handleVideoPageNavigation, isCollectionVideo, isPlayerDisplayModeReady, isVideoPage, startAutoExitFullscreenMonitoring, startAutoPlayUserChangeMonitoring, webFullscreen, widescreen } from '~/utils/player'
+import { applyAutoPlayByVideoType, applyDefaultCaptionState, applyDefaultDanmakuState, defaultMode, handleVideoPageNavigation, isCollectionVideo, isPlayerDisplayModeReady, isVideoPage, startAutoExitFullscreenMonitoring, startAutoPlayUserChangeMonitoring, webFullscreen, widescreen } from '~/utils/player'
 import { initRandomPlay, resetRandomPlayInitialization } from '~/utils/randomPlay'
 import { setupShortcutHandlers } from '~/utils/shortcuts'
 import { SVG_ICONS } from '~/utils/svgIcons'
@@ -295,6 +295,7 @@ else {
     }
     setupShortcutHandlers()
     applyDefaultDanmakuState()
+    applyDefaultCaptionState()
     initVerticalVideoZoom()
     // 应用自动连播设置，延迟更长时间确保播放器完全初始化
     setTimeout(() => {

--- a/src/logic/storage.ts
+++ b/src/logic/storage.ts
@@ -346,6 +346,8 @@ export interface Settings {
   defaultVideoPlayerMode: DefaultVideoPlayerMode
   bewlyWidescreenSidebarPosition: BewlyWidescreenSidebarPosition
   defaultDanmakuState: 'system' | 'on' | 'off'
+  defaultCaptionState: 'remember' | 'on' | 'off'
+  lastCaptionState: boolean
   keepCollectionVideoDefaultMode: boolean // 合集视频保持默认模式
   autoExitFullscreenOnEnd: boolean // 全屏播放完毕后自动退出
   autoExitFullscreenExcludeAutoPlay: boolean // 全屏自动退出时排除自动连播
@@ -570,6 +572,8 @@ export const originalSettings: Settings = {
   defaultVideoPlayerMode: 'default',
   bewlyWidescreenSidebarPosition: 'right',
   defaultDanmakuState: 'system',
+  defaultCaptionState: 'off',
+  lastCaptionState: false,
   keepCollectionVideoDefaultMode: false, // 合集视频保持默认模式，默认关闭
   autoExitFullscreenOnEnd: false, // 全屏播放完毕后自动退出，默认关闭
   autoExitFullscreenExcludeAutoPlay: false, // 全屏自动退出时排除自动连播，默认关闭

--- a/src/logic/storage.ts
+++ b/src/logic/storage.ts
@@ -346,7 +346,7 @@ export interface Settings {
   defaultVideoPlayerMode: DefaultVideoPlayerMode
   bewlyWidescreenSidebarPosition: BewlyWidescreenSidebarPosition
   defaultDanmakuState: 'system' | 'on' | 'off'
-  defaultCaptionState: 'remember' | 'on' | 'off'
+  defaultCaptionState: 'system' | 'remember' | 'on' | 'off'
   lastCaptionState: boolean
   keepCollectionVideoDefaultMode: boolean // 合集视频保持默认模式
   autoExitFullscreenOnEnd: boolean // 全屏播放完毕后自动退出

--- a/src/utils/player.ts
+++ b/src/utils/player.ts
@@ -293,6 +293,42 @@ export function applyDefaultDanmakuState() {
   }).start()
 }
 
+// 根据设置应用默认字幕状态
+export function applyDefaultCaptionState() {
+  const preference = settings.value.defaultCaptionState
+  if (!preference)
+    return
+
+  const shouldEnable = preference === 'remember' ? settings.value.lastCaptionState : preference === 'on'
+
+  new RetryTask(20, 500, () => {
+    const closeSwitch = document.querySelector<HTMLElement>('.bpx-player-ctrl-subtitle-close-switch')
+    const languageItem = document.querySelector<HTMLElement>('.bpx-player-ctrl-subtitle-language-item')
+
+    if (closeSwitch && languageItem) {
+      const isCurrentlyOn = !closeSwitch.classList.contains('bpx-state-active')
+      if (isCurrentlyOn === shouldEnable)
+        return true
+
+      if (shouldEnable)
+        languageItem.click()
+      else
+        closeSwitch.click()
+
+      return true
+    }
+
+    return false
+  }).start()
+
+  saveCaptionState(shouldEnable)
+}
+
+// 保存字幕状态，供“记住上次状态”使用
+export function saveCaptionState(enabled: boolean) {
+  settings.value.lastCaptionState = enabled
+}
+
 // 检测是否为合集视频
 export function isCollectionVideo(): boolean {
   // 检测多P视频选集
@@ -779,6 +815,7 @@ export function toggleCaption() {
     else {
       closeSwitch.click()
     }
+    saveCaptionState(isClosed)
     return
   }
 

--- a/src/utils/player.ts
+++ b/src/utils/player.ts
@@ -296,10 +296,11 @@ export function applyDefaultDanmakuState() {
 // 根据设置应用默认字幕状态
 export function applyDefaultCaptionState() {
   const preference = settings.value.defaultCaptionState
-  if (!preference)
+  if (!preference || preference === 'system')
     return
 
-  const shouldEnable = preference === 'remember' ? settings.value.lastCaptionState : preference === 'on'
+  const isRemember = preference === 'remember'
+  const shouldEnable = isRemember ? settings.value.lastCaptionState : preference === 'on'
 
   new RetryTask(20, 500, () => {
     const closeSwitch = document.querySelector<HTMLElement>('.bpx-player-ctrl-subtitle-close-switch')
@@ -321,10 +322,11 @@ export function applyDefaultCaptionState() {
     return false
   }).start()
 
-  saveCaptionState(shouldEnable)
+  if (isRemember)
+    saveCaptionState(shouldEnable)
 }
 
-// 保存字幕状态，供“记住上次状态”使用
+// 保存字幕状态，供"记住上次状态"使用
 export function saveCaptionState(enabled: boolean) {
   settings.value.lastCaptionState = enabled
 }
@@ -815,7 +817,8 @@ export function toggleCaption() {
     else {
       closeSwitch.click()
     }
-    saveCaptionState(isClosed)
+    if (settings.value.defaultCaptionState === 'remember')
+      saveCaptionState(isClosed)
     return
   }
 


### PR DESCRIPTION
### 概述

新增视频默认字幕状态设置项，位于 设置 -> Bilibili功能 -> 播放器 -> 播放器组件 中，提供三个选项：

- **默认关闭**：每次打开视频强制关闭字幕（默认值，与 B站播放器原生行为一致）
- **默认开启**：每次打开视频强制开启字幕
- **记住上次状态**：记录通过插件快捷键（C 键）切换的字幕状态，下次视频加载时恢复

### 动机

已阅读 #646，B站 AI 字幕默认开启确实会对部分用户造成困扰。

但也有反向需求存在。比如连续观看课程类视频时，字幕持续开启是刚需。因此提供三种策略，让用户自行选择。

### 实现

参照已有的视频默认弹幕状态实现，新增 applyDefaultCaptionState() 函数，在视频页初始化时控制字幕开关。BPX 播放器的状态检测基于 .bpx-player-ctrl-subtitle-close-switch 元素的 bpx-state-active class。

涉及文件：
- src/logic/storage.ts — 新增 defaultCaptionState 和 lastCaptionState 存储字段
- src/utils/player.ts — 新增 applyDefaultCaptionState()、saveCaptionState()
- src/contentScripts/index.ts — 视频页初始化时调用
- src/components/Settings/.../VideoPlayback.vue — 设置 UI
- src/_locales/*.yml — 4 个语言文件的 i18n 键值

### 新增修复

修复全屏下切换视频P时字幕未启用的问题

当 B站播放器处于全屏/网页全屏状态时，无论是自动连播还是手动切换至下一 P 视频，applyDefaultPlayerMode() 均会因全屏保护逻辑提前 return，导致 applyDefaultCaptionState() 未被调用。

在全屏早期返回分支中补充 applyDefaultDanmakuState() 和 applyDefaultCaptionState() 调用，确保全屏下切 P 时字幕状态仍能被正确恢复。
