### PR TITLE
fix: 修复视频小窗放大按钮遮挡关闭按钮

### DIFF
--- a/src/tests/verticalVideoZoom.spec.ts
+++ b/src/tests/verticalVideoZoom.spec.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { initVerticalVideoZoom, resetVerticalVideoZoom } from '~/utils/verticalVideoZoom'
+
+vi.mock('~/utils/main', () => ({
+  injectCSS: (css: string, element: HTMLElement | ShadowRoot = document.documentElement) => {
+    const style = document.createElement('style')
+    style.textContent = css
+    element.appendChild(style)
+    return style
+  },
+}))
+
+vi.mock('~/utils/player', () => ({
+  getVideoElement: () => null,
+}))
+
+const ZOOM_BUTTON_CLASS = 'bewly-vertical-video-zoom-button'
+
+describe('vertical video zoom controls', () => {
+  afterEach(() => {
+    resetVerticalVideoZoom()
+    vi.useRealTimers()
+
+    document.querySelectorAll('style').forEach((style) => {
+      if (style.textContent?.includes(ZOOM_BUTTON_CLASS))
+        style.remove()
+    })
+  })
+
+  it('anchors the button in the top-left corner to keep the native close button clear', () => {
+    vi.useFakeTimers()
+    initVerticalVideoZoom()
+
+    const style = Array.from(document.querySelectorAll('style'))
+      .find(element => element.textContent?.includes(ZOOM_BUTTON_CLASS))
+
+    expect(style?.textContent).toMatch(
+      new RegExp(`\\.${ZOOM_BUTTON_CLASS} \\{[\\s\\S]*?top: 12px !important;[\\s\\S]*?left: 12px !important;[\\s\\S]*?right: auto !important;`),
+    )
+  })
+})

--- a/src/utils/verticalVideoZoom.ts
+++ b/src/utils/verticalVideoZoom.ts
@@ -53,8 +53,9 @@ function injectStyle() {
 
     .${BUTTON_CLASS} {
       position: absolute !important;
-      top: 52px !important;
-      right: 12px !important;
+      top: 12px !important;
+      left: 12px !important;
+      right: auto !important;
       z-index: 100 !important;
       display: none;
       align-items: center !important;


### PR DESCRIPTION
## 修改内容

- 将竖屏视频的“放大/缩小”按钮固定到播放器左上角。
- 为视频小窗右上角的原生关闭按钮留出完整操作空间。
- 添加样式回归测试，验证按钮始终使用 `top: 12px`、`left: 12px` 和 `right: auto`。

## 问题原因

“放大/缩小”按钮原本固定在播放器右侧。在视频小窗布局中，它会与 Bilibili 原生关闭按钮占用同一区域，从而遮挡关闭按钮；单纯增加右侧间距又会在窄小窗中把按钮推向画面中部。

本次改为固定在左上角，使按钮位置不受小窗宽度影响，同时避开右上角原生控件。

## 用户影响

竖屏视频进入小窗模式后，用户可以同时正常使用“放大/缩小”和关闭按钮，不再发生重叠或遮挡。

## 验证

- `corepack pnpm test`：7 项测试通过
- `corepack pnpm typecheck`
- `corepack pnpm lint`
- `corepack pnpm lint-staged`

Fixes #790
