### PR TITLE
fix: 修复账号登录页暗色样式与消息序列化

### DIFF
--- a/src/background/messageListeners/api/auth.ts
+++ b/src/background/messageListeners/api/auth.ts
@@ -1,4 +1,3 @@
-// 由于 sendResponse 复杂, 所以使用自定义的函数
 import type { APIMAP } from '../../utils'
 import { AHS } from '../../utils'
 
@@ -19,7 +18,7 @@ const API_AUTH = {
     params: {
       biliCSRF: '',
     },
-    afterHandle: AHS.J_S,
+    afterHandle: AHS.J_D,
   },
   getLoginQRCode: {
     url: 'https://passport.bilibili.com/x/passport-tv-login/qrcode/auth_code',
@@ -35,7 +34,7 @@ const API_AUTH = {
       ts: '0',
       sign: 'e134154ed6add881d28fbdf68653cd9c',
     },
-    afterHandle: AHS.J_S,
+    afterHandle: AHS.J_D,
   },
   qrCodeLogin: {
     url: 'https://passport.bilibili.com/x/passport-tv-login/qrcode/auth_code',
@@ -52,7 +51,7 @@ const API_AUTH = {
       ts: '0',
       sign: 'e134154ed6add881d28fbdf68653cd9c',
     },
-    afterHandle: AHS.J_S,
+    afterHandle: AHS.J_D,
   },
 } satisfies APIMAP
 

--- a/src/styles/adaptedStyles/pages/accountSettingsPage.scss
+++ b/src/styles/adaptedStyles/pages/accountSettingsPage.scss
@@ -8,7 +8,6 @@
 
   // #region dark mode adaption part
   &.dark {
-    .top-img,
     .top_bg {
       filter: invert(1) hue-rotate(180deg);
     }

--- a/src/styles/adaptedStyles/pages/accountSettingsPage.scss
+++ b/src/styles/adaptedStyles/pages/accountSettingsPage.scss
@@ -8,6 +8,7 @@
 
   // #region dark mode adaption part
   &.dark {
+    .top-img,
     .top_bg {
       filter: invert(1) hue-rotate(180deg);
     }

--- a/src/styles/adaptedStyles/pages/loginPage.scss
+++ b/src/styles/adaptedStyles/pages/loginPage.scss
@@ -90,14 +90,6 @@
     .login-protocol {
       color: var(--bew-text-3);
     }
-
-    .top-header {
-      filter: invert(1) hue-rotate(180deg);
-    }
-
-    .top-img {
-      background-color: black;
-    }
   }
   // #endregion
 }

--- a/src/styles/adaptedStyles/pages/loginPage.scss
+++ b/src/styles/adaptedStyles/pages/loginPage.scss
@@ -94,6 +94,10 @@
     .top-header {
       filter: invert(1) hue-rotate(180deg);
     }
+
+    .top-img {
+      background-color: black;
+    }
   }
   // #endregion
 }

--- a/src/tests/authApi.spec.ts
+++ b/src/tests/authApi.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import API_AUTH from '~/background/messageListeners/api/auth'
+import { AHS } from '~/background/utils'
+
+vi.mock('webextension-polyfill', () => ({
+  default: {},
+}))
+
+describe('auth API message responses', () => {
+  it('uses promise-compatible JSON handlers', () => {
+    for (const api of Object.values(API_AUTH)) {
+      expect(api.afterHandle).toBe(AHS.J_D)
+      expect(api.afterHandle).not.toContain(AHS.J_S.at(-1))
+    }
+  })
+})


### PR DESCRIPTION
## 修改内容

- 移除登录页暗色模式对整个 `.top-header` 使用的反色滤镜
- 将认证 API 从旧的回调式 `J_S` 后处理切换到 Promise 兼容的 `J_D`
- 添加认证消息响应的回归测试

## 原因

登录页原先通过 `.top-header { filter: invert(1) hue-rotate(180deg) }` 反转整个顶部横幅。这会同时反转 `.top-img` 图片未覆盖区域的白色底色，使其在暗色模式下错误显示为黑色。移除横幅级滤镜后，原始图片颜色和白色底色均能正确显示。

认证 API 的消息监听器已经使用 Promise 返回响应，但仍配置了旧的 `sendResponse` 后处理。由于当前调用没有传入 `sendResponse`，后处理链最终返回了函数；浏览器无法通过扩展消息通道序列化函数，因此抛出 `TypeError: Could not serialize message`。

## 影响

- 账号登录界面的 `.top-img` 保持原本的白色底色
- 登录二维码、二维码登录和退出登录 API 返回可序列化的 JSON 数据

Closes #542

## 验证

- 人工验证登录页暗色模式下的顶部横幅与白色底色
- `pnpm test`（10 个测试文件、25 项测试通过）
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`
