### PR TITLE
fix: 修复原生搜索链接未直接进入插件搜索页

### DIFF
--- a/src/contentScripts/index.ts
+++ b/src/contentScripts/index.ts
@@ -16,9 +16,10 @@ import { captureOriginalBilibiliTopBar, ensureOriginalBilibiliTopBarAppended, re
 import { initFavoriteDialogEnhancement } from '~/utils/favoriteDialog'
 import { runWhenIdle } from '~/utils/lazyLoad'
 import { getLocalWallpaper, hasLocalWallpaper, isLocalWallpaperUrl } from '~/utils/localWallpaper'
-import { compareVersions, injectCSS, isElectron, isHomePage, isInIframe, isNotificationPage, isVideoOrBangumiPage, isVideoPlaybackPage } from '~/utils/main'
+import { compareVersions, getCookie, injectCSS, isElectron, isHomePage, isInIframe, isNotificationPage, isVideoOrBangumiPage, isVideoPlaybackPage } from '~/utils/main'
 import { applyAutoPlayByVideoType, applyDefaultCaptionState, applyDefaultDanmakuState, defaultMode, handleVideoPageNavigation, isCollectionVideo, isPlayerDisplayModeReady, isVideoPage, startAutoExitFullscreenMonitoring, startAutoPlayUserChangeMonitoring, webFullscreen, widescreen } from '~/utils/player'
 import { initRandomPlay, resetRandomPlayInitialization } from '~/utils/randomPlay'
+import { getPluginSearchResultsUrl } from '~/utils/searchNavigation'
 import { setupShortcutHandlers } from '~/utils/shortcuts'
 import { SVG_ICONS } from '~/utils/svgIcons'
 import { openLinkInBackground } from '~/utils/tabs'
@@ -170,6 +171,27 @@ else if (shouldInitializeContentScript) {
   let hasAppliedPlayerMode = false // 添加标志变量
   let playerModeRetryTimer: ReturnType<typeof setTimeout> | undefined
   let watchLaterButtonAdded = false // 标记稍后再看按钮是否已添加
+
+  function setupPluginSearchLinkNavigation() {
+    document.addEventListener('click', (event) => {
+      if (!settings.value.usePluginSearchResultsPage || !getCookie('DedeUserID'))
+        return
+
+      const target = event.target
+      if (!(target instanceof Element))
+        return
+
+      const anchor = target.closest('a[href]')
+      if (!(anchor instanceof HTMLAnchorElement))
+        return
+
+      const pluginSearchResultsUrl = getPluginSearchResultsUrl(anchor.href)
+      if (pluginSearchResultsUrl)
+        anchor.href = pluginSearchResultsUrl
+    }, true)
+  }
+
+  void settingsReady.then(() => setupPluginSearchLinkNavigation())
 
   function shouldApplyBewlyDesign() {
     if (settings.value.adaptToOtherPageStyles)
@@ -535,6 +557,17 @@ else if (shouldInitializeContentScript) {
   const removeOriginalTopBar = injectCSS(`.bili-header, #biliMainHeader { visibility: hidden !important; }`)
 
   async function onDOMLoaded() {
+    const pluginSearchResultsUrl = !isInIframe() && getPluginSearchResultsUrl(location.href)
+
+    if (pluginSearchResultsUrl) {
+      await settingsReady
+
+      if (settings.value.usePluginSearchResultsPage && getCookie('DedeUserID')) {
+        location.replace(pluginSearchResultsUrl)
+        return
+      }
+    }
+
     const changeHomePage = !isInIframe() && !settings.value.useOriginalBilibiliHomepage && isHomePage()
 
     // Remove the original Bilibili homepage if in Bilibili homepage & useOriginalBilibiliHomepage is enabled
@@ -625,10 +658,14 @@ else if (shouldInitializeContentScript) {
     }
   }
 
-  if (document.readyState !== 'loading')
-    onDOMLoaded()
-  else
-    document.addEventListener('DOMContentLoaded', () => onDOMLoaded())
+  if (document.readyState !== 'loading') {
+    void onDOMLoaded()
+  }
+  else {
+    document.addEventListener('DOMContentLoaded', () => {
+      void onDOMLoaded()
+    })
+  }
 
   function injectAppWhenIdle() {
     return new Promise<void>((resolve) => {

--- a/src/tests/searchNavigation.spec.ts
+++ b/src/tests/searchNavigation.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { getPluginSearchResultsUrl } from '~/utils/searchNavigation'
+
+describe('native search navigation', () => {
+  it('routes native all-search links to the built-in results page', () => {
+    expect(getPluginSearchResultsUrl('https://search.bilibili.com/all?keyword=%E7%8C%AB%E5%92%AA'))
+      .toBe('https://www.bilibili.com/?page=SearchResults&keyword=%E7%8C%AB%E5%92%AA')
+  })
+
+  it('routes links with extra tracking parameters without carrying them over', () => {
+    expect(getPluginSearchResultsUrl('https://search.bilibili.com/all?keyword=tag&from_source=video_tag'))
+      .toBe('https://www.bilibili.com/?page=SearchResults&keyword=tag')
+  })
+
+  it('preserves a supported native search category', () => {
+    expect(getPluginSearchResultsUrl('https://search.bilibili.com/video?keyword=Vue'))
+      .toBe('https://www.bilibili.com/?page=SearchResults&keyword=Vue&category=video')
+    expect(getPluginSearchResultsUrl('https://search.bilibili.com/upuser?keyword=BewlyCat'))
+      .toBe('https://www.bilibili.com/?page=SearchResults&keyword=BewlyCat&category=user')
+  })
+
+  it('ignores keyword-less, unrelated, and malformed URLs', () => {
+    expect(getPluginSearchResultsUrl('https://search.bilibili.com/all')).toBeNull()
+    expect(getPluginSearchResultsUrl('https://www.bilibili.com/?keyword=test')).toBeNull()
+    expect(getPluginSearchResultsUrl('not a url')).toBeNull()
+  })
+})

--- a/src/utils/searchNavigation.ts
+++ b/src/utils/searchNavigation.ts
@@ -1,0 +1,45 @@
+const NATIVE_SEARCH_CATEGORY_BY_PATH: Record<string, string> = {
+  article: 'article',
+  bangumi: 'bangumi',
+  live: 'live',
+  media_bangumi: 'bangumi',
+  media_ft: 'media_ft',
+  movie: 'media_ft',
+  upuser: 'user',
+  user: 'user',
+  video: 'video',
+}
+
+/**
+ * Convert a Bilibili native search URL into BewlyCat's built-in search results
+ * URL. Returning null leaves unsupported or keyword-less pages untouched.
+ */
+export function getPluginSearchResultsUrl(value: string): string | null {
+  try {
+    const sourceUrl = new URL(value)
+    if (
+      (sourceUrl.protocol !== 'http:' && sourceUrl.protocol !== 'https:')
+      || sourceUrl.hostname !== 'search.bilibili.com'
+    ) {
+      return null
+    }
+
+    const keyword = sourceUrl.searchParams.get('keyword')?.trim()
+    if (!keyword)
+      return null
+
+    const targetUrl = new URL('https://www.bilibili.com/')
+    targetUrl.searchParams.set('page', 'SearchResults')
+    targetUrl.searchParams.set('keyword', keyword)
+
+    const nativeCategory = sourceUrl.pathname.split('/').filter(Boolean)[0]?.toLowerCase()
+    const pluginCategory = nativeCategory && NATIVE_SEARCH_CATEGORY_BY_PATH[nativeCategory]
+    if (pluginCategory)
+      targetUrl.searchParams.set('category', pluginCategory)
+
+    return targetUrl.toString()
+  }
+  catch {
+    return null
+  }
+}


### PR DESCRIPTION
## 修改内容

- 在点击视频标签、评论关键词等原生搜索链接前，将目标地址改为 BewlyCat 内置搜索结果页，避免先加载官方搜索页再二次跳转
- 对地址栏直达或其他来源进入原生搜索页的情况保留重定向兜底
- 遵循“使用插件搜索结果页”设置和登录状态，并保留支持的视频、用户、番剧、影视、直播、专栏分类
- 增加搜索 URL 转换的回归测试

## 根因

内容脚本虽然覆盖 `search.bilibili.com`，但该页面只挂载了 BewlyCat 顶栏和适配样式，没有将 Bilibili 原生搜索地址桥接到位于 `www.bilibili.com/?page=SearchResults` 的插件内置结果页。

## 验证

- `pnpm eslint src/contentScripts/index.ts src/utils/searchNavigation.ts src/tests/searchNavigation.spec.ts`
- `pnpm typecheck`
- `pnpm test -- searchNavigation.spec.ts`（10 个测试文件、28 项测试通过）
- `git diff --check`

Fixes #735