### PR TITLE
fix(block-ads): remove empty feed card slots

### DIFF
--- a/src/contentScripts/features/blockUselessFeedCards.ts
+++ b/src/contentScripts/features/blockUselessFeedCards.ts
@@ -1,13 +1,21 @@
 const BLOCKED_FEED_CARD_CLASS = 'bewly-blocked-feed-card'
+const VIDEO_CARD_CLASS = 'bili-video-card'
 
 // Homepage recommended cards (that do NOT support "not interested")
 const RCMD_VIDEO_CARD_SELECTOR = '.bili-video-card.is-rcmd:not(.enable-no-interest)'
+const FEED_CARD_SELECTOR = '.feed-card'
+const OBSERVER_OPTIONS: MutationObserverInit = {
+  attributeFilter: ['class'],
+  attributeOldValue: true,
+  attributes: true,
+  childList: true,
+  subtree: true,
+}
 
 let feedCardObserver: MutationObserver | null = null
 let observeRoot: Element | null = null
 let flushScheduled = false
 const pendingRoots = new Set<Element>()
-const recheckScheduled = new WeakSet<HTMLElement>()
 
 function getObserveRoot(): Element {
   // Prefer the feed container if it exists; fallback to body.
@@ -25,7 +33,7 @@ function ensureObserveRoot() {
 
   try {
     feedCardObserver.disconnect()
-    feedCardObserver.observe(preferred, { childList: true, subtree: true })
+    feedCardObserver.observe(preferred, OBSERVER_OPTIONS)
     observeRoot = preferred
   }
   catch {
@@ -33,42 +41,22 @@ function ensureObserveRoot() {
   }
 }
 
-function scheduleRecheckBlockedFeedCard(feedCard: HTMLElement) {
-  if (recheckScheduled.has(feedCard))
-    return
-
-  recheckScheduled.add(feedCard)
-
-  // Defensive: some classes are attached asynchronously after upgrade/hydration.
-  window.setTimeout(() => {
-    recheckScheduled.delete(feedCard)
-
-    if (!feedCard.isConnected)
-      return
-
-    if (!feedCard.querySelector(RCMD_VIDEO_CARD_SELECTOR)) {
-      feedCard.classList.remove(BLOCKED_FEED_CARD_CLASS)
-    }
-  }, 1500)
-}
-
-function markBlockedFeedCardFromVideoCard(videoCard: Element) {
-  const feedCard = videoCard.closest<HTMLElement>('.feed-card')
-  if (!feedCard)
-    return
-
-  if (!feedCard.classList.contains(BLOCKED_FEED_CARD_CLASS)) {
-    feedCard.classList.add(BLOCKED_FEED_CARD_CLASS)
-    scheduleRecheckBlockedFeedCard(feedCard)
-  }
+function syncFeedCard(feedCard: HTMLElement) {
+  feedCard.classList.toggle(
+    BLOCKED_FEED_CARD_CLASS,
+    feedCard.querySelector(RCMD_VIDEO_CARD_SELECTOR) !== null,
+  )
 }
 
 function scanForRcmdCards(root: ParentNode) {
-  // When root itself is a target element
-  if (root instanceof Element && root.matches(RCMD_VIDEO_CARD_SELECTOR))
-    markBlockedFeedCardFromVideoCard(root)
+  // An inserted or updated node can be inside an existing feed card.
+  if (root instanceof Element) {
+    const closestFeedCard = root.closest<HTMLElement>(FEED_CARD_SELECTOR)
+    if (closestFeedCard)
+      syncFeedCard(closestFeedCard)
+  }
 
-  root.querySelectorAll?.(RCMD_VIDEO_CARD_SELECTOR).forEach(markBlockedFeedCardFromVideoCard)
+  root.querySelectorAll?.<HTMLElement>(FEED_CARD_SELECTOR).forEach(syncFeedCard)
 }
 
 function flushPending() {
@@ -100,6 +88,21 @@ function start() {
 
   feedCardObserver = new MutationObserver((mutations) => {
     for (const mutation of mutations) {
+      if (mutation.type === 'attributes') {
+        const target = mutation.target
+        const wasVideoCard = mutation.oldValue?.split(/\s+/).includes(VIDEO_CARD_CLASS)
+
+        // Bilibili attaches recommendation classes asynchronously during hydration.
+        if (target instanceof Element && (target.classList.contains(VIDEO_CARD_CLASS) || wasVideoCard))
+          pendingRoots.add(target)
+
+        continue
+      }
+
+      // If the matching child is removed, resync its existing feed-card parent.
+      if (mutation.removedNodes.length > 0 && mutation.target instanceof Element)
+        pendingRoots.add(mutation.target)
+
       for (let index = 0; index < mutation.addedNodes.length; index++) {
         const node = mutation.addedNodes[index]
         if (node.nodeType !== Node.ELEMENT_NODE)
@@ -113,7 +116,7 @@ function start() {
   })
 
   observeRoot = getObserveRoot()
-  feedCardObserver.observe(observeRoot, { childList: true, subtree: true })
+  feedCardObserver.observe(observeRoot, OBSERVER_OPTIONS)
 }
 
 function stop() {

--- a/src/tests/blockUselessFeedCards.spec.ts
+++ b/src/tests/blockUselessFeedCards.spec.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { setUselessFeedCardBlockerEnabled } from '~/contentScripts/features/blockUselessFeedCards'
+
+const BLOCKED_FEED_CARD_CLASS = 'bewly-blocked-feed-card'
+
+async function flushCardUpdates() {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('useless homepage feed card blocker', () => {
+  beforeEach(() => {
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0)
+      return 1
+    })
+    document.body.replaceChildren()
+  })
+
+  afterEach(() => {
+    setUselessFeedCardBlockerEnabled(false)
+    vi.unstubAllGlobals()
+    document.body.replaceChildren()
+  })
+
+  it('marks the outer feed card when recommendation classes are attached asynchronously', async () => {
+    const feedCard = document.createElement('div')
+    feedCard.className = 'feed-card'
+
+    const videoCard = document.createElement('div')
+    videoCard.className = 'bili-video-card'
+    feedCard.append(videoCard)
+    document.body.append(feedCard)
+
+    setUselessFeedCardBlockerEnabled(true)
+    expect(feedCard.classList.contains(BLOCKED_FEED_CARD_CLASS)).toBe(false)
+
+    videoCard.classList.add('is-rcmd')
+    await flushCardUpdates()
+
+    expect(feedCard.classList.contains(BLOCKED_FEED_CARD_CLASS)).toBe(true)
+  })
+
+  it('removes the outer marker when a card stops matching', async () => {
+    const feedCard = document.createElement('div')
+    feedCard.className = 'feed-card'
+
+    const videoCard = document.createElement('div')
+    videoCard.className = 'bili-video-card is-rcmd'
+    feedCard.append(videoCard)
+    document.body.append(feedCard)
+
+    setUselessFeedCardBlockerEnabled(true)
+    expect(feedCard.classList.contains(BLOCKED_FEED_CARD_CLASS)).toBe(true)
+
+    videoCard.classList.add('enable-no-interest')
+    await flushCardUpdates()
+
+    expect(feedCard.classList.contains(BLOCKED_FEED_CARD_CLASS)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- Keep the homepage feed layout compact when blocked recommendation cards are removed.
- Observe asynchronous recommendation card class changes and resync the outer `.feed-card` marker.
- Remove stale markers when cards stop matching or their children are removed.
- Add regression coverage for asynchronous card state changes.

## Root cause

Bilibili attaches recommendation classes asynchronously during hydration. The previous observer only watched child-list mutations, so CSS could hide the inner advertisement card before the outer `.feed-card` received its marker. The still-visible wrapper continued occupying a grid slot and left an empty gap.

## Validation

- `corepack pnpm test` (8 tests passed)
- `corepack pnpm typecheck`
- `corepack pnpm lint`
- `corepack pnpm lint-staged`

Fixes #789
