### PR TITLE
fix: 修复净化分享链接时嵌套方括号未闭合的问题 (#694)

### DIFF
--- a/src/inject/index.ts
+++ b/src/inject/index.ts
@@ -586,21 +586,42 @@ else {
     catch { return url }
   }
 
+  // 提取文本中第一个成对的「【...】」内容，支持嵌套
+  function extractFirstBracketContent(text: string): string | null {
+    const start = text.indexOf('【')
+    if (start === -1)
+      return null
+    let depth = 0
+    for (let i = start; i < text.length; i++) {
+      if (text[i] === '【')
+        depth++
+      else if (text[i] === '】')
+        depth--
+      if (depth === 0 && i > start)
+        return text.slice(start + 1, i)
+    }
+    return null
+  }
+
   function cleanShareText(text: string, includeTitle: boolean, removeTracking: boolean): string {
-    const shareMatch = text.match(/【(.+?)】\s*(https?:\/\/\S+)/)
-    if (shareMatch) {
-      let url = shareMatch[2]
-      if (removeTracking)
-        url = cleanUrl(url)
-      return includeTitle ? `${shareMatch[1]} ${url}` : url
+    // 分别解析标题与链接，标题内部可能存在嵌套的「【...】」
+    const title = extractFirstBracketContent(text)
+    const urlMatch = text.match(/(https?:\/\/\S+)/)
+    const url = urlMatch?.[1]
+
+    if (url) {
+      const cleanedUrl = removeTracking ? cleanUrl(url) : url
+      if (title)
+        return includeTitle ? `${title} ${cleanedUrl}` : cleanedUrl
+      return cleanedUrl
     }
-    if (removeTracking) {
-      return text.replace(/(https?:\/\/\S+)/g, url => cleanUrl(url))
-    }
+
+    if (removeTracking)
+      return text.replace(/(https?:\/\/\S+)/g, u => cleanUrl(u))
     return text
   }
 
-  // Intercept navigator.clipboard.writeText to enable clean share link feature
+  // 拦截 navigator.clipboard.writeText，启用净化分享链接功能
   const originalWriteText = navigator.clipboard.writeText.bind(navigator.clipboard)
   navigator.clipboard.writeText = function (text: string) {
     if (!currentSettings?.enableCleanShareLink)

--- a/src/utils/main.ts
+++ b/src/utils/main.ts
@@ -447,7 +447,7 @@ export function isInIframe(): boolean {
 }
 
 /**
- * Bilibili tracking parameters to be removed from URLs
+ * 需要从链接中移除的 B 站追踪参数
  */
 const BILIBILI_TRACKING_PARAMS = [
   'spm_id_from',
@@ -521,29 +521,38 @@ export function cleanBilibiliShareText(
 ): string {
   const { includeTitle = false, removeTrackingParams = true } = options
 
-  // Match Bilibili share text format: 【Title】 URL
-  const shareTextRegex = /【(.+?)】\s*(https?:\/\/\S+)/
-  const match = text.match(shareTextRegex)
-
-  if (match) {
-    const title = match[1]
-    let url = match[2]
-
-    if (removeTrackingParams)
-      url = cleanBilibiliUrl(url)
-
-    if (includeTitle)
-      return `${title} ${url}`
-
-    return url
+  // 提取文本中第一个成对的「【...】」内容，支持嵌套
+  const extractFirstBracketContent = (s: string): string | null => {
+    const start = s.indexOf('【')
+    if (start === -1)
+      return null
+    let depth = 0
+    for (let i = start; i < s.length; i++) {
+      if (s[i] === '【')
+        depth++
+      else if (s[i] === '】')
+        depth--
+      if (depth === 0 && i > start)
+        return s.slice(start + 1, i)
+    }
+    return null
   }
 
-  // If it doesn't match the share format, try to clean URLs in the text
-  const urlRegex = /(https?:\/\/\S+)/g
+  // 分别解析标题与链接，标题内部可能存在嵌套的「【...】」
+  const title = extractFirstBracketContent(text)
+  const urlMatch = text.match(/(https?:\/\/\S+)/)
+  const url = urlMatch?.[1]
+
+  if (url) {
+    const cleanedUrl = removeTrackingParams ? cleanBilibiliUrl(url) : url
+    if (title)
+      return includeTitle ? `${title} ${cleanedUrl}` : cleanedUrl
+    return cleanedUrl
+  }
+
+  // 不符合分享格式时，尝试清理文本中的链接
   if (removeTrackingParams) {
-    return text.replace(urlRegex, (url) => {
-      return cleanBilibiliUrl(url)
-    })
+    return text.replace(/(https?:\/\/\S+)/g, url => cleanBilibiliUrl(url))
   }
 
   return text


### PR DESCRIPTION
### 修改描述
修复了勾选「精准空降」分享时，视频标题若包含嵌套的中文方括号（如 【高一数学】 ），净化后的链接会出现多余的、不闭合的方括号的问题

### 修改
- src/utils/main.ts : 重写 cleanBilibiliShareText ，改用平衡括号解析提取标题，正确处理标题内嵌套的「【...】」
- src/inject/index.ts : 同步修改 cleanShareText （分享按钮剪贴板拦截路径），采用相同的平衡括号解析逻辑

### 测试
1. 加载扩展到浏览器
2. 打开含有“【】”的视频（使用 https://www.bilibili.com/video/BV1QeNc6iE84/），在分享面板勾选「精准空降」并选择一个跳转时间点
3. 点击复制链接，确认粘贴出的文本中方括号正确闭合