### PR TITLE
feat: 外置稍后再看按钮支持状态显示与移除

### DIFF
--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -24,6 +24,9 @@ common:
   please_log_in_first: 请先登录
   login: 登录
   save_to_watch_later: 稍后再看
+  add_to_watch_later: 添加到稍后再看
+  added_to_watch_later: 已添加到稍后再看
+  remove_from_watch_later: 从稍后再看中移除
   added: 已添加
   performance_impact_warn: 这个功能可能会影响性能！
   no_data: 暂无数据
@@ -208,7 +211,7 @@ settings:
   enlarge_favorite_dialog: 放大收藏弹窗
   enlarge_favorite_dialog_desc: 启用后，视频页收藏弹窗将以更大的尺寸显示，方便查看和管理收藏夹。
   external_watch_later_button: 稍后再看按钮外置
-  external_watch_later_button_desc: 启用后，视频页将在工具栏显示独立的稍后再看按钮，方便快速添加视频到稍后再看。
+  external_watch_later_button_desc: 启用后，视频页工具栏会显示独立的稍后再看按钮；按钮会显示当前视频状态，可点击添加或移除。
   keep_collection_video_default_mode: 合集视频保持默认模式
   keep_collection_video_default_mode_desc: 当启用时，合集视频将始终使用默认播放器模式，不会应用宽屏或全屏设置
   remember_playback_rate: 记住倍速

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -24,6 +24,9 @@ common:
   please_log_in_first: 請先登入
   login: 登入
   save_to_watch_later: 稍後觀看
+  add_to_watch_later: 加入稍後觀看
+  added_to_watch_later: 已加入稍後觀看
+  remove_from_watch_later: 從稍後觀看中移除
   added: 已新增
   performance_impact_warn: 這個功能可能會降低效能！
   no_data: 暫無資料
@@ -596,7 +599,7 @@ settings:
   enlarge_favorite_dialog: 放大收藏彈窗
   enlarge_favorite_dialog_desc: 啟用後，影片頁收藏彈窗將以更大的尺寸顯示，方便查看和管理收藏夾。
   external_watch_later_button: 稍後再看按鈕外置
-  external_watch_later_button_desc: 啟用後，影片頁將在工具欄顯示獨立的稍後再看按鈕，方便快速添加影片到稍後再看。
+  external_watch_later_button_desc: 啟用後，影片頁工具欄會顯示獨立的稍後觀看按鈕；按鈕會顯示目前影片狀態，可點擊加入或移除。
   volume_normalization:
     title: 音量均衡
     enable: 啟用音量均衡

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -24,6 +24,9 @@ common:
   please_log_in_first: Please log in first
   login: Login
   save_to_watch_later: Save to Watch later
+  add_to_watch_later: Add to Watch later
+  added_to_watch_later: Added to Watch later
+  remove_from_watch_later: Remove from Watch later
   added: Added
   performance_impact_warn: This feature may cause performance *DECREASE*!
   no_data: No data available
@@ -672,7 +675,7 @@ settings:
   enlarge_favorite_dialog: Enlarge favorite dialog
   enlarge_favorite_dialog_desc: When enabled, the favorite dialog on video pages will be displayed in a larger size for easier viewing and management.
   external_watch_later_button: External watch later button
-  external_watch_later_button_desc: When enabled, a standalone watch later button will be displayed on the video page toolbar for quick access.
+  external_watch_later_button_desc: Show a standalone Watch later button in the video toolbar. It displays the current state and can add or remove the video.
   volume_normalization:
     title: Volume Normalization
     enable: Enable volume normalization

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -24,6 +24,9 @@ common:
   please_log_in_first: 唔該登入先
   login: 登入
   save_to_watch_later: 陣間至睇
+  add_to_watch_later: 加到陣間至睇
+  added_to_watch_later: 已加到陣間至睇
+  remove_from_watch_later: 由陣間至睇剷走
   added: 已添加
   performance_impact_warn: 呢個功能可能會降低效能！
   no_data: 暫時冇數據
@@ -581,7 +584,7 @@ settings:
   enlarge_favorite_dialog: 放大收藏彈窗
   enlarge_favorite_dialog_desc: 啓用後，影片頁收藏彈窗會用更大嘅尺寸顯示，方便睇同管理收藏夾。
   external_watch_later_button: 稍後再睇按鈕外置
-  external_watch_later_button_desc: 啓用後，影片頁會喺工具欄顯示獨立嘅稍後再睇按鈕，方便快速添加影片到稍後再睇。
+  external_watch_later_button_desc: 啓用後，影片頁工具欄會顯示獨立嘅陣間至睇按鈕；按鈕會顯示目前影片狀態，可以撳一下加入或者剷走。
   group_fonts: ''
   group_visual_effects: ''
 auth:

--- a/src/contentScripts/index.ts
+++ b/src/contentScripts/index.ts
@@ -359,8 +359,9 @@ else if (shouldInitializeContentScript) {
     setTimeout(() => {
       if (!watchLaterButtonAdded && settings.value.externalWatchLaterButton) {
         import('~/utils/watchLaterButton').then(({ addWatchLaterButton }) => {
-          addWatchLaterButton()
-          watchLaterButtonAdded = true
+          if (!settings.value.externalWatchLaterButton)
+            return
+          watchLaterButtonAdded = addWatchLaterButton()
         }).catch(err => console.error('添加稍后再看按钮失败:', err))
       }
     }, 5000) // 5秒后添加，确保页面已完全稳定
@@ -423,6 +424,7 @@ else if (shouldInitializeContentScript) {
         exitBewlyWidescreen()
         resetVerticalVideoZoom()
         hasAppliedPlayerMode = false // URL变化时重置标志
+        document.querySelector('.bewly-watch-later-btn')?.remove()
         watchLaterButtonAdded = false // URL变化时重置稍后再看按钮标志
         // 不再重置用户手动修改标志，保持用户的自动播放偏好设置
 
@@ -764,10 +766,8 @@ else if (shouldInitializeContentScript) {
         else {
         // 移除稍后再看按钮
           const existingButton = document.querySelector('.bewly-watch-later-btn')
-          if (existingButton) {
-            existingButton.remove()
-            watchLaterButtonAdded = false
-          }
+          existingButton?.remove()
+          watchLaterButtonAdded = false
         }
       }
     }

--- a/src/logic/storage.ts
+++ b/src/logic/storage.ts
@@ -401,7 +401,7 @@ export const originalSettings: Settings = {
   showCommentHostTag: true, // 默认启用楼主标识显示
   adjustCommentImageHeight: true, // 默认启用评论图片高度调整
   enlargeFavoriteDialog: false, // 默认关闭收藏夹放大样式
-  externalWatchLaterButton: false, // 默认关闭稍后再看按钮外置
+  externalWatchLaterButton: true, // 默认开启稍后再看按钮外置
 
   // Grid 相关默认设置
   gridColumns: { ...defaultGridColumns },

--- a/src/tests/watchLaterButton.spec.ts
+++ b/src/tests/watchLaterButton.spec.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { addWatchLaterButton, extractVideoIds } from '~/utils/watchLaterButton'
+
+const mocks = vi.hoisted(() => ({
+  getAllWatchLaterList: vi.fn(),
+  getVideoInfo: vi.fn(),
+  getTopBarWatchLaterList: vi.fn(),
+  removeFromWatchLater: vi.fn(),
+  saveToWatchLater: vi.fn(),
+}))
+
+vi.mock('~/utils/api', () => ({
+  default: {
+    video: {
+      getVideoInfo: mocks.getVideoInfo,
+    },
+    watchlater: {
+      getAllWatchLaterList: mocks.getAllWatchLaterList,
+      removeFromWatchLater: mocks.removeFromWatchLater,
+      saveToWatchLater: mocks.saveToWatchLater,
+    },
+  },
+}))
+
+vi.mock('~/utils/main', () => ({
+  getCSRF: () => 'csrf-token',
+}))
+
+vi.mock('~/stores/topBarStore', () => ({
+  useTopBarStore: () => ({
+    getAllWatchLaterList: mocks.getTopBarWatchLaterList,
+  }),
+}))
+
+vi.mock('~/utils/i18n', () => ({
+  i18n: {
+    global: {
+      t: (key: string) => ({
+        'common.add_to_watch_later': '添加到稍后再看',
+        'common.added_to_watch_later': '已添加到稍后再看',
+        'common.remove_from_watch_later': '从稍后再看中移除',
+      })[key] || key,
+    },
+  },
+}))
+
+function mountToolbar() {
+  document.body.innerHTML = '<div class="video-toolbar"><div class="video-tool-more"></div></div>'
+}
+
+function getButton(): HTMLButtonElement {
+  const button = document.querySelector<HTMLButtonElement>('.bewly-watch-later-btn')
+  if (!button)
+    throw new Error('Watch later button was not mounted')
+  return button
+}
+
+describe('external watch later button', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    history.replaceState({}, '', '/video/BV1Test12345')
+    mountToolbar()
+    mocks.getAllWatchLaterList.mockResolvedValue({
+      code: 0,
+      data: { count: 0, list: [] },
+    })
+    mocks.getVideoInfo.mockResolvedValue({ code: 0, data: { aid: 123 } })
+    mocks.saveToWatchLater.mockResolvedValue({ code: 0 })
+    mocks.removeFromWatchLater.mockResolvedValue({ code: 0 })
+  })
+
+  it('extracts video identifiers from paths and collection query parameters', () => {
+    expect(extractVideoIds('https://www.bilibili.com/video/BV1Test12345?p=2')).toEqual({ bvid: 'BV1Test12345' })
+    expect(extractVideoIds('https://www.bilibili.com/video/av12345')).toEqual({ aid: 12345 })
+    expect(extractVideoIds('https://www.bilibili.com/list/ml123?bvid=BV1List12345')).toEqual({ bvid: 'BV1List12345' })
+    expect(extractVideoIds('https://www.bilibili.com/list/ml123?avid=67890')).toEqual({ aid: 67890 })
+    expect(extractVideoIds('https://www.bilibili.com/list/ml123?aid=54321')).toEqual({ aid: 54321 })
+    expect(extractVideoIds('https://www.bilibili.com/')).toEqual({})
+  })
+
+  it('highlights an existing item and removes it when clicked', async () => {
+    mocks.getAllWatchLaterList.mockResolvedValue({
+      code: 0,
+      data: {
+        count: 1,
+        list: [{ aid: 456, bvid: 'BV1Test12345' }],
+      },
+    })
+
+    expect(addWatchLaterButton()).toBe(true)
+    const button = getButton()
+
+    await vi.waitFor(() => expect(button.getAttribute('aria-busy')).toBe('false'))
+    expect(button.classList.contains('is-active')).toBe(true)
+    expect(button.getAttribute('aria-pressed')).toBe('true')
+    expect(button.textContent).toContain('已添加到稍后再看')
+
+    button.click()
+
+    await vi.waitFor(() => expect(mocks.removeFromWatchLater).toHaveBeenCalledWith({
+      aid: 456,
+      csrf: 'csrf-token',
+    }))
+    expect(button.classList.contains('is-active')).toBe(false)
+    expect(button.textContent).toContain('添加到稍后再看')
+  })
+
+  it('adds an item, then resolves its aid so a second click can remove it', async () => {
+    expect(addWatchLaterButton()).toBe(true)
+    const button = getButton()
+    await vi.waitFor(() => expect(button.getAttribute('aria-busy')).toBe('false'))
+
+    button.click()
+    await vi.waitFor(() => expect(mocks.saveToWatchLater).toHaveBeenCalledWith({
+      bvid: 'BV1Test12345',
+      csrf: 'csrf-token',
+    }))
+    expect(button.getAttribute('aria-pressed')).toBe('true')
+
+    button.click()
+    await vi.waitFor(() => expect(mocks.removeFromWatchLater).toHaveBeenCalledWith({
+      aid: 123,
+      csrf: 'csrf-token',
+    }))
+    expect(mocks.getVideoInfo).toHaveBeenCalledWith({ bvid: 'BV1Test12345' })
+    expect(button.getAttribute('aria-pressed')).toBe('false')
+  })
+
+  it('replaces a stale button after in-page navigation to another video', async () => {
+    expect(addWatchLaterButton()).toBe(true)
+    const previousButton = getButton()
+    await vi.waitFor(() => expect(previousButton.getAttribute('aria-busy')).toBe('false'))
+
+    history.replaceState({}, '', '/video/av789')
+    expect(addWatchLaterButton()).toBe(true)
+
+    const currentButton = getButton()
+    expect(currentButton).not.toBe(previousButton)
+    expect(previousButton.isConnected).toBe(false)
+    expect(currentButton.dataset.videoKey).toBe('av789')
+  })
+
+  it('uses the current collection item when the stale button is clicked before being rebuilt', async () => {
+    expect(addWatchLaterButton()).toBe(true)
+    const staleButton = getButton()
+    await vi.waitFor(() => expect(staleButton.getAttribute('aria-busy')).toBe('false'))
+
+    history.replaceState({}, '', '/list/ml123?bvid=BV1Current6789')
+    staleButton.click()
+
+    await vi.waitFor(() => expect(mocks.saveToWatchLater).toHaveBeenCalledWith({
+      bvid: 'BV1Current6789',
+      csrf: 'csrf-token',
+    }))
+    expect(mocks.saveToWatchLater).not.toHaveBeenCalledWith({
+      bvid: 'BV1Test12345',
+      csrf: 'csrf-token',
+    })
+
+    const currentButton = getButton()
+    expect(currentButton).not.toBe(staleButton)
+    expect(staleButton.isConnected).toBe(false)
+    expect(currentButton.dataset.videoKey).toBe('BV1Current6789')
+  })
+})

--- a/src/utils/watchLaterButton.ts
+++ b/src/utils/watchLaterButton.ts
@@ -1,7 +1,30 @@
-/**
- * 稍后再看按钮工具函数
- * 用于在B站视频页面添加独立的稍后再看按钮
- */
+import type { List as WatchLaterItem, WatchLaterResult } from '~/models/video/watchLater'
+import { useTopBarStore } from '~/stores/topBarStore'
+import api from '~/utils/api'
+import { i18n } from '~/utils/i18n'
+import { getCSRF } from '~/utils/main'
+
+const BUTTON_CLASS = 'bewly-watch-later-btn'
+const INACTIVE_ICON_CLASS = 'i-mingcute:carplay-line'
+const ACTIVE_ICON_CLASS = 'i-mingcute:check-line'
+
+export interface VideoIds {
+  bvid?: string
+  aid?: number
+}
+
+interface WatchLaterButtonState {
+  aid?: number
+  isInWatchLater: boolean
+  pendingAid?: Promise<number | undefined>
+}
+
+interface MountedWatchLaterButton {
+  button: HTMLButtonElement
+  ids: VideoIds
+  ready: Promise<void>
+  state: WatchLaterButtonState
+}
 
 /**
  * 从URL中提取视频ID
@@ -9,18 +32,16 @@
  * @param url 视频页面URL，默认为当前页面URL
  * @returns 包含bvid或aid的对象
  */
-export function extractVideoIds(url: string = location.href): { bvid?: string, aid?: number } {
+export function extractVideoIds(url: string = location.href): VideoIds {
   // 提取路径中的 BVID（普通视频页）
   const bvidMatch = url.match(/\/video\/(BV[a-zA-Z0-9]+)/)
-  if (bvidMatch) {
+  if (bvidMatch)
     return { bvid: bvidMatch[1] }
-  }
 
   // 提取路径中的 AID
-  const aidMatch = url.match(/\/video\/av(\d+)/)
-  if (aidMatch) {
+  const aidMatch = url.match(/\/video\/av(\d+)/i)
+  if (aidMatch)
     return { aid: Number.parseInt(aidMatch[1]) }
-  }
 
   // 合集/列表页：ID 在 query 中（SPA 切集时 pathname 不变，bvid/avid 会变）
   try {
@@ -40,133 +61,279 @@ export function extractVideoIds(url: string = location.href): { bvid?: string, a
   return {}
 }
 
-/**
- * 添加稍后再看按钮到视频页面
- */
-export function addWatchLaterButton() {
-  // 检查是否已经添加过按钮
-  if (document.querySelector('.bewly-watch-later-btn')) {
-    return
+function getVideoKey({ bvid, aid }: VideoIds): string {
+  return bvid || (aid ? `av${aid}` : '')
+}
+
+function findWatchLaterItem(list: WatchLaterItem[] | undefined, { bvid, aid }: VideoIds): WatchLaterItem | undefined {
+  return list?.find(item => (bvid && item.bvid === bvid) || (aid && item.aid === aid))
+}
+
+function translate(key: string): string {
+  return String(i18n.global.t(key))
+}
+
+function updateButtonState(button: HTMLButtonElement, isInWatchLater: boolean) {
+  const icon = button.querySelector<HTMLElement>('.bewly-watch-later-btn__icon')
+  const label = button.querySelector<HTMLElement>('.bewly-watch-later-btn__label')
+  const addLabel = translate('common.add_to_watch_later')
+  const addedLabel = translate('common.added_to_watch_later')
+  const actionLabel = isInWatchLater
+    ? translate('common.remove_from_watch_later')
+    : addLabel
+
+  button.classList.toggle('is-active', isInWatchLater)
+  button.dataset.inWatchLater = String(isInWatchLater)
+  button.setAttribute('aria-pressed', String(isInWatchLater))
+  button.setAttribute('aria-label', actionLabel)
+  button.title = actionLabel
+  button.style.color = isInWatchLater
+    ? 'var(--bew-theme-color, var(--brand_blue, #00aeec))'
+    : 'var(--text2, #61666d)'
+
+  if (isInWatchLater) {
+    button.style.backgroundColor = 'rgba(0, 174, 236, 0.12)'
+    button.style.setProperty('background-color', 'color-mix(in srgb, var(--bew-theme-color, #00aeec) 12%, transparent)')
+  }
+  else {
+    button.style.backgroundColor = 'transparent'
   }
 
-  // 查找视频工具栏的更多按钮容器
-  const moreButton = document.querySelector('.video-tool-more')
-  if (!moreButton) {
-    return
-  }
+  if (icon)
+    icon.className = `${ACTIVE_ICON_CLASS} bewly-watch-later-btn__icon`
+  if (icon && !isInWatchLater)
+    icon.className = `${INACTIVE_ICON_CLASS} bewly-watch-later-btn__icon`
+  if (label)
+    label.textContent = isInWatchLater ? addedLabel : addLabel
+}
 
-  // 进入页时至少能解析出视频 ID 才挂按钮；真正提交时再读一次当前 URL
-  const initialIds = extractVideoIds()
-  if (!initialIds.bvid && !initialIds.aid) {
-    return
-  }
+function setButtonBusy(button: HTMLButtonElement, isBusy: boolean) {
+  button.disabled = isBusy
+  button.setAttribute('aria-busy', String(isBusy))
+  button.style.cursor = isBusy ? 'wait' : 'pointer'
+  button.style.opacity = isBusy ? '0.65' : '1'
+}
 
-  // 创建稍后再看按钮
-  const watchLaterBtn = document.createElement('div')
-  watchLaterBtn.className = 'video-toolbar-right-item bewly-watch-later-btn'
-  watchLaterBtn.style.cssText = `
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    border-radius: 6px;
-    transition: background-color 0.2s, transform 0.15s ease;
-    height: 32px;
-    width: 32px;
-    padding: 0;
-    margin: 0 4px;
-  `
+function animateButton(button: HTMLButtonElement) {
+  button.style.transform = 'scale(1.05)'
+  window.setTimeout(() => {
+    if (button.isConnected)
+      button.style.transform = 'scale(1)'
+  }, 150)
+}
 
-  watchLaterBtn.innerHTML = `
-    <div class="video-toolbar-item-icon" style="
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      width: 100%;
-      height: 100%;
-    ">
-      <i class="i-mingcute:carplay-line" style="
-        font-size: 18px;
-        line-height: 1;
-        color: var(--text1);
-        transition: color 0.2s ease;
-      "></i>
-    </div>
-  `
-
-  // 添加点击事件
-  watchLaterBtn.addEventListener('click', async () => {
+function scheduleTopBarRefresh() {
+  window.setTimeout(() => {
     try {
-      // 获取图标元素
-      const iconElement = watchLaterBtn.querySelector('i')
-      if (!iconElement)
-        return
-
-      // 禁用按钮防止重复点击
-      watchLaterBtn.style.pointerEvents = 'none'
-
-      // 动态导入api模块
-      const { default: api } = await import('~/utils/api')
-      const { getCSRF } = await import('~/utils/main')
-      const { useTopBarStore } = await import('~/stores/topBarStore')
-
-      // 必须在点击时读取当前 URL：合集/列表 SPA 切集后 bvid 会变，不能用创建按钮时的闭包值
-      const { bvid, aid } = extractVideoIds()
-      if (!bvid && !aid) {
-        watchLaterBtn.style.pointerEvents = 'auto'
-        return
-      }
-
-      const params: { bvid?: string, aid?: number, csrf: string } = {
-        csrf: getCSRF(),
-      }
-
-      if (bvid) {
-        params.bvid = bvid
-      }
-      else if (aid) {
-        params.aid = aid
-      }
-
-      // 使用已有的API封装
-      const result = await api.watchlater.saveToWatchLater(params)
-
-      if (result.code === 0) {
-        // 成功后将图标变为勾选
-        iconElement.className = 'i-mingcute:check-line'
-        iconElement.style.color = 'var(--bew-theme-color)'
-
-        // 添加成功动画效果
-        watchLaterBtn.style.transform = 'scale(1.1)'
-        setTimeout(() => {
-          watchLaterBtn.style.transform = 'scale(1)'
-        }, 150)
-
-        // 更新顶栏数据
-        setTimeout(() => {
-          const topBarStore = useTopBarStore()
-          topBarStore.getAllWatchLaterList()
-        }, 1000)
-
-        // 2秒后恢复原始图标
-        setTimeout(() => {
-          iconElement.className = 'i-mingcute:carplay-line'
-          iconElement.style.color = 'var(--text1)'
-          watchLaterBtn.style.pointerEvents = 'auto'
-        }, 2000)
-      }
-      else {
-        // 失败时恢复按钮状态
-        watchLaterBtn.style.pointerEvents = 'auto'
-      }
+      void useTopBarStore().getAllWatchLaterList()
     }
     catch (error) {
-      console.error('添加稍后再看出错:', error)
-      // 出错时恢复按钮状态
-      watchLaterBtn.style.pointerEvents = 'auto'
+      console.error('刷新稍后再看列表失败:', error)
     }
+  }, 1000)
+}
+
+async function resolveAid(ids: VideoIds, state: WatchLaterButtonState): Promise<number | undefined> {
+  if (state.aid)
+    return state.aid
+  if (!ids.bvid)
+    return undefined
+  if (state.pendingAid)
+    return state.pendingAid
+
+  state.pendingAid = api.video.getVideoInfo({ bvid: ids.bvid })
+    .then((result: any) => {
+      const aid = result.code === 0 && Number.isFinite(result.data?.aid)
+        ? Number(result.data.aid)
+        : undefined
+      state.aid = aid
+      return aid
+    })
+    .finally(() => {
+      state.pendingAid = undefined
+    })
+
+  return state.pendingAid
+}
+
+async function initializeButtonState(button: HTMLButtonElement, ids: VideoIds, state: WatchLaterButtonState) {
+  try {
+    const result = await api.watchlater.getAllWatchLaterList() as WatchLaterResult
+    if (!button.isConnected)
+      return
+
+    if (result.code === 0) {
+      const item = findWatchLaterItem(result.data?.list, ids)
+      state.isInWatchLater = Boolean(item)
+      state.aid = item?.aid || state.aid
+      updateButtonState(button, state.isInWatchLater)
+    }
+  }
+  catch (error) {
+    console.error('获取稍后再看状态失败:', error)
+  }
+  finally {
+    if (button.isConnected)
+      setButtonBusy(button, false)
+  }
+}
+
+async function toggleWatchLater(button: HTMLButtonElement, ids: VideoIds, state: WatchLaterButtonState) {
+  setButtonBusy(button, true)
+
+  try {
+    if (state.isInWatchLater) {
+      const aid = await resolveAid(ids, state)
+      if (!aid) {
+        console.warn('无法获取当前视频的 aid，不能从稍后再看中移除')
+        return
+      }
+
+      const result = await api.watchlater.removeFromWatchLater({
+        aid,
+        csrf: getCSRF(),
+      })
+      if (result.code !== 0) {
+        console.warn('从稍后再看中移除失败:', result.message || result.code)
+        return
+      }
+
+      state.isInWatchLater = false
+    }
+    else {
+      const result = await api.watchlater.saveToWatchLater({
+        ...ids,
+        csrf: getCSRF(),
+      })
+      if (result.code !== 0) {
+        console.warn('添加到稍后再看失败:', result.message || result.code)
+        return
+      }
+
+      state.isInWatchLater = true
+    }
+
+    updateButtonState(button, state.isInWatchLater)
+    animateButton(button)
+    scheduleTopBarRefresh()
+  }
+  catch (error) {
+    console.error('更新稍后再看状态失败:', error)
+  }
+  finally {
+    if (button.isConnected)
+      setButtonBusy(button, false)
+  }
+}
+
+function createButton(ids: VideoIds): HTMLButtonElement {
+  const button = document.createElement('button')
+  button.type = 'button'
+  button.className = `video-toolbar-right-item ${BUTTON_CLASS}`
+  button.dataset.videoKey = getVideoKey(ids)
+  button.style.cssText = `
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    box-sizing: border-box;
+    width: auto;
+    min-width: max-content;
+    height: 32px;
+    margin: 0 4px;
+    padding: 0 10px;
+    border: 0;
+    border-radius: 6px;
+    background: transparent;
+    font: inherit;
+    font-size: 14px;
+    line-height: 20px;
+    white-space: nowrap;
+    transition: color 0.2s ease, background-color 0.2s ease, transform 0.15s ease, opacity 0.2s ease;
+  `
+  button.innerHTML = `
+    <i class="${INACTIVE_ICON_CLASS} bewly-watch-later-btn__icon" style="
+      flex: none;
+      color: inherit;
+      font-size: 18px;
+      line-height: 1;
+    "></i>
+    <span class="bewly-watch-later-btn__label" style="color: inherit; white-space: nowrap;"></span>
+  `
+
+  updateButtonState(button, false)
+  setButtonBusy(button, true)
+  return button
+}
+
+function mountWatchLaterButton(ids: VideoIds): MountedWatchLaterButton | undefined {
+  const moreButton = document.querySelector('.video-tool-more')
+  if (!moreButton?.parentNode)
+    return undefined
+
+  const state: WatchLaterButtonState = {
+    aid: ids.aid,
+    isInWatchLater: false,
+  }
+  const button = createButton(ids)
+  const mounted: MountedWatchLaterButton = {
+    button,
+    ids,
+    ready: Promise.resolve(),
+    state,
+  }
+
+  button.addEventListener('click', () => {
+    void handleButtonClick(mounted)
   })
 
-  // 将按钮插入到更多按钮之前
-  moreButton.parentNode?.insertBefore(watchLaterBtn, moreButton)
+  moreButton.parentNode.insertBefore(button, moreButton)
+  mounted.ready = initializeButtonState(button, ids, state)
+  return mounted
+}
+
+async function handleButtonClick(mounted: MountedWatchLaterButton) {
+  // 合集/列表页切集后必须以点击瞬间的 URL 为准，不能继续使用旧按钮闭包中的视频 ID。
+  const currentIds = extractVideoIds()
+  const currentVideoKey = getVideoKey(currentIds)
+  if (!currentVideoKey)
+    return
+
+  if (currentVideoKey !== getVideoKey(mounted.ids)) {
+    mounted.button.remove()
+    const replacement = mountWatchLaterButton(currentIds)
+    if (!replacement)
+      return
+
+    await replacement.ready
+    if (!replacement.button.isConnected || getVideoKey(extractVideoIds()) !== currentVideoKey)
+      return
+
+    await toggleWatchLater(replacement.button, replacement.ids, replacement.state)
+    return
+  }
+
+  await mounted.ready
+  if (!mounted.button.isConnected || getVideoKey(extractVideoIds()) !== currentVideoKey)
+    return
+
+  await toggleWatchLater(mounted.button, currentIds, mounted.state)
+}
+
+/**
+ * 添加稍后再看按钮到视频页面。
+ * @returns 是否已找到工具栏并成功插入（或复用）按钮
+ */
+export function addWatchLaterButton(): boolean {
+  const ids = extractVideoIds()
+  const videoKey = getVideoKey(ids)
+  if (!videoKey)
+    return false
+
+  const existingButton = document.querySelector<HTMLButtonElement>(`.${BUTTON_CLASS}`)
+  if (existingButton?.dataset.videoKey === videoKey)
+    return true
+  existingButton?.remove()
+
+  return Boolean(mountWatchLaterButton(ids))
 }


### PR DESCRIPTION
## 关联 Issue

Closes #787

## 改动内容

- 默认开启“稍后再看按钮外置”设置，新用户可直接在视频页工具栏使用。
- 按钮初始化时读取当前稍后再看列表；视频已在列表中时使用主题色高亮，并显示“已添加到稍后再看”。
- 将按钮改为双向切换：未添加时点击加入，已添加时再次点击即可移除。
- BV 视频在需要移除时按需解析 `aid`，支持添加后不刷新页面直接再次点击移除。
- 增加按钮文字、操作状态、禁用态及无障碍属性，并补充简体中文、繁体中文、粤语和英文文案。
- 修复 B 站站内切换视频后旧按钮仍绑定上一个视频的问题。
- 新增外置按钮状态、高亮、添加、移除及 SPA 导航行为测试。

## 原因与影响

原实现只调用添加接口，成功提示两秒后便恢复初始图标；它既不会查询当前视频是否已经在稍后再看中，也没有移除路径。此外，站内切换视频时旧按钮节点没有被清理，可能继续操作上一个视频。

本次修改后，按钮会持续呈现真实状态，用户可以在同一位置完成添加和移除；站内切换视频时也会重新绑定当前视频。按照 Issue 讨论，本 PR 不包含“播放完自动移除”功能。

## 验证

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test --run`（6 个测试文件、13 项测试通过）
- `pnpm build:js -- --mode production`
