### PR TITLE
fix: 合集稍后再看加错集，稍后再看列表单条打开改为正常视频页

### DIFF
--- a/src/components/TopBar/components/pops/WatchLaterPop.vue
+++ b/src/components/TopBar/components/pops/WatchLaterPop.vue
@@ -48,14 +48,9 @@ onMounted(async () => {
 })
 
 /**
- * Return the URL of the watch later item
- * @param bvid bvid
- * @return {string} url
+ * 单条点击进入普通视频页（合集可保留侧栏与上下集）
+ * 「播放全部」仍走 /list/watchlater 队列连播
  */
-function getWatchLaterUrl(bvid: string): string {
-  return `https://www.bilibili.com/list/watchlater?bvid=${bvid}`
-}
-
 function getVideoPageUrl(bvid: string): string {
   return `https://www.bilibili.com/video/${bvid}/`
 }
@@ -174,7 +169,7 @@ function handleOpenVideoPageAndRemove(index: number, aid: number, bvid: string) 
         <ALink
           v-for="(item, index) in watchLaterList"
           :key="item.aid"
-          :href="getWatchLaterUrl(item.bvid)"
+          :href="getVideoPageUrl(item.bvid)"
           class="group"
           type="topBar"
           m="last:b-4" p="2"

--- a/src/contentScripts/views/WatchLater/WatchLater.vue
+++ b/src/contentScripts/views/WatchLater/WatchLater.vue
@@ -206,7 +206,7 @@ function handleOpenVideoPageAndRemove(index: number, bvid: string, aid: number) 
           <ALink
             v-for="(item, index) in currentWatchLaterList"
             :key="item.aid"
-            :href="`https://www.bilibili.com/list/watchlater?bvid=${item.bvid}`"
+            :href="`https://www.bilibili.com/video/${item.bvid}/`"
             type="videoCard"
             class="group"
             flex cursor-pointer
@@ -283,7 +283,7 @@ function handleOpenVideoPageAndRemove(index: number, bvid: string, aid: number) 
                     class="keep-two-lines"
                     overflow="hidden"
                     un-text="lg overflow-ellipsis"
-                    @click.stop.prevent="handleLinkClick(`https://www.bilibili.com/list/watchlater?bvid=${item.bvid}`)"
+                    @click.stop.prevent="handleVideoLinkClick(item.bvid)"
                   >
                     {{ item.title }}
                   </a>

--- a/src/utils/watchLaterButton.ts
+++ b/src/utils/watchLaterButton.ts
@@ -5,20 +5,36 @@
 
 /**
  * 从URL中提取视频ID
+ * 支持 /video/BV...、/video/av...，以及 /list/...?bvid= / ?avid= 等合集/列表页
  * @param url 视频页面URL，默认为当前页面URL
  * @returns 包含bvid或aid的对象
  */
 export function extractVideoIds(url: string = location.href): { bvid?: string, aid?: number } {
-  // 提取BVID
+  // 提取路径中的 BVID（普通视频页）
   const bvidMatch = url.match(/\/video\/(BV[a-zA-Z0-9]+)/)
   if (bvidMatch) {
     return { bvid: bvidMatch[1] }
   }
 
-  // 提取AID
+  // 提取路径中的 AID
   const aidMatch = url.match(/\/video\/av(\d+)/)
   if (aidMatch) {
     return { aid: Number.parseInt(aidMatch[1]) }
+  }
+
+  // 合集/列表页：ID 在 query 中（SPA 切集时 pathname 不变，bvid/avid 会变）
+  try {
+    const searchParams = new URL(url).searchParams
+    const bvid = searchParams.get('bvid')
+    if (bvid)
+      return { bvid }
+
+    const avid = searchParams.get('avid') || searchParams.get('aid')
+    if (avid)
+      return { aid: Number.parseInt(avid) }
+  }
+  catch {
+    // ignore invalid URL
   }
 
   return {}
@@ -39,9 +55,9 @@ export function addWatchLaterButton() {
     return
   }
 
-  // 获取视频ID
-  const { bvid, aid } = extractVideoIds()
-  if (!bvid && !aid) {
+  // 进入页时至少能解析出视频 ID 才挂按钮；真正提交时再读一次当前 URL
+  const initialIds = extractVideoIds()
+  if (!initialIds.bvid && !initialIds.aid) {
     return
   }
 
@@ -93,6 +109,13 @@ export function addWatchLaterButton() {
       const { default: api } = await import('~/utils/api')
       const { getCSRF } = await import('~/utils/main')
       const { useTopBarStore } = await import('~/stores/topBarStore')
+
+      // 必须在点击时读取当前 URL：合集/列表 SPA 切集后 bvid 会变，不能用创建按钮时的闭包值
+      const { bvid, aid } = extractVideoIds()
+      if (!bvid && !aid) {
+        watchLaterBtn.style.pointerEvents = 'auto'
+        return
+      }
 
       const params: { bvid?: string, aid?: number, csrf: string } = {
         csrf: getCSRF(),


### PR DESCRIPTION
Close #767 

## Summary
- 修复外置稍后再看在合集内切集后仍提交进入页 `bvid` 的问题（点击时按当前 URL 重新解析；`extractVideoIds` 支持 `/list/...?bvid=`）
- 稍后再看「点某一条」改为打开 `/video/BVxxx`，保留合集侧栏与上下集；「播放全部」仍走 `/list/watchlater` 队列连播
- 关联 #767（issue 写成「分 P」，实际复现是合集切集换 BV）

## 关于分 P
分 P 与合集不同：多 P 共用同一个 `bvid`，稍后再看添加接口只收稿件 `aid`/`bvid`，没测试能否可靠指定当前第几 P 与播放进度。  
因此本 PR 不修复「分 P 记到第几集 / 第几秒」；打开单条后若能续播，主要依赖 B 站该稿件的观看历史，而不是稍后再看条目写入的分 P 状态。
