### PR TITLE
fix: 修复会话恢复后的样式注入

### DIFF
--- a/src/background/contentScriptRecovery.ts
+++ b/src/background/contentScriptRecovery.ts
@@ -1,0 +1,146 @@
+import type { Scripting, Tabs } from 'webextension-polyfill'
+import browser from 'webextension-polyfill'
+
+import { CONTENT_SCRIPT_PING, CONTENT_SCRIPT_PONG, isContentScriptTargetUrl } from '~/constants/contentScript'
+
+const CONTENT_SCRIPT_CSS = 'dist/contentScripts/style.css'
+const CONTENT_SCRIPT_JS = 'dist/contentScripts/index.global.js'
+const PAGE_SCRIPT_JS = 'dist/contentScripts/inject.global.js'
+const CONTENT_SCRIPT_STARTUP_GRACE_PERIOD_MS = 100
+
+export interface ContentScriptRecoveryBrowser {
+  tabs: Pick<Tabs.Static, 'get' | 'sendMessage'>
+  scripting: Pick<Scripting.Static, 'executeScript' | 'insertCSS'>
+}
+
+export type ContentScriptRecoveryResult = 'ineligible' | 'already-injected' | 'injected'
+
+async function isEligibleActiveTab(tabId: number, extensionApi: ContentScriptRecoveryBrowser): Promise<boolean> {
+  try {
+    const tab = await extensionApi.tabs.get(tabId)
+    return tab.active === true
+      && tab.status === 'complete'
+      && tab.discarded !== true
+      && isContentScriptTargetUrl(tab.url)
+  }
+  catch {
+    return false
+  }
+}
+
+async function pingContentScript(tabId: number, extensionApi: ContentScriptRecoveryBrowser): Promise<boolean> {
+  try {
+    const response = await extensionApi.tabs.sendMessage(
+      tabId,
+      { type: CONTENT_SCRIPT_PING },
+      { frameId: 0 },
+    )
+    return response === CONTENT_SCRIPT_PONG
+  }
+  catch {
+    // A missing receiver is expected for the session-restoration case handled here.
+    return false
+  }
+}
+
+export async function recoverContentScript(
+  tabId: number,
+  extensionApi: ContentScriptRecoveryBrowser = browser,
+): Promise<ContentScriptRecoveryResult> {
+  if (!await isEligibleActiveTab(tabId, extensionApi))
+    return 'ineligible'
+
+  if (await pingContentScript(tabId, extensionApi))
+    return 'already-injected'
+
+  await new Promise(resolve => setTimeout(resolve, CONTENT_SCRIPT_STARTUP_GRACE_PERIOD_MS))
+
+  // Re-check after the failed message. The tab may have navigated while the
+  // ping and grace period were in flight, and a normal manifest injection may
+  // also have finished starting in the meantime.
+  if (!await isEligibleActiveTab(tabId, extensionApi))
+    return 'ineligible'
+
+  if (await pingContentScript(tabId, extensionApi))
+    return 'already-injected'
+
+  const target: Scripting.InjectionTarget = { tabId, frameIds: [0] }
+
+  await extensionApi.scripting.insertCSS({
+    target,
+    files: [CONTENT_SCRIPT_CSS],
+  })
+  await extensionApi.scripting.executeScript({
+    target,
+    files: [CONTENT_SCRIPT_JS],
+    world: 'ISOLATED',
+    injectImmediately: true,
+  })
+  await extensionApi.scripting.executeScript({
+    target,
+    files: [PAGE_SCRIPT_JS],
+    world: 'MAIN',
+    injectImmediately: true,
+  })
+
+  return 'injected'
+}
+
+const pendingRecoveries = new Map<number, Promise<void>>()
+
+function queueContentScriptRecovery(tabId: number): void {
+  if (pendingRecoveries.has(tabId))
+    return
+
+  const recovery = recoverContentScript(tabId)
+    .then((result) => {
+      if (result === 'injected')
+        console.log(`[BewlyCat] Recovered missing content script in tab ${tabId}.`)
+    })
+    .catch((error) => {
+      console.warn(`[BewlyCat] Failed to recover content script in tab ${tabId}.`, error)
+    })
+    .finally(() => {
+      if (pendingRecoveries.get(tabId) === recovery)
+        pendingRecoveries.delete(tabId)
+    })
+
+  pendingRecoveries.set(tabId, recovery)
+}
+
+async function queueActiveTabs(): Promise<void> {
+  const tabs = await browser.tabs.query({ active: true })
+  tabs.forEach((tab) => {
+    if (tab.id !== undefined)
+      queueContentScriptRecovery(tab.id)
+  })
+}
+
+let recoveryListenersInitialized = false
+
+export function setupContentScriptRecovery(): void {
+  // eslint-disable-next-line node/prefer-global/process
+  if (recoveryListenersInitialized || process.env.FIREFOX || process.env.SAFARI)
+    return
+
+  recoveryListenersInitialized = true
+
+  browser.tabs.onActivated.addListener(({ tabId }) => {
+    queueContentScriptRecovery(tabId)
+  })
+
+  browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+    if (changeInfo.status === 'complete' && tab.active)
+      queueContentScriptRecovery(tabId)
+  })
+
+  browser.runtime.onStartup.addListener(() => {
+    void queueActiveTabs().catch((error) => {
+      console.warn('[BewlyCat] Failed to inspect active tabs on startup.', error)
+    })
+  })
+
+  void queueActiveTabs().catch((error) => {
+    console.warn('[BewlyCat] Failed to inspect active tabs.', error)
+  })
+}

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,6 +1,7 @@
 import browser from 'webextension-polyfill'
 
 import { setupAppAuthScheduler } from './appAuthScheduler'
+import { setupContentScriptRecovery } from './contentScriptRecovery'
 import { setupApiMsgListeners } from './messageListeners/api'
 import { setupTabMsgListeners } from './messageListeners/tabs'
 import { initWbiKeys } from './wbiSign'
@@ -52,3 +53,4 @@ if (process.env.FIREFOX) {
 setupApiMsgListeners()
 setupTabMsgListeners()
 setupAppAuthScheduler()
+setupContentScriptRecovery()

--- a/src/constants/contentScript.ts
+++ b/src/constants/contentScript.ts
@@ -1,0 +1,44 @@
+export const CONTENT_SCRIPT_HOSTS = [
+  'www.bilibili.com',
+  'search.bilibili.com',
+  't.bilibili.com',
+  'space.bilibili.com',
+  'message.bilibili.com',
+  'member.bilibili.com',
+  'account.bilibili.com',
+  'www.hdslb.com',
+  'passport.bilibili.com',
+  'music.bilibili.com',
+] as const
+
+export const CONTENT_SCRIPT_MATCHES = CONTENT_SCRIPT_HOSTS.map(host => `*://${host}/*`)
+
+export const CONTENT_SCRIPT_EXCLUDE_MATCHES = [
+  '*://www.bilibili.com/match/game*',
+  '*://www.bilibili.com/toy*',
+]
+
+export const CONTENT_SCRIPT_PING = 'bewly-cat:content-script:ping'
+export const CONTENT_SCRIPT_PONG = 'bewly-cat:content-script:ready'
+
+const CONTENT_SCRIPT_HOST_SET = new Set<string>(CONTENT_SCRIPT_HOSTS)
+
+export function isContentScriptTargetUrl(value?: string): boolean {
+  if (!value)
+    return false
+
+  try {
+    const url = new URL(value)
+    if (url.protocol !== 'http:' && url.protocol !== 'https:')
+      return false
+
+    if (!CONTENT_SCRIPT_HOST_SET.has(url.hostname))
+      return false
+
+    return url.hostname !== 'www.bilibili.com'
+      || (!url.pathname.startsWith('/match/game') && !url.pathname.startsWith('/toy'))
+  }
+  catch {
+    return false
+  }
+}

--- a/src/contentScripts/index.ts
+++ b/src/contentScripts/index.ts
@@ -4,6 +4,7 @@ import 'uno.css'
 import { createApp } from 'vue'
 
 import { useDark } from '~/composables/useDark'
+import { CONTENT_SCRIPT_PING, CONTENT_SCRIPT_PONG } from '~/constants/contentScript'
 import { BEWLY_MOUNTED, IFRAME_DARK_MODE_CHANGE, IFRAME_TOP_BAR_CHANGE } from '~/constants/globalEvents'
 import { localSettings, settings, settingsReady } from '~/logic'
 import { setupApp } from '~/logic/common-setup'
@@ -28,6 +29,21 @@ import { initAudioInterceptor, setupSettingsWatcher } from './audioInterceptor'
 import { setupIframePhotoViewerDetector } from './features/iframePhotoViewerDetector'
 import App from './views/App.vue'
 import { initVolumeNormalizationControl } from './volumeNormalizationControl'
+
+const contentScriptGlobal = globalThis as typeof globalThis & {
+  __BEWLYCAT_CONTENT_SCRIPT_INITIALIZED__?: boolean
+}
+const shouldInitializeContentScript = !contentScriptGlobal.__BEWLYCAT_CONTENT_SCRIPT_INITIALIZED__
+
+if (shouldInitializeContentScript) {
+  contentScriptGlobal.__BEWLYCAT_CONTENT_SCRIPT_INITIALIZED__ = true
+  browser.runtime.onMessage.addListener((message: unknown) => {
+    if (typeof message === 'object' && message !== null && 'type' in message && message.type === CONTENT_SCRIPT_PING)
+      return Promise.resolve(CONTENT_SCRIPT_PONG)
+
+    return false
+  })
+}
 
 const isFirefox: boolean = /Firefox/i.test(navigator.userAgent)
 const isElectronEnv = isElectron()
@@ -136,7 +152,7 @@ export function isSupportedIframePages(): boolean {
 if (isElectronEnv) {
   console.warn('[BewlyCat] Detected Electron environment, extension disabled.')
 }
-else {
+else if (shouldInitializeContentScript) {
   // Fix `OverlayScrollbars` not working in Firefox
   // https://github.com/fingerprintjs/fingerprintjs/issues/683#issuecomment-881210244
   if (isFirefox) {

--- a/src/inject/index.ts
+++ b/src/inject/index.ts
@@ -11,11 +11,19 @@ const settingsReadyPromise = new Promise<void>((resolve) => {
   resolveSettingsReady = resolve
 })
 
+const pageScriptGlobal = globalThis as typeof globalThis & {
+  __BEWLYCAT_PAGE_SCRIPT_INITIALIZED__?: boolean
+}
+const shouldInitializePageScript = !pageScriptGlobal.__BEWLYCAT_PAGE_SCRIPT_INITIALIZED__
+
+if (shouldInitializePageScript)
+  pageScriptGlobal.__BEWLYCAT_PAGE_SCRIPT_INITIALIZED__ = true
+
 const isElectronEnv = isElectron()
 if (isElectronEnv) {
   console.warn('[BewlyCat] Detected Electron environment, extension disabled.')
 }
-else {
+else if (shouldInitializePageScript) {
 // 之前inject.js的内容
   const isArray = (val: any): boolean => Array.isArray(val)
   function injectFunction(

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -3,6 +3,7 @@ import type { Manifest } from 'webextension-polyfill'
 
 import type PkgType from '../package.json'
 import { isDev, isFirefox, isSafari, port, r } from '../scripts/utils'
+import { CONTENT_SCRIPT_EXCLUDE_MATCHES, CONTENT_SCRIPT_MATCHES } from './constants/contentScript'
 
 export async function getManifest() {
   const pkg = await fs.readJSON(r('package.json')) as typeof PkgType
@@ -38,6 +39,7 @@ export async function getManifest() {
     permissions: [
       'storage',
       'declarativeNetRequest',
+      ...(!isFirefox && !isSafari ? ['scripting'] : []),
       ...isFirefox
         ? ['webRequest', 'webRequestBlocking', 'cookies']
         : [],
@@ -48,22 +50,8 @@ export async function getManifest() {
     ],
     content_scripts: [
       {
-        matches: [
-          '*://www.bilibili.com/*',
-          '*://search.bilibili.com/*',
-          '*://t.bilibili.com/*',
-          '*://space.bilibili.com/*',
-          '*://message.bilibili.com/*',
-          '*://member.bilibili.com/*',
-          '*://account.bilibili.com/*',
-          '*://www.hdslb.com/*',
-          '*://passport.bilibili.com/*',
-          '*://music.bilibili.com/*',
-        ],
-        exclude_matches: [
-          '*://www.bilibili.com/match/game*',
-          '*://www.bilibili.com/toy*',
-        ],
+        matches: [...CONTENT_SCRIPT_MATCHES],
+        exclude_matches: [...CONTENT_SCRIPT_EXCLUDE_MATCHES],
         js: ['./dist/contentScripts/index.global.js'],
         css: ['./dist/contentScripts/style.css'],
         run_at: 'document_start',
@@ -71,22 +59,8 @@ export async function getManifest() {
         all_frames: true,
       },
       {
-        matches: [
-          '*://www.bilibili.com/*',
-          '*://search.bilibili.com/*',
-          '*://t.bilibili.com/*',
-          '*://space.bilibili.com/*',
-          '*://message.bilibili.com/*',
-          '*://member.bilibili.com/*',
-          '*://account.bilibili.com/*',
-          '*://www.hdslb.com/*',
-          '*://passport.bilibili.com/*',
-          '*://music.bilibili.com/*',
-        ],
-        exclude_matches: [
-          '*://www.bilibili.com/match/game*',
-          '*://www.bilibili.com/toy*',
-        ],
+        matches: [...CONTENT_SCRIPT_MATCHES],
+        exclude_matches: [...CONTENT_SCRIPT_EXCLUDE_MATCHES],
         js: ['./dist/contentScripts/inject.global.js'],
         run_at: 'document_start',
         match_about_blank: true,

--- a/src/tests/contentScript.spec.ts
+++ b/src/tests/contentScript.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { CONTENT_SCRIPT_MATCHES, isContentScriptTargetUrl } from '~/constants/contentScript'
+
+describe('content script configuration', () => {
+  it('keeps the generated manifest matches aligned with supported hosts', () => {
+    expect(CONTENT_SCRIPT_MATCHES).toEqual([
+      '*://www.bilibili.com/*',
+      '*://search.bilibili.com/*',
+      '*://t.bilibili.com/*',
+      '*://space.bilibili.com/*',
+      '*://message.bilibili.com/*',
+      '*://member.bilibili.com/*',
+      '*://account.bilibili.com/*',
+      '*://www.hdslb.com/*',
+      '*://passport.bilibili.com/*',
+      '*://music.bilibili.com/*',
+    ])
+  })
+
+  it('accepts URLs covered by the manifest content scripts', () => {
+    expect(isContentScriptTargetUrl('https://www.bilibili.com/')).toBe(true)
+    expect(isContentScriptTargetUrl('http://search.bilibili.com/all?keyword=test')).toBe(true)
+    expect(isContentScriptTargetUrl('https://space.bilibili.com/123')).toBe(true)
+  })
+
+  it('rejects excluded, unrelated, and invalid URLs', () => {
+    expect(isContentScriptTargetUrl('https://www.bilibili.com/match/game/123')).toBe(false)
+    expect(isContentScriptTargetUrl('https://www.bilibili.com/toy/foo')).toBe(false)
+    expect(isContentScriptTargetUrl('https://manga.bilibili.com/detail/123')).toBe(false)
+    expect(isContentScriptTargetUrl('https://www.bilibili.com.example.com/')).toBe(false)
+    expect(isContentScriptTargetUrl('ftp://www.bilibili.com/')).toBe(false)
+    expect(isContentScriptTargetUrl('not a url')).toBe(false)
+  })
+})

--- a/src/tests/contentScriptRecovery.spec.ts
+++ b/src/tests/contentScriptRecovery.spec.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ContentScriptRecoveryBrowser } from '~/background/contentScriptRecovery'
+import { recoverContentScript } from '~/background/contentScriptRecovery'
+import { CONTENT_SCRIPT_PONG } from '~/constants/contentScript'
+
+vi.mock('webextension-polyfill', () => ({
+  default: {
+    scripting: {},
+    tabs: {},
+  },
+}))
+
+const eligibleTab = {
+  active: true,
+  status: 'complete',
+  url: 'https://www.bilibili.com/',
+}
+
+function createExtensionApi() {
+  const tabs = {
+    get: vi.fn(),
+    sendMessage: vi.fn(),
+  }
+  const scripting = {
+    executeScript: vi.fn(),
+    insertCSS: vi.fn(),
+  }
+
+  return {
+    extensionApi: { tabs, scripting } as unknown as ContentScriptRecoveryBrowser,
+    scripting,
+    tabs,
+  }
+}
+
+describe('content script recovery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not inject when the manifest content script responds', async () => {
+    const { extensionApi, scripting, tabs } = createExtensionApi()
+    tabs.get.mockResolvedValue(eligibleTab)
+    tabs.sendMessage.mockResolvedValue(CONTENT_SCRIPT_PONG)
+
+    await expect(recoverContentScript(7, extensionApi)).resolves.toBe('already-injected')
+    expect(tabs.sendMessage).toHaveBeenCalledWith(7, expect.anything(), { frameId: 0 })
+    expect(scripting.insertCSS).not.toHaveBeenCalled()
+    expect(scripting.executeScript).not.toHaveBeenCalled()
+  })
+
+  it('restores CSS and both script worlds when the receiver is missing', async () => {
+    const { extensionApi, scripting, tabs } = createExtensionApi()
+    tabs.get.mockResolvedValue(eligibleTab)
+    tabs.sendMessage.mockRejectedValue(new Error('Receiving end does not exist'))
+
+    await expect(recoverContentScript(11, extensionApi)).resolves.toBe('injected')
+
+    expect(tabs.get).toHaveBeenCalledTimes(2)
+    expect(tabs.sendMessage).toHaveBeenCalledTimes(2)
+    expect(scripting.insertCSS).toHaveBeenCalledWith({
+      target: { tabId: 11, frameIds: [0] },
+      files: ['dist/contentScripts/style.css'],
+    })
+    expect(scripting.executeScript).toHaveBeenNthCalledWith(1, {
+      target: { tabId: 11, frameIds: [0] },
+      files: ['dist/contentScripts/index.global.js'],
+      world: 'ISOLATED',
+      injectImmediately: true,
+    })
+    expect(scripting.executeScript).toHaveBeenNthCalledWith(2, {
+      target: { tabId: 11, frameIds: [0] },
+      files: ['dist/contentScripts/inject.global.js'],
+      world: 'MAIN',
+      injectImmediately: true,
+    })
+  })
+
+  it('allows a normal manifest injection to finish before recovering', async () => {
+    const { extensionApi, scripting, tabs } = createExtensionApi()
+    tabs.get.mockResolvedValue(eligibleTab)
+    tabs.sendMessage
+      .mockRejectedValueOnce(new Error('Receiver is still starting'))
+      .mockResolvedValueOnce(CONTENT_SCRIPT_PONG)
+
+    await expect(recoverContentScript(12, extensionApi)).resolves.toBe('already-injected')
+    expect(tabs.sendMessage).toHaveBeenCalledTimes(2)
+    expect(scripting.insertCSS).not.toHaveBeenCalled()
+    expect(scripting.executeScript).not.toHaveBeenCalled()
+  })
+
+  it('does not inject into an ineligible active tab', async () => {
+    const { extensionApi, scripting, tabs } = createExtensionApi()
+    tabs.get.mockResolvedValue({
+      active: true,
+      status: 'complete',
+      url: 'https://example.com/',
+    })
+
+    await expect(recoverContentScript(13, extensionApi)).resolves.toBe('ineligible')
+    expect(tabs.sendMessage).not.toHaveBeenCalled()
+    expect(scripting.insertCSS).not.toHaveBeenCalled()
+  })
+
+  it('stops if the tab starts navigating after a failed ping', async () => {
+    const { extensionApi, scripting, tabs } = createExtensionApi()
+    tabs.get
+      .mockResolvedValueOnce(eligibleTab)
+      .mockResolvedValueOnce({ ...eligibleTab, status: 'loading' })
+    tabs.sendMessage.mockRejectedValue(new Error('Tab navigated'))
+
+    await expect(recoverContentScript(17, extensionApi)).resolves.toBe('ineligible')
+    expect(scripting.insertCSS).not.toHaveBeenCalled()
+    expect(scripting.executeScript).not.toHaveBeenCalled()
+  })
+})

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -26,6 +26,7 @@ export default defineConfig(() => ({
     '__DEV__': JSON.stringify(isDev),
     'process.env.NODE_ENV': JSON.stringify(isDev ? 'development' : 'production'),
     'process.env.FIREFOX': isFirefox ? 'true' : 'false',
+    'process.env.SAFARI': isSafari ? 'true' : 'false',
   },
   platform: 'browser',
   minifyWhitespace: !isDev,


### PR DESCRIPTION
## 修改内容

- 在 Chromium 后台增加 content script 恢复机制，覆盖浏览器启动、标签激活和活动页面加载完成场景。
- 先向主框架发送 ping，并保留 100ms 启动宽限期；仅在确认静态 content script 缺失后补注入 CSS、ISOLATED 脚本和 MAIN world 脚本。
- 增加活动状态、导航状态、discarded tab 和并发恢复检查，避免正常加载或快速导航时重复注入。
- 为隔离环境脚本和页面环境脚本增加幂等标记，避免重复挂载 Vue 应用或重复代理页面 API。
- 统一 manifest 与后台恢复逻辑使用的 URL 匹配规则，并仅为 Chromium 构建添加 `scripting` 权限。
- 增加 URL 匹配、缺失接收端、延迟启动及导航竞态测试。

## 问题原因

Chrome 冷启动并恢复多个标签页时，如果当前激活页不是 Bilibili，后台恢复出的 Bilibili 文档可能没有触发 manifest 静态 content script 注入。之后切换到该标签页不会产生新的导航，因此原有逻辑没有补注入机会，插件样式和应用均不会生效，直到用户手动刷新页面。

## 用户影响

冷启动 Chrome 后切换到已恢复的 Bilibili 标签页时，BewlyCat 会自动检查并恢复缺失的样式与脚本，无需手动刷新。正常完成静态注入的页面不会重复执行恢复逻辑。

## 验证

- `pnpm test`：7 个测试文件、17 个测试通过
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm build-firefox`

Closes #736
