### PR TITLE
feat: 修复原版顶栏滚动切换与频道栏交互

### DIFF
--- a/src/contentScripts/views/App.vue
+++ b/src/contentScripts/views/App.vue
@@ -14,6 +14,7 @@ import type { DockItem } from '~/stores/mainStore'
 import { useMainStore } from '~/stores/mainStore'
 import { useSettingsStore } from '~/stores/settingsStore'
 import { useTopBarStore } from '~/stores/topBarStore'
+import { setOriginalBilibiliTopBarScrolled } from '~/utils/bilibiliTopBar'
 import { isHomePage, isInIframe, isNotificationPage, isSearchResultsPage, isVideoOrBangumiPage, openLinkToNewTab, queryDomUntilFound, scrollToTop } from '~/utils/main'
 import emitter from '~/utils/mitt'
 
@@ -555,6 +556,8 @@ function handleOsScroll(_instance: any, event: Event) {
     const scrollTop = latestScrollTop
 
     emitter.emit(OVERLAY_SCROLL_BAR_SCROLL, scrollTop)
+    if (settings.value.useOriginalBilibiliTopBar)
+      setOriginalBilibiliTopBarScrolled(document, scrollTop > 0)
 
     // 只在滚动距离超过阈值时更新状态
     const scrollDelta = Math.abs(scrollTop - lastScrollTop)
@@ -916,6 +919,9 @@ if (settings.value.cleanUrlArgument) {
               <div
                 p="t-[calc(var(--bew-top-bar-height)+10px)]" m-auto
                 w="lg:[calc(100%-200px)] [calc(100%-150px)]"
+                :style="settings.useOriginalBilibiliTopBar && !reachTop
+                  ? { paddingTop: 'calc(var(--bew-top-bar-height) + 120px)' }
+                  : undefined"
               >
                 <Transition name="page-fade">
                   <Component :is="pages[activatedPage]" :key="activatedPage" />

--- a/src/contentScripts/views/necessarySettingsWatchers.ts
+++ b/src/contentScripts/views/necessarySettingsWatchers.ts
@@ -4,7 +4,7 @@ import { IFRAME_TOP_BAR_CHANGE } from '~/constants/globalEvents'
 import { setUselessFeedCardBlockerEnabled } from '~/contentScripts/features/blockUselessFeedCards'
 import { LanguageType } from '~/enums/appEnums'
 import { appAuthTokens, FROSTED_GLASS_BLUR_MAX_PX, FROSTED_GLASS_BLUR_MIN_PX, localSettings, originalSettings, settings } from '~/logic'
-import { resetBilibiliTopBarInlineStyles } from '~/utils/bilibiliTopBar'
+import { resetBilibiliTopBarInlineStyles, setOriginalBilibiliTopBarScrolled } from '~/utils/bilibiliTopBar'
 import { cleanBilibiliShareText, getUserID, injectCSS, isHomePage, isInIframe, isVideoPlaybackPage } from '~/utils/main'
 
 function isFestivalPage(): boolean {
@@ -515,6 +515,14 @@ export function setupNecessarySettingsWatchers() {
 
       if (settings.value.useOriginalBilibiliTopBar && !shouldHideOuterBiliTopBar)
         resetBilibiliTopBarInlineStyles(document)
+
+      if (settings.value.useOriginalBilibiliTopBar && !shouldHideOuterBiliTopBar) {
+        const scrollTop = document.getElementById('bewly')
+          ?.shadowRoot
+          ?.querySelector<HTMLElement>('.bewly-scroll-viewport')
+          ?.scrollTop ?? 0
+        setOriginalBilibiliTopBarScrolled(document, scrollTop > 0)
+      }
     }
     else {
       // Handle non-homepage pages

--- a/src/styles/removeTopBar.scss
+++ b/src/styles/removeTopBar.scss
@@ -1,6 +1,140 @@
+.homePage .bili-header > .bili-header__channel,
+.homePage .bili-header > .bewly-bili-fixed-channel,
+.homePage .bili-header > .bewly-bili-channel-panel {
+  display: none !important;
+}
+
+.homePage .bili-header {
+  .bewly-bili-logo-entry,
+  .bewly-home-entry-arrow {
+    display: none;
+  }
+}
+
+.homePage:not(.remove-top-bar) .bili-header.bewly-original-top-bar-scrolled > .bili-header__bar {
+  background-color: #fff !important;
+  backdrop-filter: none;
+}
+
+.dark.homePage:not(.remove-top-bar) .bili-header.bewly-original-top-bar-scrolled > .bili-header__bar {
+  background-color: rgb(36 38 40) !important;
+}
+
+.homePage:not(.remove-top-bar) .bili-header.bewly-original-top-bar-scrolled {
+  .bewly-bili-logo-entry {
+    display: flex;
+    align-items: center;
+    margin-right: 16px;
+
+    a {
+      display: flex;
+      align-items: center;
+      height: var(--bew-top-bar-height);
+    }
+
+    img {
+      display: block;
+      width: 88px;
+      max-height: 42px;
+      object-fit: contain;
+    }
+  }
+
+  .entry-title {
+    gap: 8px;
+    margin-right: 15px;
+
+    .zhuzhan-icon {
+      display: none;
+    }
+  }
+
+  .bewly-home-entry-arrow {
+    display: inline-block;
+    width: 7px;
+    height: 7px;
+    border-right: 2px solid currentColor;
+    border-bottom: 2px solid currentColor;
+    transform: translateY(-2px) rotate(45deg);
+  }
+
+  > .bewly-bili-fixed-channel {
+    display: flex !important;
+    position: fixed !important;
+    top: var(--bew-top-bar-height) !important;
+    left: 0 !important;
+    width: 100% !important;
+    max-width: none !important;
+    z-index: 1001 !important;
+  }
+}
+
+.homePage:not(.remove-top-bar) .bili-header.bewly-original-top-bar-scrolled.bewly-original-channel-open {
+  > .bewly-bili-channel-panel {
+    display: flex !important;
+    position: fixed !important;
+    top: var(--bew-top-bar-height) !important;
+    left: 24px !important;
+    width: max-content;
+    max-width: calc(100vw - 48px);
+    z-index: 1003 !important;
+    padding: 16px 0;
+    overflow-x: auto;
+    border-radius: 0 0 8px 8px;
+    background-color: var(--bew-elevated-solid) !important;
+    box-shadow: var(--bew-shadow-2);
+  }
+}
+
+.bewly-bili-channel-panel {
+  .channel-panel__column {
+    display: flex;
+    width: 152px;
+    flex: none;
+    flex-direction: column;
+    flex-wrap: wrap;
+    padding: 0 16px;
+    border-right: 1px solid var(--bew-fill-2);
+
+    &:last-child {
+      border-right: 0;
+    }
+  }
+
+  .channel-panel__item {
+    display: flex;
+    align-items: center;
+    box-sizing: border-box;
+    height: 32px;
+    margin: 3px 0;
+    padding: 6px;
+    border-radius: 4px;
+    color: var(--bew-text-1);
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 20px;
+    white-space: nowrap;
+
+    &:hover {
+      background-color: var(--bew-fill-2);
+    }
+  }
+
+  .channel-panel__icon,
+  .navigation-channel-icon {
+    width: 24px;
+    height: 24px;
+    flex: none;
+    margin-right: 10px;
+  }
+}
+
 .remove-top-bar {
   // remove the original top bar and adjust the height of the top bar to match the bewly top bar
   .bili-header .bili-header__bar,
+  .bili-header > .bili-header__channel,
+  .bili-header > .bewly-bili-fixed-channel,
+  .bili-header > .bewly-bili-channel-panel,
   #internationalHeader,
   .link-navbar,
   #home_nav,

--- a/src/tests/bilibiliTopBar.spec.ts
+++ b/src/tests/bilibiliTopBar.spec.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { captureOriginalBilibiliTopBar, ensureOriginalBilibiliTopBarAppended, setOriginalBilibiliTopBarScrolled } from '~/utils/bilibiliTopBar'
+
+describe('b 站原版顶栏滚动状态', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <header class="bili-header">
+        <div class="bili-header__bar">
+          <ul class="left-entry">
+            <li>
+              <a class="entry-title">
+                <svg class="zhuzhan-icon"></svg>
+                <span>首页</span>
+              </a>
+            </li>
+          </ul>
+        </div>
+        <div class="bili-header__banner">
+          <a class="inner-logo"><img src="//example.com/bilibili-logo.png"></a>
+        </div>
+        <div class="bili-header__channel" style="display: none"></div>
+      </header>
+      <div class="header-channel" style="display: none">
+        <div class="header-channel-fixed">
+          <div class="header-channel-fixed-left"></div>
+          <div class="header-channel-fixed-right">
+            <a class="header-channel-fixed-right-item">番剧</a>
+          </div>
+          <button class="header-channel-fixed-arrow"></button>
+        </div>
+      </div>
+    `
+    captureOriginalBilibiliTopBar(document)
+  })
+
+  it('捕获后保留顶部状态并准备完整下拉结构', () => {
+    expect(document.querySelector('.bili-header')?.classList.contains('bewly-original-top-bar-scrolled')).toBe(false)
+    expect(document.querySelector('.bili-header__bar')?.classList.contains('slide-down')).toBe(false)
+    expect(document.querySelector<HTMLImageElement>('.bewly-bili-logo-entry img')?.src).toContain('bilibili-logo.png')
+    expect(document.querySelector('.entry-title .bewly-home-entry-arrow')).not.toBeNull()
+    expect(document.querySelectorAll('.bewly-bili-channel-panel .channel-panel__column')).toHaveLength(5)
+    expect(document.querySelectorAll('.bewly-bili-channel-panel .channel-panel__icon').length).toBeGreaterThan(0)
+    expect(document.querySelector('body > .header-channel:not(.bewly-bili-fixed-channel)')).toBeNull()
+    expect(document.querySelector('.bili-header > .bewly-bili-fixed-channel')).not.toBeNull()
+    expect(document.querySelector('.bewly-bili-fixed-channel .header-channel-fixed-right-item')?.textContent).toBe('番剧')
+  })
+
+  it('在 B 站脚本移除下拉类名后自动恢复', async () => {
+    const bar = document.querySelector('.bili-header__bar')
+    setOriginalBilibiliTopBarScrolled(document, true)
+    bar?.classList.remove('slide-down')
+    await Promise.resolve()
+
+    expect(bar?.classList.contains('slide-down')).toBe(true)
+  })
+
+  it('跟随 BewlyCat 滚动位置切换下拉样式', () => {
+    const header = document.querySelector('.bili-header')
+    const bar = document.querySelector('.bili-header__bar')
+
+    setOriginalBilibiliTopBarScrolled(document, true)
+    expect(header?.classList.contains('bewly-original-top-bar-scrolled')).toBe(true)
+    expect(bar?.classList.contains('slide-down')).toBe(true)
+
+    setOriginalBilibiliTopBarScrolled(document, false)
+    expect(header?.classList.contains('bewly-original-top-bar-scrolled')).toBe(false)
+    expect(bar?.classList.contains('slide-down')).toBe(false)
+  })
+
+  it('保留原版顶栏的分区面板供悬浮样式控制', () => {
+    ensureOriginalBilibiliTopBarAppended(document)
+
+    expect(document.querySelector<HTMLElement>('.bili-header__banner')?.style.display).toBe('none')
+    expect(document.querySelector<HTMLElement>('.bili-header__channel')?.style.display).toBe('')
+  })
+
+  it('由兼容层控制下拉后的分区面板展开', () => {
+    ensureOriginalBilibiliTopBarAppended(document)
+    const header = document.querySelector('.bili-header')
+    const home = document.createElement('a')
+    home.className = 'entry-title'
+    header?.querySelector('.bili-header__bar')?.appendChild(home)
+
+    setOriginalBilibiliTopBarScrolled(document, true)
+    home.dispatchEvent(new Event('pointerover', { bubbles: true }))
+
+    expect(header?.classList.contains('bewly-original-channel-open')).toBe(true)
+
+    setOriginalBilibiliTopBarScrolled(document, false)
+    expect(header?.classList.contains('bewly-original-channel-open')).toBe(false)
+  })
+
+  it('悬停原版固定频道栏时展开全部标签', () => {
+    const fixedChannel = document.querySelector<HTMLElement>('.bewly-bili-fixed-channel')
+    const fixedChannelContent = fixedChannel?.querySelector('.header-channel-fixed')
+
+    fixedChannel?.dispatchEvent(new Event('pointerenter'))
+    expect(fixedChannelContent?.classList.contains('header-channel-fixed-down')).toBe(true)
+
+    fixedChannel?.dispatchEvent(new Event('pointerleave'))
+    expect(fixedChannelContent?.classList.contains('header-channel-fixed-down')).toBe(false)
+  })
+})

--- a/src/utils/bilibiliTopBar.ts
+++ b/src/utils/bilibiliTopBar.ts
@@ -1,3 +1,5 @@
+import { SVG_ICONS } from '~/utils/svgIcons'
+
 const BILIBILI_TOP_BAR_SELECTORS = [
   '.bili-header',
   '.bili-header .bili-header__bar',
@@ -11,13 +13,72 @@ const BILIBILI_TOP_BAR_SELECTORS = [
 ]
 
 let cachedOriginalTopBar: HTMLElement | null = null
+const initializedHoverHeaders = new WeakSet<HTMLElement>()
+const initializedScrollStateHeaders = new WeakSet<HTMLElement>()
+const channelPanelColumns = [
+  [
+    ['番剧', '//www.bilibili.com/anime/', '#channel-anime'],
+    ['电影', '//www.bilibili.com/movie/', '#channel-movie'],
+    ['国创', '//www.bilibili.com/guochuang/', '#channel-guochuang'],
+    ['电视剧', '//www.bilibili.com/tv/', '#channel-teleplay'],
+    ['综艺', '//www.bilibili.com/variety/', '#channel-zongyi'],
+    ['纪录片', '//www.bilibili.com/documentary/', '#channel-documentary'],
+    ['动画', '//www.bilibili.com/v/douga/', '#channel-douga'],
+    ['游戏', '//www.bilibili.com/v/game/', '#channel-game'],
+    ['鬼畜', '//www.bilibili.com/v/kichiku/', '#channel-kichiku'],
+    ['音乐', '//www.bilibili.com/v/music', '#channel-music'],
+  ],
+  [
+    ['舞蹈', '//www.bilibili.com/v/dance/', '#channel-dance'],
+    ['影视', '//www.bilibili.com/v/cinephile', '#channel-cinephile'],
+    ['娱乐', '//www.bilibili.com/v/ent/', '#channel-ent'],
+    ['知识', '//www.bilibili.com/v/knowledge/', '#channel-knowledge'],
+    ['科技', '//www.bilibili.com/v/tech/', '#channel-tech'],
+    ['资讯', '//www.bilibili.com/v/information/', '#channel-information'],
+    ['美食', '//www.bilibili.com/v/food', '#channel-food'],
+    ['生活', '//www.bilibili.com/v/life', '#channel-life-experience'],
+    ['汽车', '//www.bilibili.com/v/car', '#channel-car'],
+    ['时尚', '//www.bilibili.com/v/fashion', '#channel-fashion'],
+  ],
+  [
+    ['体育运动', '//www.bilibili.com/v/sports', '#channel-sports'],
+    ['动物', '//www.bilibili.com/v/animal', '#channel-animal'],
+    ['vlog', '//www.bilibili.com/v/life/daily/?tag=530003', '#channel-vlog'],
+    ['绘画', '//www.bilibili.com/v/douga/other', '#channel-painting'],
+    ['人工智能', '//www.bilibili.com/v/tech/ai', '#channel-ai'],
+    ['家装房产', '//www.bilibili.com/v/life/home', '#channel-home'],
+    ['户外潮流', '//www.bilibili.com/v/life/travel', '#channel-outdoors'],
+    ['健身', '//www.bilibili.com/v/sports/aerobics', '#channel-gym'],
+    ['手工', '//www.bilibili.com/v/life/handmake', '#channel-handmake'],
+    ['旅游出行', '//www.bilibili.com/v/life/travel', '#channel-travel'],
+  ],
+  [
+    ['三农', '//www.bilibili.com/v/knowledge/agriculture', '#channel-rural'],
+    ['亲子', '//www.bilibili.com/v/life/parenting', '#channel-parenting'],
+    ['健康', '//www.bilibili.com/v/knowledge/health', '#channel-health'],
+    ['情感', '//www.bilibili.com/v/life/emotion', '#channel-emotion'],
+    ['生活兴趣', '//www.bilibili.com/v/life', '#channel-life'],
+    ['生活经验', '//www.bilibili.com/v/life/experience', '#channel-life-experience'],
+    ['公益', '//love.bilibili.com', '#channel-love'],
+    ['超高清', '//www.bilibili.com/v/tech/digital', '#channel-digital'],
+    ['视频播客', '//www.bilibili.com/v/life', '#channel-yinpin'],
+  ],
+  [
+    ['专栏', '//www.bilibili.com/read/home', '#channel-read'],
+    ['直播', '//live.bilibili.com', '#channel-live'],
+    ['活动', '//www.bilibili.com/blackboard/activity-list.html', '#channel-activity'],
+    ['课堂', '//www.bilibili.com/cheese/', '#channel-zhishi'],
+    ['社区中心', '//www.bilibili.com/blackboard/activity-5zJxM3spoS.html', '#channel-blackroom'],
+    ['新歌热榜', '//music.bilibili.com/pc/music-center/', '#channel-musicplus'],
+  ],
+] satisfies ReadonlyArray<ReadonlyArray<readonly [string, string, string]>>
 
 function getDocumentTopBar(doc: Document): HTMLElement | null {
   return doc.querySelector<HTMLElement>('.bili-header')
 }
 
 export function captureOriginalBilibiliTopBar(doc: Document) {
-  if (cachedOriginalTopBar && cachedOriginalTopBar.ownerDocument === doc)
+  if (cachedOriginalTopBar?.isConnected && cachedOriginalTopBar.ownerDocument === doc)
     return cachedOriginalTopBar
 
   const header = getDocumentTopBar(doc)
@@ -25,8 +86,192 @@ export function captureOriginalBilibiliTopBar(doc: Document) {
     return null
 
   cachedOriginalTopBar = header
-  cachedOriginalTopBar.querySelector('.bili-header__bar')?.classList.add('slide-down')
+  setOriginalBilibiliTopBarScrolled(doc, false)
+  ensureOriginalTopBarScrolledLayout(header)
   return cachedOriginalTopBar
+}
+
+/**
+ * 同步 BewlyCat 独立滚动容器与 B 站原版顶栏的下拉状态。
+ * B 站脚本只监听页面滚动，无法感知 Shadow DOM 内部容器的 scrollTop。
+ */
+export function setOriginalBilibiliTopBarScrolled(doc: Document, scrolled: boolean) {
+  const header = getDocumentTopBar(doc) || cachedOriginalTopBar
+  header?.classList.toggle('bewly-original-top-bar-scrolled', scrolled)
+  header?.querySelector('.bili-header__bar')?.classList.toggle('slide-down', scrolled)
+  if (header)
+    keepOriginalTopBarScrolled(header)
+  if (!scrolled)
+    header?.classList.remove('bewly-original-channel-open')
+}
+
+function keepOriginalTopBarScrolled(header: HTMLElement) {
+  if (initializedScrollStateHeaders.has(header))
+    return
+
+  initializedScrollStateHeaders.add(header)
+  const observer = new MutationObserver(() => {
+    if (!header.classList.contains('bewly-original-top-bar-scrolled'))
+      return
+
+    const bar = header.querySelector('.bili-header__bar')
+    if (bar && !bar.classList.contains('slide-down'))
+      bar.classList.add('slide-down')
+    ensureOriginalTopBarScrolledLayout(header)
+  })
+  observer.observe(header, {
+    attributes: true,
+    attributeFilter: ['class'],
+    childList: true,
+    subtree: true,
+  })
+}
+
+function ensureOriginalTopBarScrolledLayout(header: HTMLElement) {
+  const leftEntry = header.querySelector<HTMLElement>('.bili-header__bar .left-entry')
+  const homeEntry = leftEntry?.querySelector<HTMLElement>('.entry-title')
+  if (!leftEntry || !homeEntry)
+    return
+  const doc = header.ownerDocument
+
+  if (!leftEntry.querySelector('.bewly-bili-logo-entry')) {
+    const sourceLogo = header.querySelector<HTMLImageElement>('.bili-header__banner .inner-logo img')
+    if (sourceLogo?.getAttribute('src')) {
+      const item = doc.createElement('li')
+      item.className = 'bewly-bili-logo-entry'
+
+      const link = doc.createElement('a')
+      link.href = '//www.bilibili.com'
+      link.setAttribute('aria-label', 'Bilibili')
+
+      const image = doc.createElement('img')
+      image.src = sourceLogo.getAttribute('src')!
+      image.alt = 'Bilibili'
+
+      link.appendChild(image)
+      item.appendChild(link)
+      leftEntry.prepend(item)
+    }
+  }
+
+  if (!homeEntry.querySelector('.bewly-home-entry-arrow')) {
+    const arrow = doc.createElement('span')
+    arrow.className = 'bewly-home-entry-arrow'
+    arrow.setAttribute('aria-hidden', 'true')
+    homeEntry.appendChild(arrow)
+  }
+
+  if (!header.querySelector(':scope > .bewly-bili-fixed-channel')) {
+    const nativeFixedChannel = doc.querySelector<HTMLElement>(
+      '.header-channel:not(.bewly-bili-fixed-channel)',
+    )
+    if (nativeFixedChannel) {
+      const fixedChannel = nativeFixedChannel
+      fixedChannel.classList.add('bewly-bili-fixed-channel')
+      fixedChannel.style.removeProperty('display')
+
+      const fixedChannelContent = fixedChannel.querySelector('.header-channel-fixed')
+      fixedChannel.addEventListener('pointerenter', () => {
+        fixedChannelContent?.classList.add('header-channel-fixed-down')
+      })
+      fixedChannel.addEventListener('pointerleave', () => {
+        fixedChannelContent?.classList.remove('header-channel-fixed-down')
+      })
+
+      header.appendChild(fixedChannel)
+    }
+  }
+
+  if (!header.querySelector('.bewly-bili-channel-panel')) {
+    const nativePanel = header.querySelector<HTMLElement>(
+      '.bili-header-channel-panel:not(.bewly-bili-channel-panel)',
+    )
+
+    if (nativePanel) {
+      const panel = nativePanel.cloneNode(true) as HTMLElement
+      panel.classList.add('bewly-bili-channel-panel')
+      header.appendChild(panel)
+      return
+    }
+
+    if (!doc.querySelector('[data-bewly-channel-icons]')) {
+      const icons = doc.createElement('div')
+      icons.dataset.bewlyChannelIcons = ''
+      icons.innerHTML = SVG_ICONS
+      doc.body.appendChild(icons)
+    }
+
+    const panel = doc.createElement('div')
+    panel.className = 'bili-header-channel-panel bewly-bili-channel-panel'
+
+    channelPanelColumns.forEach((columnItems) => {
+      const column = doc.createElement('div')
+      column.className = 'channel-panel__column'
+
+      columnItems.forEach(([name, href, iconHref]) => {
+        const link = doc.createElement('a')
+        link.className = 'channel-panel__item'
+        link.href = href
+        link.target = '_blank'
+
+        const icon = doc.createElementNS('http://www.w3.org/2000/svg', 'svg')
+        icon.classList.add('channel-panel__icon')
+        icon.setAttribute('aria-hidden', 'true')
+        const use = doc.createElementNS('http://www.w3.org/2000/svg', 'use')
+        use.setAttribute('href', iconHref)
+        icon.appendChild(use)
+
+        const label = doc.createElement('span')
+        label.className = 'name'
+        label.textContent = name
+
+        link.append(icon, label)
+        column.appendChild(link)
+      })
+
+      panel.appendChild(column)
+    })
+
+    header.appendChild(panel)
+  }
+}
+
+function setupOriginalTopBarChannelHover(header: HTMLElement) {
+  if (initializedHoverHeaders.has(header))
+    return
+
+  initializedHoverHeaders.add(header)
+  let closeTimer: ReturnType<typeof setTimeout> | null = null
+
+  const clearCloseTimer = () => {
+    if (!closeTimer)
+      return
+
+    clearTimeout(closeTimer)
+    closeTimer = null
+  }
+
+  header.addEventListener('pointerover', (event) => {
+    const target = event.target as Element | null
+    if (!target?.closest('.entry-title, .bewly-bili-channel-panel'))
+      return
+
+    clearCloseTimer()
+    if (header.classList.contains('bewly-original-top-bar-scrolled'))
+      header.classList.add('bewly-original-channel-open')
+  })
+
+  header.addEventListener('pointerout', (event) => {
+    const target = event.target as Element | null
+    if (!target?.closest('.entry-title, .bewly-bili-channel-panel'))
+      return
+
+    clearCloseTimer()
+    closeTimer = setTimeout(() => {
+      header.classList.remove('bewly-original-channel-open')
+      closeTimer = null
+    }, 120)
+  })
 }
 
 export function detachOriginalBilibiliTopBar(doc: Document) {
@@ -43,9 +288,14 @@ export function ensureOriginalBilibiliTopBarAppended(doc: Document): boolean {
   if (!header)
     return false
 
-  // 1. 隐藏多余段落（如 banner 等），只保留顶栏条
-  const innerUselessContents = header.querySelectorAll<HTMLElement>(':scope > *:not(.bili-header__bar)')
+  // 1. 隐藏 banner 等首页内容，分区面板由样式在下拉后悬浮“首页”时显示
+  const innerUselessContents = header.querySelectorAll<HTMLElement>(
+    ':scope > *:not(.bili-header__bar):not(.bili-header__channel)',
+  )
   innerUselessContents.forEach(item => (item.style.display = 'none'))
+  header.querySelector<HTMLElement>(':scope > .bili-header__channel')?.style.removeProperty('display')
+  setupOriginalTopBarChannelHover(header)
+  ensureOriginalTopBarScrolledLayout(header)
 
   // 2. 确保顶栏是 body 的直接子元素且位于最前
   // 即使 header 已存在，如果它在某个被隐藏的父容器里，这里也会将其移动到 body 下


### PR DESCRIPTION
## 修改内容

- 将 BewlyCat 内部滚动容器的滚动状态同步到 B 站原版顶栏
- 在下滑时恢复原版 `slide-down` 顶栏状态，并在回到顶部时还原
- 复用 B 站原生固定频道栏及其异步更新、悬停展开和箭头交互
- 复用原版“首页”悬浮频道菜单，保留原始分类、SVG 图标和尺寸
- 补充 Logo、首页箭头、暗色模式和内容占位等兼容样式
- 新增原版顶栏滚动状态专项测试

## 问题原因

BewlyCat 首页使用 Shadow DOM 内部的独立滚动容器。页面滚动时，B 站监听的 `window`/文档滚动事件不会触发，因此原版顶栏无法进入下滑状态，固定频道栏和相关菜单也不会正常切换。

## 用户影响

启用“使用原版 B 站顶栏”后，BewlyCat 首页现在会随内部页面滚动正确切换原版顶栏；下滑状态的固定频道栏、完整 tags、首页悬浮菜单和交互与原版页面保持一致。

## 验证

- `pnpm typecheck`
- `pnpm exec eslint src/utils/bilibiliTopBar.ts src/tests/bilibiliTopBar.spec.ts`
- `pnpm exec vitest run src/tests/bilibiliTopBar.spec.ts`（6 项通过）
- `pnpm build`
- `git diff --check`

Closes #390
