### PR TITLE
fix: 修复直播页刷新按钮、加速快捷键和暗色模式动态页背景图三个问题

### DIFF
--- a/src/components/VideoCardGrid.vue
+++ b/src/components/VideoCardGrid.vue
@@ -901,7 +901,11 @@ function getUniqueKey(item: T, index: number): string | number {
     />
 
     <!-- 无更多内容提示（仅在有数据时显示，避免与空列表提示重复） -->
-    <Empty v-if="noMoreContent && !needToLoginFirst && items.length > 0" class="pb-4" :description="$t('common.no_more_content')" />
+    <Empty v-if="noMoreContent && !needToLoginFirst && items.length > 0" class="pb-4" :description="$t('common.no_more_content')">
+      <Button type="primary" @click="handleRefresh">
+        {{ refreshButtonText || $t('common.operation.refresh') }}
+      </Button>
+    </Empty>
   </div>
 </template>
 

--- a/src/styles/adaptedStyles/pages/momentsPage.scss
+++ b/src/styles/adaptedStyles/pages/momentsPage.scss
@@ -81,7 +81,7 @@
 
   &.dark {
     #app div.bg {
-      opacity: 0;
+      opacity: 0.15;
     }
 
     .bili-dyn-home--member,

--- a/src/utils/shortcuts.ts
+++ b/src/utils/shortcuts.ts
@@ -185,7 +185,9 @@ export function setupShortcutHandlers() {
             continue
 
           // 如果快捷键匹配
-          if (configKey.toLowerCase() === keyCombo.toLowerCase()) {
+          // 兼容：配置为 '+' 时，允许直接按 '=' 键触发（标准键盘上 '+' 需要 Shift+=）
+          if (configKey.toLowerCase() === keyCombo.toLowerCase()
+            || (configKey === '+' && keyCombo === '=')) {
             // 获取处理函数
             const handler = shortcutHandlers[id]
             if (handler) {


### PR DESCRIPTION
## 修复内容

一次性修复了在issues 673 637 585里提及的 3 个低风险问题：

### 1. 首页直播页面无法刷新 (#673)
- **原因**: `VideoCardGrid` 的"无更多内容"状态缺少刷新按钮
- **修复**: 在有数据时的"无更多内容"提示中添加刷新按钮

### 2. 加快速度默认快捷键无法直接使用 (#637)
- **原因**: 标准键盘上 `+` 需要 `Shift+=`，而 `generateKeyCombo` 会生成 `Shift++`；直接按 `=` 键生成 `=`，两者都不匹配配置的 `+`
- **修复**: 在匹配逻辑中增加兼容：配置为 `+` 时，直接按 `=` 也可触发，保持向后兼容

### 3. 暗色模式下动态页背景图不显示 (#585)
- **原因**: `momentsPage.scss` 暗色模式下 `#app div.bg { opacity: 0 }` 隐藏了背景图
- **修复**: 改为 `opacity: 0.15`

## 改动文件
- `src/components/VideoCardGrid.vue` — 添加刷新按钮
- `src/utils/shortcuts.ts` — 快捷键匹配兼容
- `src/styles/adaptedStyles/pages/momentsPage.scss` — 暗色模式背景透明度

## 测试
- [x] 直播页底部刷新按钮可点击并触发重新加载
- [x] 视频播放页直接按 `=` 键可加速播放
- [x] 暗色模式下动态详情页背景图可见