### PR TITLE
chore: 固定自动导入声明文件的换行格式

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Keep the generated declaration stable across platforms.
+/src/auto-imports.d.ts text eol=lf


### PR DESCRIPTION
## 改动内容

- 新增 `.gitattributes`。
- 将 `src/auto-imports.d.ts` 明确设置为 `text eol=lf`，统一 Git 检出与自动生成器使用的换行格式。

## 原因与影响

Windows 环境启用 `core.autocrlf=true` 时，Git 会按 CRLF 缓存该文件的工作区元数据；`unplugin-auto-import` 构建时则会用 LF 重新生成相同内容。两份文件归一化后的 Git blob 完全相同，但原始大小和时间戳不同，因此可能长期出现 `git status` 显示已修改、`git diff` 却为空的伪修改。

本次规则只作用于这一个自动生成的声明文件，不改变其内容，也不影响仓库其他文件的换行策略。后续在不同平台运行构建时，Git 状态将保持稳定。

## 验证

- `git check-attr text eol -- src/auto-imports.d.ts` 返回 `text: set`、`eol: lf`
- 工作区文件与 HEAD 中的归一化哈希均为 `645b87b1b453d449c40c10206e18bf88f43a1b6e`
- 执行 `pnpm build:js -- --mode production` 后，`src/auto-imports.d.ts` 未再次出现在 `git status`
