### PR TITLE
fix: 修复列表模式封面宽度并支持响应式列数

### DIFF
--- a/src/components/VideoCard/VideoCard.vue
+++ b/src/components/VideoCard/VideoCard.vue
@@ -413,6 +413,7 @@ provide('getVideoType', () => props.type!)
         <VideoCardInfo
           v-if="!logic.removed.value"
           ref="infoComponentRef"
+          :class="{ 'horizontal-card-info': horizontal }"
           :skeleton="infoSkeleton"
           :video="props.video"
           :layout="layout"
@@ -528,6 +529,13 @@ provide('getVideoType', () => props.type!)
 
 .horizontal-card-cover {
   --uno: "w-full max-w-400px aspect-video";
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.horizontal-card-info {
+  flex: 1 1 0;
+  min-width: 0;
 }
 
 .vertical-card-cover {

--- a/src/components/VideoCardGrid.vue
+++ b/src/components/VideoCardGrid.vue
@@ -7,6 +7,7 @@ import { useVideoCardShadowStyle } from '~/composables/useVideoCardShadowStyle'
 import { OVERLAY_SCROLL_BAR_SCROLL } from '~/constants/globalEvents'
 import type { GridLayoutType } from '~/logic'
 import { settings } from '~/logic'
+import { getListLayoutColumnCount } from '~/utils/gridLayout'
 import emitter from '~/utils/mitt'
 
 import SmoothLoading from './SmoothLoading.vue'
@@ -647,7 +648,7 @@ function getCurrentColumnCount(layout: GridLayoutType, width: number): number {
   if (layout === 'twoColumns')
     return 2
   if (layout === 'oneColumn')
-    return 1
+    return getListLayoutColumnCount(width)
   return getAdaptiveGridColumns(width)
 }
 
@@ -1003,7 +1004,7 @@ function getUniqueKey(item: T, index: number): string | number {
 
 .grid-one-column {
   display: grid;
-  grid-template-columns: repeat(1, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 500px), 1fr));
   gap: 16px;
   contain: layout style;
   align-items: stretch;

--- a/src/contentScripts/views/Home/components/Ranking.vue
+++ b/src/contentScripts/views/Home/components/Ranking.vue
@@ -280,7 +280,7 @@ defineExpose({ initData })
 
 .grid-one-column {
   display: grid;
-  grid-template-columns: repeat(1, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 500px), 1fr));
   gap: 20px;
 }
 </style>

--- a/src/tests/gridLayout.spec.ts
+++ b/src/tests/gridLayout.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getListLayoutColumnCount,
+  LIST_LAYOUT_GRID_GAP,
+  LIST_LAYOUT_MIN_CARD_WIDTH,
+} from '~/utils/gridLayout'
+
+describe('list grid layout', () => {
+  function minimumWidthForColumns(columns: number): number {
+    return columns * LIST_LAYOUT_MIN_CARD_WIDTH
+      + (columns - 1) * LIST_LAYOUT_GRID_GAP
+  }
+
+  it('adds columns whenever another minimum-width card fits', () => {
+    expect(getListLayoutColumnCount(minimumWidthForColumns(2) - 1)).toBe(1)
+    expect(getListLayoutColumnCount(minimumWidthForColumns(2))).toBe(2)
+    expect(getListLayoutColumnCount(minimumWidthForColumns(3))).toBe(3)
+    expect(getListLayoutColumnCount(minimumWidthForColumns(4))).toBe(4)
+  })
+
+  it('falls back to one column for invalid or non-positive widths', () => {
+    expect(getListLayoutColumnCount(0)).toBe(1)
+    expect(getListLayoutColumnCount(Number.NaN)).toBe(1)
+  })
+})

--- a/src/utils/gridLayout.ts
+++ b/src/utils/gridLayout.ts
@@ -1,0 +1,15 @@
+export const LIST_LAYOUT_MIN_CARD_WIDTH = 500
+export const LIST_LAYOUT_GRID_GAP = 16
+
+export function getListLayoutColumnCount(width: number): number {
+  if (!Number.isFinite(width) || width <= 0)
+    return 1
+
+  return Math.max(
+    1,
+    Math.floor(
+      (width + LIST_LAYOUT_GRID_GAP)
+      / (LIST_LAYOUT_MIN_CARD_WIDTH + LIST_LAYOUT_GRID_GAP),
+    ),
+  )
+}


### PR DESCRIPTION
## 关联 Issue

Closes #785

## 问题原因

横向视频卡片的封面和信息区都以内容宽度参与 Flex 收缩。不同标题、标签的最小内容宽度不同，导致同一列表中的封面被压缩成不同尺寸。

此外，原列表模式固定为单列：宽屏下空间利用不足，而分屏时切换到固定双列又容易显得拥挤。

## 修改内容

- 将横向卡片的封面和信息区设为相同的 Flex 基准，并允许信息区收缩，保证封面宽度一致。
- 新增设备自适应模式，自适应设备宽度，如有需要可以把这个模式并到tile模式里
- 同步排行榜中的番剧卡片列表布局。
- 添加列表列数断点测试。

## 用户影响

用户继续点击原有的列表模式图标即可获得响应式布局：窄窗口自动减少列数，宽窗口自动增加列数；自适应网格和固定双列模式保持不变。

## 验证

- `corepack pnpm exec eslint`（本 PR 的 5 个文件）
- `corepack pnpm typecheck`
- `corepack pnpm test`（6 个测试文件、11 项测试通过）
- `corepack pnpm build:js -- --mode production`
