### PR TITLE
fix: 修复视频页暗色模式与主题色适配

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,3 +72,7 @@ The project uses a multi-target build system:
 - Auto-imports for Vue and webextension-polyfill
 - Extensive use of Shadow DOM for style isolation
 - Platform-specific builds with conditional manifest generation
+
+## 语言规范
+- 新增或修改的代码注释统一使用中文。
+- Pull Request 的标题和正文统一使用中文。

--- a/src/inject/index.ts
+++ b/src/inject/index.ts
@@ -60,6 +60,52 @@ else {
   const COMMENT_COMPONENT_PATCHED = Symbol('bewly-comment-component-patched')
   const pendingCommentEnhancements = new WeakSet<object>()
 
+  const COMMENT_SHADOW_STYLE_PATCHES: Record<string, { id: string, css: string }> = {
+    'bili-comment-replies-renderer': {
+      id: 'bewly-comment-replies-style',
+      css: `
+        #spinner {
+          background: var(--bew-comment-replies-mask-bg, rgba(var(--bg1_rgb), 0.85)) !important;
+        }
+      `,
+    },
+    'bili-comment-renderer': {
+      id: 'bewly-comment-renderer-style',
+      css: `
+        #body.dark .tag {
+          --bili-comment-tag-color: var(--bew-comment-tag-color, var(--bili-comment-tag-color-dark)) !important;
+          --bili-comment-tag-bg: var(--bew-comment-tag-bg, var(--bili-comment-tag-bg-dark)) !important;
+        }
+      `,
+    },
+    'bili-comment-box': {
+      id: 'bewly-comment-box-style',
+      css: `
+        #editor:not(:hover):not(.active) {
+          border-color: var(--bew-comment-editor-border, var(--Ga1)) !important;
+        }
+      `,
+    },
+    'bili-comments-vote-card': {
+      id: 'bewly-vote-card-style',
+      css: `
+        :host {
+          --option-color: var(--bew-text-1, #18191c) !important;
+        }
+      `,
+    },
+  }
+
+  function ensureCommentShadowStyle(root: ShadowRoot, id: string, css: string) {
+    if (root.querySelector(`#${id}`))
+      return
+
+    const style = document.createElement('style')
+    style.id = id
+    style.textContent = css
+    root.appendChild(style)
+  }
+
   function patchCommentComponentUpdate(
     name: string,
     classConstructor: any,
@@ -329,6 +375,23 @@ else {
           return Reflect.apply(target, thisArg, args)
         }
 
+        const shadowStylePatch = COMMENT_SHADOW_STYLE_PATCHES[name]
+        if (shadowStylePatch) {
+          try {
+            patchCommentComponentUpdate(name, classConstructor, (component) => {
+              const root = component.shadowRoot
+              if (!root)
+                return
+
+              ensureCommentShadowStyle(root, shadowStylePatch.id, shadowStylePatch.css)
+            })
+          }
+          catch (error) {
+            console.warn(`[BewlyCat] Failed to patch ${name}.`, error)
+          }
+          return Reflect.apply(target, thisArg, args)
+        }
+
         // 处理评论区图片组件
         if (name === 'bili-comment-pictures-renderer') {
           try {
@@ -391,33 +454,6 @@ else {
               const shouldShowLocation = Boolean(currentSettings?.showIPLocation && locationString)
               const locationAnchor = hostEl ?? sexEl ?? userNameEl
               updateInfoElement(root, 'location', shouldShowLocation, locationString, locationAnchor)
-            })
-          }
-          catch (error) {
-            console.warn(`[BewlyCat] Failed to patch ${name}.`, error)
-          }
-          return Reflect.apply(target, thisArg, args)
-        }
-
-        // 处理评论投票卡片组件（修复深色模式下的文字颜色）
-        if (name === 'bili-comments-vote-card') {
-          try {
-            patchCommentComponentUpdate(name, classConstructor, (component) => {
-              const root = component.shadowRoot
-              if (!root)
-                return
-
-              // 检查是否已经注入过样式
-              if (!root.querySelector('#bewly-vote-card-style')) {
-                const style = document.createElement('style')
-                style.id = 'bewly-vote-card-style'
-                style.textContent = `
-                :host {
-                  --option-color: var(--bew-text-1, #18191c) !important;
-                }
-              `
-                root.appendChild(style)
-              }
             })
           }
           catch (error) {

--- a/src/styles/adaptedStyles/common/comments.scss
+++ b/src/styles/adaptedStyles/common/comments.scss
@@ -57,7 +57,7 @@
 
   // #region dark mode adaption part
   &.dark {
-    // Bridge the personalized palette into Bilibili comment component shadow roots.
+    // 将个性化配色变量传入 Bilibili 评论组件的 Shadow DOM。
     --bew-comment-replies-mask-bg: color-mix(in oklab, var(--bew-bg), transparent 15%);
     --bew-comment-tag-color: var(--bew-text-2);
     --bew-comment-tag-bg: var(--bew-fill-1);

--- a/src/styles/adaptedStyles/common/comments.scss
+++ b/src/styles/adaptedStyles/common/comments.scss
@@ -57,6 +57,12 @@
 
   // #region dark mode adaption part
   &.dark {
+    // Bridge the personalized palette into Bilibili comment component shadow roots.
+    --bew-comment-replies-mask-bg: color-mix(in oklab, var(--bew-bg), transparent 15%);
+    --bew-comment-tag-color: var(--bew-text-2);
+    --bew-comment-tag-bg: var(--bew-fill-1);
+    --bew-comment-editor-border: var(--bew-border-color);
+
     // 評論人用戶名
     .reply-item .root-reply-container .content-warp .user-info .user-name,
     .sub-reply-item .sub-user-info .sub-user-name {

--- a/src/styles/adaptedStyles/index.ts
+++ b/src/styles/adaptedStyles/index.ts
@@ -77,6 +77,8 @@ async function setupStyles() {
     || /https?:\/\/(?:www\.)?bilibili\.com\/list\/watchlater.*/.test(currentUrl)
     // favorite playlist 收藏播放页
     || /https?:\/\/(?:www\.)?bilibili\.com\/list\/ml.*/.test(currentUrl)
+    // legacy favorite playlist playback page 旧版收藏播放页
+    || /https?:\/\/(?:www\.)?bilibili\.com\/medialist\/play\/.*/.test(currentUrl)
     // 视频合集
     || /https?:\/\/(?:www\.)?bilibili\.com\/list\/.*/.test(currentUrl)
   ) {

--- a/src/styles/adaptedStyles/index.ts
+++ b/src/styles/adaptedStyles/index.ts
@@ -77,7 +77,7 @@ async function setupStyles() {
     || /https?:\/\/(?:www\.)?bilibili\.com\/list\/watchlater.*/.test(currentUrl)
     // favorite playlist 收藏播放页
     || /https?:\/\/(?:www\.)?bilibili\.com\/list\/ml.*/.test(currentUrl)
-    // legacy favorite playlist playback page 旧版收藏播放页
+    // 旧版收藏播放页
     || /https?:\/\/(?:www\.)?bilibili\.com\/medialist\/play\/.*/.test(currentUrl)
     // 视频合集
     || /https?:\/\/(?:www\.)?bilibili\.com\/list\/.*/.test(currentUrl)

--- a/src/styles/adaptedStyles/pages/videoPage.scss
+++ b/src/styles/adaptedStyles/pages/videoPage.scss
@@ -52,6 +52,14 @@
       background: unset;
     }
 
+    .video-info-container .video-info-title-inner .video-title .video-title-href:hover,
+    .simple-base-item:hover .title,
+    .simple-base-item.active .title,
+    .normal-base-item:hover .info .title,
+    .normal-base-item.active .info .title {
+      color: var(--bew-theme-color) !important;
+    }
+
     // Firefox specific fix for checkbox visibility
     @-moz-document url-prefix() {
       .content .group-list li input[type="checkbox"]:checked + i,
@@ -567,6 +575,12 @@
 
   // #region dark mode adaption part
   &.dark {
+    .collection-m-exp .content .group-list li label.disable input[type="checkbox"] + i,
+    .collection-m-exp .content .group-list li label.disable input[type="checkbox"]:hover + i {
+      background: var(--bew-fill-1) !important;
+      border-color: var(--bew-border-color) !important;
+    }
+
     .video-ai-assistant .video-ai-assistant-bg::before,
     .note-pc .note-container .note-header .back-note-list:hover,
     .note-pc .note-container .note-header .jump-note-package:hover,


### PR DESCRIPTION
虽然不知道各位为啥暗色模式要把背景改这么亮，不然都看不出这些bug，不过给各位列文虎克修了。

## 修改内容

- 将 Bilibili 评论组件 Shadow DOM 中的加载遮罩、标签与未激活编辑器边框接入 BewlyCat 个性化暗色配色
- 修复收藏夹已满时禁用复选框在暗色模式下显示为白色的问题
- 收藏夹与稍后再看列表的悬停项、当前项标题（包括顶部视频标题链接）使用个性化主题色
- 为旧版 `/medialist/play/` 路由加载视频页适配样式
- 补充项目语言规范，要求新增或修改的代码注释、PR 标题和正文统一使用中文

## 问题原因

Bilibili 的部分评论控件渲染在 Shadow DOM 中，并使用文档级样式无法覆盖的内置暗色变量。视频标题悬停状态仍使用 Bilibili 固定蓝色，收藏夹已满时的禁用复选框则会回退到浅色背景图。

## 用户影响

使用自定义暗色背景时，评论区不再出现黑色加载遮罩或浅色控件；收藏夹和稍后再看页面的视频标题悬停状态也会跟随用户选择的主题色。

## 验证

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build:inject`
- `pnpm build:js`
- 在 `/list/watchlater/` 页面完成手动验证

Closes #459
Closes #477
