### PR TITLE
fix: 修复原版顶栏搜索二次跳转

### DIFF
--- a/src/components/SearchBar/SearchBar.vue
+++ b/src/components/SearchBar/SearchBar.vue
@@ -6,7 +6,6 @@ import { computed, inject, reactive, ref, shallowRef, watch } from 'vue'
 import type { BewlyAppProvider } from '~/composables/useAppProvider'
 import { AppPage } from '~/enums/appEnums'
 import { settings } from '~/logic'
-import { useTopBarStore } from '~/stores/topBarStore'
 import api from '~/utils/api'
 import { findLeafActiveElement } from '~/utils/element'
 import { isHomePage } from '~/utils/main'
@@ -118,9 +117,6 @@ const placeholderText = computed(() => {
 
 // 尝试获取 BEWLY_APP（在首页时可用）
 const bewlyApp = inject<BewlyAppProvider | undefined>('BEWLY_APP', undefined)
-
-// 获取登录状态
-const topBarStore = useTopBarStore()
 
 // 判断是否在搜索结果页且启用了插件搜索
 const shouldHandleInCurrentPage = computed(() => {
@@ -338,16 +334,10 @@ function handleNativeInput(event: Event) {
 function buildKeywordHref(keyword: string) {
   const encoded = encodeURIComponent(keyword)
 
-  // 如果未登录，直接返回 B 站原版搜索页面 URL
-  if (!topBarStore.isLogin) {
-    return `https://search.bilibili.com/all?keyword=${encoded}`
-  }
-
   if (settings.value.usePluginSearchResultsPage) {
-    // 写死插件搜索结果页面 URL
     return `https://www.bilibili.com/?page=SearchResults&keyword=${encoded}`
   }
-  // 写死B站原版搜索页面 URL
+
   return `https://search.bilibili.com/all?keyword=${encoded}`
 }
 

--- a/src/contentScripts/index.ts
+++ b/src/contentScripts/index.ts
@@ -12,7 +12,7 @@ import { useTopBarStore } from '~/stores/topBarStore'
 import RESET_BEWLY_CSS from '~/styles/reset.css?raw'
 import { applyBewlyWidescreen, exitBewlyWidescreen } from '~/utils/bewlyWidescreen'
 import { cleanupBilibiliScripts } from '~/utils/bilibiliScriptCleanup'
-import { captureOriginalBilibiliTopBar, ensureOriginalBilibiliTopBarAppended, resetBilibiliTopBarInlineStyles, setupLoginButtonClickHandlers } from '~/utils/bilibiliTopBar'
+import { captureOriginalBilibiliTopBar, ensureOriginalBilibiliTopBarAppended, resetBilibiliTopBarInlineStyles, setupLoginButtonClickHandlers, setupOriginalBilibiliTopBarSearchHandlers } from '~/utils/bilibiliTopBar'
 import { initFavoriteDialogEnhancement } from '~/utils/favoriteDialog'
 import { runWhenIdle } from '~/utils/lazyLoad'
 import { getLocalWallpaper, hasLocalWallpaper, isLocalWallpaperUrl } from '~/utils/localWallpaper'
@@ -561,6 +561,8 @@ else if (shouldInitializeContentScript) {
   const removeOriginalTopBar = injectCSS(`.bili-header, #biliMainHeader { visibility: hidden !important; }`)
 
   async function onDOMLoaded() {
+    setupOriginalBilibiliTopBarSearchHandlers(document, () => settings.value.usePluginSearchResultsPage)
+
     const pluginSearchResultsUrl = !isInIframe() && getPluginSearchResultsUrl(location.href)
 
     if (pluginSearchResultsUrl) {

--- a/src/contentScripts/views/Search/Search.vue
+++ b/src/contentScripts/views/Search/Search.vue
@@ -8,7 +8,7 @@ import { useTopBarStore } from '~/stores/topBarStore'
 // 搜索关键词
 const searchInput = ref<string>('')
 const topBarStore = useTopBarStore()
-const { searchKeyword: topBarSearchKeyword, isLogin } = storeToRefs(topBarStore)
+const { searchKeyword: topBarSearchKeyword } = storeToRefs(topBarStore)
 
 // 页面卸载时清空顶栏搜索框（真正离开搜索页面）
 onUnmounted(() => {
@@ -19,13 +19,6 @@ function performInPlaceSearch(keyword: string) {
   const normalized = keyword.trim()
   if (!normalized)
     return
-
-  // 如果未登录，跳转到 B 站原版搜索页面
-  if (!isLogin.value) {
-    const encoded = encodeURIComponent(normalized)
-    window.location.href = `https://search.bilibili.com/all?keyword=${encoded}`
-    return
-  }
 
   const params = new URLSearchParams(window.location.search)
   params.set('page', 'SearchResults')

--- a/src/utils/bilibiliTopBar.ts
+++ b/src/utils/bilibiliTopBar.ts
@@ -11,6 +11,7 @@ const BILIBILI_TOP_BAR_SELECTORS = [
 ]
 
 let cachedOriginalTopBar: HTMLElement | null = null
+const originalTopBarSearchCleanups = new WeakMap<Document, () => void>()
 
 function getDocumentTopBar(doc: Document): HTMLElement | null {
   return doc.querySelector<HTMLElement>('.bili-header')
@@ -127,4 +128,100 @@ export function setupLoginButtonClickHandlers(doc: Document) {
   return () => {
     observer.disconnect()
   }
+}
+
+/**
+ * 在启用插件搜索结果页时，接管原版 B 站顶栏的搜索提交。
+ * 捕获阶段拦截可以避免 B 站自身的点击处理器先跳到 search.bilibili.com。
+ */
+export function setupOriginalBilibiliTopBarSearchHandlers(
+  doc: Document,
+  shouldUsePluginSearchResultsPage: () => boolean,
+) {
+  originalTopBarSearchCleanups.get(doc)?.()
+
+  const SEARCH_FORM_SELECTOR = [
+    '#nav-searchform',
+    '.nav-search-form',
+    '.nav-search-content',
+  ].join(', ')
+  const SEARCH_INPUT_SELECTOR = [
+    '.nav-search-input',
+    'input[name="keyword"]',
+    'input[type="search"]',
+  ].join(', ')
+  const SEARCH_SUBMIT_SELECTOR = [
+    '.nav-search-btn',
+    '.nav-search-submit',
+    'button[type="submit"]',
+  ].join(', ')
+
+  function getOriginalTopBarSearchContext(target: EventTarget | null) {
+    if (!(target instanceof Element))
+      return null
+
+    const header = target.closest('.bili-header, #biliMainHeader, #internationalHeader')
+    if (!header)
+      return null
+
+    const form = target.closest(SEARCH_FORM_SELECTOR) || header.querySelector(SEARCH_FORM_SELECTOR)
+    const input = (form || header).querySelector<HTMLInputElement>(SEARCH_INPUT_SELECTOR)
+    return { form, input }
+  }
+
+  function navigateToPluginSearch(event: Event, input: HTMLInputElement | null | undefined) {
+    if (!shouldUsePluginSearchResultsPage())
+      return false
+
+    const keyword = input?.value.trim()
+    if (!keyword)
+      return false
+
+    event.preventDefault()
+    event.stopPropagation()
+    event.stopImmediatePropagation()
+
+    const params = new URLSearchParams()
+    params.set('page', 'SearchResults')
+    params.set('keyword', keyword)
+    window.location.assign(`https://www.bilibili.com/?${params.toString()}`)
+    return true
+  }
+
+  function handleSubmit(event: SubmitEvent) {
+    const context = getOriginalTopBarSearchContext(event.target)
+    if (context)
+      navigateToPluginSearch(event, context.input)
+  }
+
+  function handleClick(event: MouseEvent) {
+    if (!(event.target instanceof Element) || !event.target.closest(SEARCH_SUBMIT_SELECTOR))
+      return
+
+    const context = getOriginalTopBarSearchContext(event.target)
+    if (context)
+      navigateToPluginSearch(event, context.input)
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key !== 'Enter' || event.isComposing)
+      return
+
+    const context = getOriginalTopBarSearchContext(event.target)
+    if (context?.input === event.target)
+      navigateToPluginSearch(event, context.input)
+  }
+
+  doc.addEventListener('submit', handleSubmit, true)
+  doc.addEventListener('click', handleClick, true)
+  doc.addEventListener('keydown', handleKeydown, true)
+
+  const cleanup = () => {
+    doc.removeEventListener('submit', handleSubmit, true)
+    doc.removeEventListener('click', handleClick, true)
+    doc.removeEventListener('keydown', handleKeydown, true)
+    originalTopBarSearchCleanups.delete(doc)
+  }
+  originalTopBarSearchCleanups.set(doc, cleanup)
+  return cleanup
 }


### PR DESCRIPTION
## 改动内容

- 在捕获阶段接管原版 B 站顶栏的搜索提交，直接进入 BewlyCat 内置搜索结果页。
- 同时覆盖点击搜索按钮、按下回车和表单提交三种入口。
- 统一 BewlyCat 通用搜索框和首页搜索页的导航判断，避免登录状态尚未初始化时错误进入原版搜索页。
- 保留原版搜索链接转换逻辑作为外部链接和直接访问的兜底。

## 问题原因

原版顶栏先执行 B 站自身的搜索处理，进入 `search.bilibili.com`，内容脚本加载后再转换为 BewlyCat 搜索地址，因此产生二次跳转和顶栏抽搐。部分搜索入口还优先依据登录状态选择原版搜索，而不是优先遵循“使用插件搜索结果页”设置。

## 用户影响

启用插件搜索结果页后，从原版顶栏发起搜索会直接进入 BewlyCat 搜索结果，不再短暂加载原版搜索页。关闭该设置时仍保留 B 站原始行为。

## 验证

- `pnpm typecheck`
- 定向 ESLint 检查
- `pnpm vitest run src/tests/searchNavigation.spec.ts`（4 项测试通过）
- `git diff --check`