### PR TITLE
feat: 订阅合集「播放全部」支持起播位置（开头 / 最新 / 上次观看）

### DIFF
--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -459,8 +459,11 @@ settings:
   use_following_new_layout_desc: 左侧显示关注的UP主列表，右侧显示视频流
   use_favorites_new_layout: 使用新版收藏页
   use_favorites_new_layout_desc: 关闭后使用旧版收藏页；旧版不显示收藏合集。
-  play_collected_season_from_latest: 订阅合集从最新一期播放
-  play_collected_season_from_latest_desc: 开启后，收藏页与顶栏收藏弹层中订阅合集的「播放全部」会从最新一期进入合集列表页；默认仍从合集开头播放。不影响列表显示顺序与连播方向。
+  collected_season_play_all_mode: 订阅合集「播放全部」起播位置
+  collected_season_play_all_mode_desc: 控制收藏页与顶栏收藏弹层中订阅合集的「播放全部」。开头为合集入口；最新为列表最后一期；上次观看会在观看历史中匹配该合集最近看过的一期，找不到则回退到开头。不影响列表显示顺序与连播方向。
+  collected_season_play_all_mode_beginning: 合集开头
+  collected_season_play_all_mode_latest: 最新一期
+  collected_season_play_all_mode_last_watched: 上次观看
   enable_following_inactive_blacklist: 启用不活跃名单
   enable_following_inactive_blacklist_desc: 当UP主超过指定天数未更新或无投稿时，将自动移至不活跃名单。在ALL视图中出现更新或点击该UP主时会自动移出不活跃名单
   following_inactive_days: UP主不活跃天数

--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -460,7 +460,7 @@ settings:
   use_favorites_new_layout: 使用新版收藏页
   use_favorites_new_layout_desc: 关闭后使用旧版收藏页；旧版不显示收藏合集。
   collected_season_play_all_mode: 订阅合集「播放全部」起播位置
-  collected_season_play_all_mode_desc: 控制收藏页、顶栏收藏弹层，以及空间页「订阅合集」原生「播放全部」的起播位置。开头为合集入口；最新为列表最后一期；上次观看会在观看历史中匹配该合集最近看过的一期，找不到则回退到开头。不影响列表显示顺序与连播方向。
+  collected_season_play_all_mode_desc: 控制收藏页、顶栏与空间页订阅合集「播放全部」的起播位置。默认为合集开头；找不到上次观看时回退到开头。不影响列表顺序与连播方向。
   collected_season_play_all_mode_beginning: 合集开头
   collected_season_play_all_mode_latest: 最新一期
   collected_season_play_all_mode_last_watched: 上次观看

--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -459,6 +459,8 @@ settings:
   use_following_new_layout_desc: 左侧显示关注的UP主列表，右侧显示视频流
   use_favorites_new_layout: 使用新版收藏页
   use_favorites_new_layout_desc: 关闭后使用旧版收藏页；旧版不显示收藏合集。
+  play_collected_season_from_latest: 订阅合集从最新一期播放
+  play_collected_season_from_latest_desc: 开启后，收藏页与顶栏收藏弹层中订阅合集的「播放全部」会从最新一期进入合集列表页；默认仍从合集开头播放。不影响列表显示顺序与连播方向。
   enable_following_inactive_blacklist: 启用不活跃名单
   enable_following_inactive_blacklist_desc: 当UP主超过指定天数未更新或无投稿时，将自动移至不活跃名单。在ALL视图中出现更新或点击该UP主时会自动移出不活跃名单
   following_inactive_days: UP主不活跃天数

--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -460,7 +460,7 @@ settings:
   use_favorites_new_layout: 使用新版收藏页
   use_favorites_new_layout_desc: 关闭后使用旧版收藏页；旧版不显示收藏合集。
   collected_season_play_all_mode: 订阅合集「播放全部」起播位置
-  collected_season_play_all_mode_desc: 控制收藏页与顶栏收藏弹层中订阅合集的「播放全部」。开头为合集入口；最新为列表最后一期；上次观看会在观看历史中匹配该合集最近看过的一期，找不到则回退到开头。不影响列表显示顺序与连播方向。
+  collected_season_play_all_mode_desc: 控制收藏页、顶栏收藏弹层，以及空间页「订阅合集」原生「播放全部」的起播位置。开头为合集入口；最新为列表最后一期；上次观看会在观看历史中匹配该合集最近看过的一期，找不到则回退到开头。不影响列表显示顺序与连播方向。
   collected_season_play_all_mode_beginning: 合集开头
   collected_season_play_all_mode_latest: 最新一期
   collected_season_play_all_mode_last_watched: 上次观看

--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -869,6 +869,7 @@ favorites:
   search_placeholder: 搜索当前收藏夹
   global_search_placeholder: 搜索全部收藏夹
   global_search_hint: 请输入关键词以搜索全部收藏夹
+  season_play_all_fallback: 合集列表未就绪，已回退到合集开头
 watch_later:
   title: 稍后再看
   clear_all: 清空稍后再看

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -413,6 +413,8 @@ settings:
   use_following_new_layout_desc: 左側顯示關注的 UP 主列表，右側顯示影片流
   use_favorites_new_layout: 使用新版收藏頁
   use_favorites_new_layout_desc: 關閉後使用舊版收藏頁；舊版不顯示收藏合集。
+  play_collected_season_from_latest: 訂閱合集從最新一期播放
+  play_collected_season_from_latest_desc: 開啟後，收藏頁與頂欄收藏彈層中訂閱合集的「播放全部」會從最新一期進入合集列表頁；預設仍從合集開頭播放。不影響列表顯示順序與連播方向。
   enable_following_inactive_blacklist: 啟用不活躍名單
   enable_following_inactive_blacklist_desc: 當UP主超過指定天數未更新或無投稿時，將自動移至不活躍名單。在ALL視圖中出現更新或點擊該UP主時會自動移出不活躍名單。
   following_inactive_days: UP 主不活躍天數

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -414,7 +414,7 @@ settings:
   use_favorites_new_layout: 使用新版收藏頁
   use_favorites_new_layout_desc: 關閉後使用舊版收藏頁；舊版不顯示收藏合集。
   collected_season_play_all_mode: 訂閱合集「播放全部」起播位置
-  collected_season_play_all_mode_desc: 控制收藏頁、頂欄收藏彈層，以及空間頁「訂閱合集」原生「播放全部」的起播位置。開頭為合集入口；最新為列表最後一期；上次觀看會在觀看歷史中匹配該合集最近看過的一期，找不到則回退到開頭。不影響列表顯示順序與連播方向。
+  collected_season_play_all_mode_desc: 控制收藏頁、頂欄與空間頁訂閱合集「播放全部」的起播位置。預設為合集開頭；找不到上次觀看時回退到開頭。不影響列表順序與連播方向。
   collected_season_play_all_mode_beginning: 合集開頭
   collected_season_play_all_mode_latest: 最新一期
   collected_season_play_all_mode_last_watched: 上次觀看

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -881,6 +881,7 @@ favorites:
     此操作無法撤消，你確定要取消收藏這些影片嗎？
   global_search_hint: 請輸入關鍵詞以搜尋全部收藏夾
   global_search_placeholder: 搜尋全部收藏夾
+  season_play_all_fallback: 合集列表尚未就緒，已退回合集開頭
   search_all_folders: 全部
   search_current_folder: 目前
   search_placeholder: 搜尋目前收藏夾

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -414,7 +414,7 @@ settings:
   use_favorites_new_layout: 使用新版收藏頁
   use_favorites_new_layout_desc: 關閉後使用舊版收藏頁；舊版不顯示收藏合集。
   collected_season_play_all_mode: 訂閱合集「播放全部」起播位置
-  collected_season_play_all_mode_desc: 控制收藏頁與頂欄收藏彈層中訂閱合集的「播放全部」。開頭為合集入口；最新為列表最後一期；上次觀看會在觀看歷史中匹配該合集最近看過的一期，找不到則回退到開頭。不影響列表顯示順序與連播方向。
+  collected_season_play_all_mode_desc: 控制收藏頁、頂欄收藏彈層，以及空間頁「訂閱合集」原生「播放全部」的起播位置。開頭為合集入口；最新為列表最後一期；上次觀看會在觀看歷史中匹配該合集最近看過的一期，找不到則回退到開頭。不影響列表顯示順序與連播方向。
   collected_season_play_all_mode_beginning: 合集開頭
   collected_season_play_all_mode_latest: 最新一期
   collected_season_play_all_mode_last_watched: 上次觀看

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -413,8 +413,11 @@ settings:
   use_following_new_layout_desc: 左側顯示關注的 UP 主列表，右側顯示影片流
   use_favorites_new_layout: 使用新版收藏頁
   use_favorites_new_layout_desc: 關閉後使用舊版收藏頁；舊版不顯示收藏合集。
-  play_collected_season_from_latest: 訂閱合集從最新一期播放
-  play_collected_season_from_latest_desc: 開啟後，收藏頁與頂欄收藏彈層中訂閱合集的「播放全部」會從最新一期進入合集列表頁；預設仍從合集開頭播放。不影響列表顯示順序與連播方向。
+  collected_season_play_all_mode: 訂閱合集「播放全部」起播位置
+  collected_season_play_all_mode_desc: 控制收藏頁與頂欄收藏彈層中訂閱合集的「播放全部」。開頭為合集入口；最新為列表最後一期；上次觀看會在觀看歷史中匹配該合集最近看過的一期，找不到則回退到開頭。不影響列表顯示順序與連播方向。
+  collected_season_play_all_mode_beginning: 合集開頭
+  collected_season_play_all_mode_latest: 最新一期
+  collected_season_play_all_mode_last_watched: 上次觀看
   enable_following_inactive_blacklist: 啟用不活躍名單
   enable_following_inactive_blacklist_desc: 當UP主超過指定天數未更新或無投稿時，將自動移至不活躍名單。在ALL視圖中出現更新或點擊該UP主時會自動移出不活躍名單。
   following_inactive_days: UP 主不活躍天數

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -465,7 +465,7 @@ settings:
   use_favorites_new_layout: Use the new Favorites page
   use_favorites_new_layout_desc: Turn this off to use the legacy Favorites page, which does not show collected series.
   collected_season_play_all_mode: Collected series Play All start position
-  collected_season_play_all_mode_desc: Controls Play All for collected series on the Favorites page and Top Bar pop. Beginning uses the series entry; Latest opens the last item; Last watched matches the most recent series episode in watch history, falling back to Beginning if none is found. Does not reverse the list UI or playlist direction.
+  collected_season_play_all_mode_desc: Controls Play All for collected series on the Favorites page, Top Bar pop, and the native space favlist collected-season page. Beginning uses the series entry; Latest opens the last item; Last watched matches the most recent series episode in watch history, falling back to Beginning if none is found. Does not reverse the list UI or playlist direction.
   collected_season_play_all_mode_beginning: Series beginning
   collected_season_play_all_mode_latest: Latest episode
   collected_season_play_all_mode_last_watched: Last watched

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -464,6 +464,8 @@ settings:
   use_following_new_layout_desc: Display followed UPs list on the left and video feed on the right
   use_favorites_new_layout: Use the new Favorites page
   use_favorites_new_layout_desc: Turn this off to use the legacy Favorites page, which does not show collected series.
+  play_collected_season_from_latest: Play collected series from the latest episode
+  play_collected_season_from_latest_desc: When enabled, Play All for a collected series on the Favorites page and Top Bar pop opens the series list at the latest episode. Off keeps the default start-from-beginning behavior. Does not reverse the list UI or playlist direction.
   enable_following_inactive_blacklist: Enable Inactive List
   enable_following_inactive_blacklist_desc: When a UP has not posted for the specified number of days or has no videos, they will be automatically moved to the Inactive List. They will be removed from the Inactive List when appearing in ALL view or when clicked
   following_inactive_days: UP inactive days

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -944,6 +944,7 @@ favorites:
     This operation cannot be reversed. Are you sure you want to remove these video(s) from your favorites?
   global_search_hint: Search for all favorites
   global_search_placeholder: Search all favorites
+  season_play_all_fallback: Season list not ready, fell back to the beginning
   search_all_folders: all
   search_current_folder: current
   search_placeholder: Search for current favorites

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -465,7 +465,7 @@ settings:
   use_favorites_new_layout: Use the new Favorites page
   use_favorites_new_layout_desc: Turn this off to use the legacy Favorites page, which does not show collected series.
   collected_season_play_all_mode: Collected series Play All start position
-  collected_season_play_all_mode_desc: Controls Play All for collected series on the Favorites page, Top Bar pop, and the native space favlist collected-season page. Beginning uses the series entry; Latest opens the last item; Last watched matches the most recent series episode in watch history, falling back to Beginning if none is found. Does not reverse the list UI or playlist direction.
+  collected_season_play_all_mode_desc: Controls Play All start position for collected series on Favorites, Top Bar, and the native space page. Defaults to series beginning; falls back to beginning if last watched is not found. Does not change list order or playlist direction.
   collected_season_play_all_mode_beginning: Series beginning
   collected_season_play_all_mode_latest: Latest episode
   collected_season_play_all_mode_last_watched: Last watched

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -464,8 +464,11 @@ settings:
   use_following_new_layout_desc: Display followed UPs list on the left and video feed on the right
   use_favorites_new_layout: Use the new Favorites page
   use_favorites_new_layout_desc: Turn this off to use the legacy Favorites page, which does not show collected series.
-  play_collected_season_from_latest: Play collected series from the latest episode
-  play_collected_season_from_latest_desc: When enabled, Play All for a collected series on the Favorites page and Top Bar pop opens the series list at the latest episode. Off keeps the default start-from-beginning behavior. Does not reverse the list UI or playlist direction.
+  collected_season_play_all_mode: Collected series Play All start position
+  collected_season_play_all_mode_desc: Controls Play All for collected series on the Favorites page and Top Bar pop. Beginning uses the series entry; Latest opens the last item; Last watched matches the most recent series episode in watch history, falling back to Beginning if none is found. Does not reverse the list UI or playlist direction.
+  collected_season_play_all_mode_beginning: Series beginning
+  collected_season_play_all_mode_latest: Latest episode
+  collected_season_play_all_mode_last_watched: Last watched
   enable_following_inactive_blacklist: Enable Inactive List
   enable_following_inactive_blacklist_desc: When a UP has not posted for the specified number of days or has no videos, they will be automatically moved to the Inactive List. They will be removed from the Inactive List when appearing in ALL view or when clicked
   following_inactive_days: UP inactive days

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -387,8 +387,11 @@ settings:
   use_following_new_layout_desc: 左邊顯示關注嘅UP主名單，右邊顯示影片流
   use_favorites_new_layout: 使用新版收藏頁
   use_favorites_new_layout_desc: 關閉之後會使用舊版收藏頁；舊版唔會顯示收藏合集。
-  play_collected_season_from_latest: 訂閱合集由最新一集開始播
-  play_collected_season_from_latest_desc: 開咗之後，收藏頁同頂欄收藏彈層入面訂閱合集嘅「播放全部」會由最新一集入去合集列表頁；預設仍然由合集開頭播。唔會改列表顯示次序同連播方向。
+  collected_season_play_all_mode: 訂閱合集「播放全部」起播位置
+  collected_season_play_all_mode_desc: 控制收藏頁同頂欄收藏彈層入面訂閱合集嘅「播放全部」。開頭係合集入口；最新係列表最後一期；上次觀看會喺觀看歷史入面搵呢個合集最近睇過嘅一期，搵唔到就退回開頭。唔會改列表顯示次序同連播方向。
+  collected_season_play_all_mode_beginning: 合集開頭
+  collected_season_play_all_mode_latest: 最新一期
+  collected_season_play_all_mode_last_watched: 上次觀看
   enable_following_inactive_blacklist: 啟用唔活躍名單
   enable_following_inactive_blacklist_desc: 閂咗之後唔會因為超過唔活躍日數或者冇投稿就自動入唔活躍名單；已經有嘅唔活躍名單同 ALL 視圖／撳 UP 移出規則唔變。
   following_inactive_days: UP主唔活躍天數

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -388,7 +388,7 @@ settings:
   use_favorites_new_layout: 使用新版收藏頁
   use_favorites_new_layout_desc: 關閉之後會使用舊版收藏頁；舊版唔會顯示收藏合集。
   collected_season_play_all_mode: 訂閱合集「播放全部」起播位置
-  collected_season_play_all_mode_desc: 控制收藏頁、頂欄收藏彈層，同空間頁「訂閱合集」原生「播放全部」嘅起播位置。開頭係合集入口；最新係列表最後一期；上次觀看會喺觀看歷史入面搵呢個合集最近睇過嘅一期，搵唔到就退回開頭。唔會改列表顯示次序同連播方向。
+  collected_season_play_all_mode_desc: 控制收藏頁、頂欄同空間頁訂閱合集「播放全部」嘅起播位置。預設係合集開頭；搵唔到上次觀看就退回開頭。唔會改列表次序同連播方向。
   collected_season_play_all_mode_beginning: 合集開頭
   collected_season_play_all_mode_latest: 最新一期
   collected_season_play_all_mode_last_watched: 上次觀看

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -387,6 +387,8 @@ settings:
   use_following_new_layout_desc: 左邊顯示關注嘅UP主名單，右邊顯示影片流
   use_favorites_new_layout: 使用新版收藏頁
   use_favorites_new_layout_desc: 關閉之後會使用舊版收藏頁；舊版唔會顯示收藏合集。
+  play_collected_season_from_latest: 訂閱合集由最新一集開始播
+  play_collected_season_from_latest_desc: 開咗之後，收藏頁同頂欄收藏彈層入面訂閱合集嘅「播放全部」會由最新一集入去合集列表頁；預設仍然由合集開頭播。唔會改列表顯示次序同連播方向。
   enable_following_inactive_blacklist: 啟用唔活躍名單
   enable_following_inactive_blacklist_desc: 閂咗之後唔會因為超過唔活躍日數或者冇投稿就自動入唔活躍名單；已經有嘅唔活躍名單同 ALL 視圖／撳 UP 移出規則唔變。
   following_inactive_days: UP主唔活躍天數

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -388,7 +388,7 @@ settings:
   use_favorites_new_layout: 使用新版收藏頁
   use_favorites_new_layout_desc: 關閉之後會使用舊版收藏頁；舊版唔會顯示收藏合集。
   collected_season_play_all_mode: 訂閱合集「播放全部」起播位置
-  collected_season_play_all_mode_desc: 控制收藏頁同頂欄收藏彈層入面訂閱合集嘅「播放全部」。開頭係合集入口；最新係列表最後一期；上次觀看會喺觀看歷史入面搵呢個合集最近睇過嘅一期，搵唔到就退回開頭。唔會改列表顯示次序同連播方向。
+  collected_season_play_all_mode_desc: 控制收藏頁、頂欄收藏彈層，同空間頁「訂閱合集」原生「播放全部」嘅起播位置。開頭係合集入口；最新係列表最後一期；上次觀看會喺觀看歷史入面搵呢個合集最近睇過嘅一期，搵唔到就退回開頭。唔會改列表顯示次序同連播方向。
   collected_season_play_all_mode_beginning: 合集開頭
   collected_season_play_all_mode_latest: 最新一期
   collected_season_play_all_mode_last_watched: 上次觀看

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -817,6 +817,7 @@ favorites:
   batch_unfavorite_confirm: |-
     係咪要剷走已揀嘅 {count} 條片呀？
     噉做冇得返轉頭噃，你確定要剷走呢啲片？
+  season_play_all_fallback: 合集列表未就緒，已退回合集開頭
 watch_later:
   title: 陣間至睇
   clear_all: 剷曬陣間至睇啲片

--- a/src/background/messageListeners/api/user.ts
+++ b/src/background/messageListeners/api/user.ts
@@ -10,6 +10,18 @@ const API_USER = {
     },
     afterHandle: AHS.J_D,
   },
+  // https://github.com/SocialSisterYi/bilibili-API-collect/blob/master/docs/user/info.md#%E7%94%A8%E6%88%B7%E5%90%8D%E7%89%87%E4%BF%A1%E6%81%AF
+  getUserCard: {
+    url: 'https://api.bilibili.com/x/web-interface/card',
+    _fetch: {
+      method: 'get',
+    },
+    params: {
+      mid: '',
+      photo: false,
+    },
+    afterHandle: AHS.J_D,
+  },
   getUserStat: {
     url: 'https://api.bilibili.com/x/web-interface/nav/stat',
     _fetch: {

--- a/src/components/Settings/PluginComponentsAndPages/Favorites/Favorites.vue
+++ b/src/components/Settings/PluginComponentsAndPages/Favorites/Favorites.vue
@@ -15,5 +15,12 @@ import SettingsItemGroup from '../../components/SettingsItemGroup.vue'
     >
       <Radio v-model="settings.useFavoritesNewLayout" />
     </SettingsItem>
+    <SettingsItem
+      :title="$t('settings.play_collected_season_from_latest')"
+      :desc="$t('settings.play_collected_season_from_latest_desc')"
+      right-width="auto"
+    >
+      <Radio v-model="settings.playCollectedSeasonFromLatest" />
+    </SettingsItem>
   </SettingsItemGroup>
 </template>

--- a/src/components/Settings/PluginComponentsAndPages/Favorites/Favorites.vue
+++ b/src/components/Settings/PluginComponentsAndPages/Favorites/Favorites.vue
@@ -1,9 +1,30 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
 import Radio from '~/components/Radio.vue'
+import Select from '~/components/Select.vue'
 import { settings } from '~/logic'
+import type { CollectedSeasonPlayAllMode } from '~/logic/storage'
 
 import SettingsItem from '../../components/SettingsItem.vue'
 import SettingsItemGroup from '../../components/SettingsItemGroup.vue'
+
+const { t } = useI18n()
+
+const collectedSeasonPlayAllModeOptions = computed(() => [
+  {
+    label: t('settings.collected_season_play_all_mode_beginning'),
+    value: 'beginning' satisfies CollectedSeasonPlayAllMode,
+  },
+  {
+    label: t('settings.collected_season_play_all_mode_latest'),
+    value: 'latest' satisfies CollectedSeasonPlayAllMode,
+  },
+  {
+    label: t('settings.collected_season_play_all_mode_last_watched'),
+    value: 'lastWatched' satisfies CollectedSeasonPlayAllMode,
+  },
+])
 </script>
 
 <template>
@@ -16,11 +37,15 @@ import SettingsItemGroup from '../../components/SettingsItemGroup.vue'
       <Radio v-model="settings.useFavoritesNewLayout" />
     </SettingsItem>
     <SettingsItem
-      :title="$t('settings.play_collected_season_from_latest')"
-      :desc="$t('settings.play_collected_season_from_latest_desc')"
+      :title="$t('settings.collected_season_play_all_mode')"
+      :desc="$t('settings.collected_season_play_all_mode_desc')"
       right-width="auto"
     >
-      <Radio v-model="settings.playCollectedSeasonFromLatest" />
+      <Select
+        v-model="settings.collectedSeasonPlayAllMode"
+        :options="collectedSeasonPlayAllModeOptions"
+        w="180px"
+      />
     </SettingsItem>
   </SettingsItemGroup>
 </template>

--- a/src/components/TopBar/components/pops/FavoritesPop.vue
+++ b/src/components/TopBar/components/pops/FavoritesPop.vue
@@ -4,10 +4,13 @@ import type { Ref } from 'vue'
 import Empty from '~/components/Empty.vue'
 import Loading from '~/components/Loading.vue'
 import { useOptimizedScroll } from '~/composables/useOptimizedScroll'
+import { settings } from '~/logic'
 import type { CollectedFavoriteSeason, CollectedFavoriteSeasonsResult, FavoriteSeasonMedia, FavoriteSeasonResourcesResult } from '~/models/video/favoriteSeason'
 import api from '~/utils/api'
 import { calcCurrentTime } from '~/utils/dataFormatter'
-import { getUserID, removeHttpFromUrl, scrollToTop } from '~/utils/main'
+import { buildFavoriteSeasonEntryUrl, resolveFavoriteSeasonPlayAllUrl } from '~/utils/favoriteSeason'
+import { getUserID, isHomePage, isInIframe, removeHttpFromUrl, scrollToTop } from '~/utils/main'
+import { openLinkInBackground } from '~/utils/tabs'
 
 import type { FavoriteCategory, FavoriteResource } from '../../types'
 
@@ -35,7 +38,7 @@ const favoriteVideosWrap = ref<HTMLElement>() as Ref<HTMLElement>
 
 const viewAllUrl = computed((): string => {
   if (activatedCategorySource.value === 'season')
-    return getFavoriteSeasonUrl()
+    return buildFavoriteSeasonEntryUrl(activatedMediaId.value, activatedCategoryLink.value)
 
   return `//space.bilibili.com/${getUserID()}/favlist?fid=${
     activatedMediaId.value
@@ -44,10 +47,59 @@ const viewAllUrl = computed((): string => {
 
 const playAllUrl = computed((): string => {
   if (activatedCategorySource.value === 'season')
-    return getFavoriteSeasonUrl()
+    return buildFavoriteSeasonEntryUrl(activatedMediaId.value, activatedCategoryLink.value)
 
   return `https://www.bilibili.com/list/ml${activatedMediaId.value}`
 })
+
+const useCustomSeasonPlayAll = computed(() => activatedCategorySource.value === 'season')
+/** 开启「从最新播放」时连 modifier 点击也走自定义解析，避免 Ctrl/中键仍打开合集开头 */
+const interceptSeasonPlayAllModifiers = computed(() =>
+  useCustomSeasonPlayAll.value && settings.value.playCollectedSeasonFromLatest,
+)
+
+const isResolvingSeasonPlayAll = ref(false)
+
+function openTopBarLink(url: string) {
+  const mode = settings.value.topBarLinkOpenMode
+  if (mode === 'background') {
+    void openLinkInBackground(url)
+    return
+  }
+
+  if (mode === 'currentTabIfNotHomepage') {
+    if (isInIframe() || isHomePage())
+      window.open(url, '_blank')
+    else
+      window.open(url, '_top')
+    return
+  }
+
+  if (mode === 'newTab') {
+    window.open(url, '_blank')
+    return
+  }
+
+  window.open(url, '_top')
+}
+
+async function handleSeasonPlayAll() {
+  if (isResolvingSeasonPlayAll.value)
+    return
+
+  isResolvingSeasonPlayAll.value = true
+  try {
+    const url = await resolveFavoriteSeasonPlayAllUrl({
+      seasonId: activatedMediaId.value,
+      link: activatedCategoryLink.value,
+      playFromLatest: settings.value.playCollectedSeasonFromLatest,
+    })
+    openTopBarLink(url)
+  }
+  finally {
+    isResolvingSeasonPlayAll.value = false
+  }
+}
 
 watch([activatedMediaId, activatedCategorySource], ([newId, newSource], [oldId, oldSource]) => {
   if (newId === oldId && newSource === oldSource)
@@ -234,16 +286,6 @@ function normalizeSeasonMedia(item: FavoriteSeasonMedia): FavoriteResource {
   }
 }
 
-function getFavoriteSeasonUrl() {
-  const fallbackUrl = `https://www.bilibili.com/list/season/${activatedMediaId.value}`
-  const matchedVideoLink = activatedCategoryLink.value.match(/^bilibili:\/\/video\/(\d+)(\?.*)?$/)
-
-  if (!matchedVideoLink)
-    return fallbackUrl
-
-  return `https://www.bilibili.com/video/av${matchedVideoLink[1]}${matchedVideoLink[2] || ''}`
-}
-
 function refreshFavoriteResources() {
   favoriteResources.length = 0
   currentPageNum.value = 1
@@ -296,6 +338,9 @@ defineExpose({
           :href="playAllUrl"
           type="topBar"
           flex="~" items="center"
+          :custom-click-event="useCustomSeasonPlayAll"
+          :custom-click-event-includes-modifiers="interceptSeasonPlayAllModifiers"
+          @click="handleSeasonPlayAll"
         >
           <span text="sm">{{ $t('common.play_all') }}</span>
         </ALink>

--- a/src/components/TopBar/components/pops/FavoritesPop.vue
+++ b/src/components/TopBar/components/pops/FavoritesPop.vue
@@ -41,6 +41,7 @@ const loadedSeasonComplete = ref(false)
 const activatedMediaId = ref<number>(0)
 const activatedCategorySource = ref<FavoriteCategorySource>('folder')
 const activatedCategoryLink = ref<string>('')
+const activatedCategoryMid = ref<number>(0)
 const activatedFavoriteTitle = ref<string>()
 const currentPageNum = ref<number>(1)
 
@@ -50,8 +51,13 @@ const noMoreContent = ref<boolean>(false)
 const favoriteVideosWrap = ref<HTMLElement>() as Ref<HTMLElement>
 
 const viewAllUrl = computed((): string => {
-  if (activatedCategorySource.value === 'season')
+  if (activatedCategorySource.value === 'season') {
+    // 「查看全部」进 UP 合集页浏览；「播放全部」按设置起播，职责分开
+    if (activatedCategoryMid.value > 0) {
+      return `https://space.bilibili.com/${activatedCategoryMid.value}/channel/collectiondetail?sid=${activatedMediaId.value}`
+    }
     return buildFavoriteSeasonEntryUrl(activatedMediaId.value, activatedCategoryLink.value)
+  }
 
   return `//space.bilibili.com/${getUserID()}/favlist?fid=${
     activatedMediaId.value
@@ -109,6 +115,9 @@ async function handleSeasonPlayAll() {
       preloaded: {
         medias: loadedSeasonMedias.value,
         complete: loadedSeasonComplete.value,
+        expectedCount: favoriteCategories.find(
+          item => item.source === 'season' && item.id === activatedMediaId.value,
+        )?.media_count,
       },
     })
     if (result.usedFallback && result.reason !== 'beginning')
@@ -340,6 +349,7 @@ function changeCategory(categoryItem: ViewCategory) {
   activatedMediaId.value = categoryItem.id
   activatedCategorySource.value = categoryItem.source
   activatedCategoryLink.value = categoryItem.link || ''
+  activatedCategoryMid.value = categoryItem.mid || 0
   activatedFavoriteTitle.value = categoryItem.title
 }
 

--- a/src/components/TopBar/components/pops/FavoritesPop.vue
+++ b/src/components/TopBar/components/pops/FavoritesPop.vue
@@ -46,17 +46,17 @@ const viewAllUrl = computed((): string => {
 })
 
 const playAllUrl = computed((): string => {
+  // 订阅合集一律走 handleSeasonPlayAll；href 若仍是入口会导致
+  // 异步解析打开目标页的同时，浏览器再按 <a> 打开第一期（双开）
   if (activatedCategorySource.value === 'season')
-    return buildFavoriteSeasonEntryUrl(activatedMediaId.value, activatedCategoryLink.value)
+    return ''
 
   return `https://www.bilibili.com/list/ml${activatedMediaId.value}`
 })
 
 const useCustomSeasonPlayAll = computed(() => activatedCategorySource.value === 'season')
-/** 非「合集开头」时走自定义解析（含 modifier），避免仍打开入口 URL */
-const interceptSeasonPlayAllModifiers = computed(() =>
-  useCustomSeasonPlayAll.value && settings.value.collectedSeasonPlayAllMode !== 'beginning',
-)
+/** 订阅合集播放全部均走自定义解析（含 modifier） */
+const interceptSeasonPlayAllModifiers = computed(() => useCustomSeasonPlayAll.value)
 
 const isResolvingSeasonPlayAll = ref(false)
 

--- a/src/components/TopBar/components/pops/FavoritesPop.vue
+++ b/src/components/TopBar/components/pops/FavoritesPop.vue
@@ -245,14 +245,27 @@ async function getFavoriteSeasonResources() {
   const res: FavoriteSeasonResourcesResult = await api.favorite.getFavoriteSeasonResources({
     season_id: activatedMediaId.value,
     pn: currentPageNum.value,
+    ps: 40,
   })
 
   if (res.code === 0 && res.data) {
     const medias = Array.isArray(res.data.medias) ? res.data.medias.filter((m: any) => m != null) : []
-    if (medias.length > 0)
-      favoriteResources.push(...medias.map(normalizeSeasonMedia))
-
-    noMoreContent.value = medias.length < 40
+    const mediaCount = res.data.info?.media_count
+    if (medias.length > 0) {
+      if (typeof mediaCount === 'number' && mediaCount >= 0 && medias.length >= mediaCount && currentPageNum.value === 1) {
+        favoriteResources.length = 0
+        favoriteResources.push(...medias.slice(0, mediaCount).map(normalizeSeasonMedia))
+        noMoreContent.value = true
+      }
+      else {
+        favoriteResources.push(...medias.map(normalizeSeasonMedia))
+        noMoreContent.value = medias.length < 40
+          || (typeof mediaCount === 'number' && mediaCount >= 0 && favoriteResources.length >= mediaCount)
+      }
+    }
+    else {
+      noMoreContent.value = true
+    }
   }
   else {
     noMoreContent.value = true

--- a/src/components/TopBar/components/pops/FavoritesPop.vue
+++ b/src/components/TopBar/components/pops/FavoritesPop.vue
@@ -1,14 +1,22 @@
 <script setup lang="ts">
 import type { Ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useToast } from 'vue-toastification'
 
 import Empty from '~/components/Empty.vue'
 import Loading from '~/components/Loading.vue'
 import { useOptimizedScroll } from '~/composables/useOptimizedScroll'
 import { settings } from '~/logic'
-import type { CollectedFavoriteSeason, CollectedFavoriteSeasonsResult, FavoriteSeasonMedia, FavoriteSeasonResourcesResult } from '~/models/video/favoriteSeason'
+import type { CollectedFavoriteSeason, CollectedFavoriteSeasonsResult, FavoriteSeasonMedia } from '~/models/video/favoriteSeason'
 import api from '~/utils/api'
 import { calcCurrentTime } from '~/utils/dataFormatter'
-import { buildFavoriteSeasonEntryUrl, resolveFavoriteSeasonPlayAllUrl } from '~/utils/favoriteSeason'
+import {
+  buildFavoriteSeasonEntryUrl,
+  FAVORITE_SEASON_PAGE_SIZE,
+  fetchFavoriteSeasonPage,
+  mergeFavoriteSeasonPage,
+  resolveFavoriteSeasonPlayAllUrl,
+} from '~/utils/favoriteSeason'
 import { getUserID, isHomePage, isInIframe, removeHttpFromUrl, scrollToTop } from '~/utils/main'
 import { openLinkInBackground } from '~/utils/tabs'
 
@@ -21,9 +29,14 @@ type ViewCategory = FavoriteCategory & {
   link?: string
 }
 
+const { t } = useI18n()
+const toast = useToast()
+
 const favoriteCategories = reactive<Array<ViewCategory>>([])
 const collectedFavoriteSeasons = reactive<Array<CollectedFavoriteSeason>>([])
 const favoriteResources = reactive<Array<FavoriteResource>>([])
+const loadedSeasonMedias = ref<FavoriteSeasonMedia[]>([])
+const loadedSeasonComplete = ref(false)
 
 const activatedMediaId = ref<number>(0)
 const activatedCategorySource = ref<FavoriteCategorySource>('folder')
@@ -89,12 +102,18 @@ async function handleSeasonPlayAll() {
 
   isResolvingSeasonPlayAll.value = true
   try {
-    const url = await resolveFavoriteSeasonPlayAllUrl({
+    const result = await resolveFavoriteSeasonPlayAllUrl({
       seasonId: activatedMediaId.value,
       link: activatedCategoryLink.value,
       mode: settings.value.collectedSeasonPlayAllMode,
+      preloaded: {
+        medias: loadedSeasonMedias.value,
+        complete: loadedSeasonComplete.value,
+      },
     })
-    openTopBarLink(url)
+    if (result.usedFallback && result.reason !== 'beginning')
+      toast.warning(t('favorites.season_play_all_fallback'))
+    openTopBarLink(result.url)
   }
   finally {
     isResolvingSeasonPlayAll.value = false
@@ -106,6 +125,8 @@ watch([activatedMediaId, activatedCategorySource], ([newId, newSource], [oldId, 
     return
 
   favoriteResources.length = 0
+  loadedSeasonMedias.value = []
+  loadedSeasonComplete.value = false
   if (favoriteVideosWrap.value)
     scrollToTop(favoriteVideosWrap.value)
 
@@ -242,33 +263,43 @@ async function getFavoriteResources() {
 }
 
 async function getFavoriteSeasonResources() {
-  const res: FavoriteSeasonResourcesResult = await api.favorite.getFavoriteSeasonResources({
-    season_id: activatedMediaId.value,
+  if (currentPageNum.value === 1) {
+    loadedSeasonMedias.value = []
+    loadedSeasonComplete.value = false
+  }
+
+  const page = await fetchFavoriteSeasonPage(
+    activatedMediaId.value,
+    currentPageNum.value,
+    FAVORITE_SEASON_PAGE_SIZE,
+  )
+
+  if (!page.ok) {
+    noMoreContent.value = true
+    loadedSeasonComplete.value = false
+    return
+  }
+
+  const merged = mergeFavoriteSeasonPage({
     pn: currentPageNum.value,
-    ps: 40,
+    pageMedias: page.pageMedias,
+    mediaCount: page.mediaCount,
+    previousMedias: loadedSeasonMedias.value,
+    pageSize: FAVORITE_SEASON_PAGE_SIZE,
   })
 
-  if (res.code === 0 && res.data) {
-    const medias = Array.isArray(res.data.medias) ? res.data.medias.filter((m: any) => m != null) : []
-    const mediaCount = res.data.info?.media_count
-    if (medias.length > 0) {
-      if (typeof mediaCount === 'number' && mediaCount >= 0 && medias.length >= mediaCount && currentPageNum.value === 1) {
-        favoriteResources.length = 0
-        favoriteResources.push(...medias.slice(0, mediaCount).map(normalizeSeasonMedia))
-        noMoreContent.value = true
-      }
-      else {
-        favoriteResources.push(...medias.map(normalizeSeasonMedia))
-        noMoreContent.value = medias.length < 40
-          || (typeof mediaCount === 'number' && mediaCount >= 0 && favoriteResources.length >= mediaCount)
-      }
-    }
-    else {
-      noMoreContent.value = true
-    }
+  loadedSeasonMedias.value = merged.medias
+  loadedSeasonComplete.value = !merged.hasMore
+  noMoreContent.value = !merged.hasMore
+
+  // 顶栏是滚动追加：首页替换，后续页只追加本页增量
+  if (currentPageNum.value === 1) {
+    favoriteResources.length = 0
+    favoriteResources.push(...merged.medias.map(normalizeSeasonMedia))
   }
   else {
-    noMoreContent.value = true
+    const previousCount = favoriteResources.length
+    favoriteResources.push(...merged.medias.slice(previousCount).map(normalizeSeasonMedia))
   }
 }
 

--- a/src/components/TopBar/components/pops/FavoritesPop.vue
+++ b/src/components/TopBar/components/pops/FavoritesPop.vue
@@ -53,9 +53,9 @@ const playAllUrl = computed((): string => {
 })
 
 const useCustomSeasonPlayAll = computed(() => activatedCategorySource.value === 'season')
-/** 开启「从最新播放」时连 modifier 点击也走自定义解析，避免 Ctrl/中键仍打开合集开头 */
+/** 非「合集开头」时走自定义解析（含 modifier），避免仍打开入口 URL */
 const interceptSeasonPlayAllModifiers = computed(() =>
-  useCustomSeasonPlayAll.value && settings.value.playCollectedSeasonFromLatest,
+  useCustomSeasonPlayAll.value && settings.value.collectedSeasonPlayAllMode !== 'beginning',
 )
 
 const isResolvingSeasonPlayAll = ref(false)
@@ -92,7 +92,7 @@ async function handleSeasonPlayAll() {
     const url = await resolveFavoriteSeasonPlayAllUrl({
       seasonId: activatedMediaId.value,
       link: activatedCategoryLink.value,
-      playFromLatest: settings.value.playCollectedSeasonFromLatest,
+      mode: settings.value.collectedSeasonPlayAllMode,
     })
     openTopBarLink(url)
   }

--- a/src/components/TopBar/components/pops/FavoritesPop.vue
+++ b/src/components/TopBar/components/pops/FavoritesPop.vue
@@ -12,6 +12,7 @@ import api from '~/utils/api'
 import { calcCurrentTime } from '~/utils/dataFormatter'
 import {
   buildFavoriteSeasonEntryUrl,
+  enrichFavoriteSeasonMediaFaces,
   FAVORITE_SEASON_PAGE_SIZE,
   fetchFavoriteSeasonPage,
   mergeFavoriteSeasonPage,
@@ -297,18 +298,18 @@ async function getFavoriteSeasonResources() {
     pageSize: FAVORITE_SEASON_PAGE_SIZE,
   })
 
-  loadedSeasonMedias.value = merged.medias
+  loadedSeasonMedias.value = await enrichFavoriteSeasonMediaFaces(merged.medias)
   loadedSeasonComplete.value = !merged.hasMore
   noMoreContent.value = !merged.hasMore
 
   // 顶栏是滚动追加：首页替换，后续页只追加本页增量
   if (currentPageNum.value === 1) {
     favoriteResources.length = 0
-    favoriteResources.push(...merged.medias.map(normalizeSeasonMedia))
+    favoriteResources.push(...loadedSeasonMedias.value.map(normalizeSeasonMedia))
   }
   else {
     const previousCount = favoriteResources.length
-    favoriteResources.push(...merged.medias.slice(previousCount).map(normalizeSeasonMedia))
+    favoriteResources.push(...loadedSeasonMedias.value.slice(previousCount).map(normalizeSeasonMedia))
   }
 }
 
@@ -322,8 +323,9 @@ function normalizeSeasonMedia(item: FavoriteSeasonMedia): FavoriteResource {
     page: 1,
     duration: item.duration,
     upper: {
-      ...item.upper,
-      face: '',
+      mid: item.upper.mid,
+      name: item.upper.name,
+      face: item.upper.face || '',
     },
     cnt_info: {
       collect: item.cnt_info.collect,

--- a/src/contentScripts/index.ts
+++ b/src/contentScripts/index.ts
@@ -17,6 +17,7 @@ import { initFavoriteDialogEnhancement } from '~/utils/favoriteDialog'
 import { runWhenIdle } from '~/utils/lazyLoad'
 import { getLocalWallpaper, hasLocalWallpaper, isLocalWallpaperUrl } from '~/utils/localWallpaper'
 import { compareVersions, getCookie, injectCSS, isElectron, isHomePage, isInIframe, isNotificationPage, isVideoOrBangumiPage, isVideoPlaybackPage } from '~/utils/main'
+import { initNativeFavoriteSeasonPlayAllIntercept } from '~/utils/nativeFavoriteSeasonPlayAll'
 import { applyAutoPlayByVideoType, applyDefaultCaptionState, applyDefaultDanmakuState, defaultMode, handleVideoPageNavigation, isCollectionVideo, isPlayerDisplayModeReady, isVideoPage, startAutoExitFullscreenMonitoring, startAutoPlayUserChangeMonitoring, webFullscreen, widescreen } from '~/utils/player'
 import { initRandomPlay, resetRandomPlayInitialization } from '~/utils/randomPlay'
 import { getPluginSearchResultsUrl } from '~/utils/searchNavigation'
@@ -660,6 +661,9 @@ else if (shouldInitializeContentScript) {
     if (isVideoOrBangumiPage()) {
       initFavoriteDialogEnhancement()
     }
+
+    // 原生空间订阅合集 favlist「播放全部」按设置起播
+    initNativeFavoriteSeasonPlayAllIntercept()
   }
 
   if (document.readyState !== 'loading') {

--- a/src/contentScripts/views/Favorites/Favorites.vue
+++ b/src/contentScripts/views/Favorites/Favorites.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
 import { settings } from '~/logic'
 
+const FavoritesNewPage = defineAsyncComponent(() => import('./FavoritesNew.vue'))
+const FavoritesOldPage = defineAsyncComponent(() => import('./FavoritesOld.vue'))
+
 const favoritesPage = computed(() => settings.value.useFavoritesNewLayout
-  ? defineAsyncComponent(() => import('./FavoritesNew.vue'))
-  : defineAsyncComponent(() => import('./FavoritesOld.vue')))
+  ? FavoritesNewPage
+  : FavoritesOldPage)
 </script>
 
 <template>

--- a/src/contentScripts/views/Favorites/FavoritesNew.vue
+++ b/src/contentScripts/views/Favorites/FavoritesNew.vue
@@ -409,17 +409,34 @@ async function getFavoriteSeasonResources(
     const res: FavoriteSeasonResourcesResult = await api.favorite.getFavoriteSeasonResources({
       season_id,
       pn,
+      ps: 40,
     })
 
     if (res.code === 0 && res.data) {
       activatedCategoryCover.value = res.data.info?.cover || selectedCategory.value?.cover || ''
 
       const medias = Array.isArray(res.data.medias) ? res.data.medias.filter((m: any) => m != null) : []
-      if (medias.length > 0)
-        favoriteResources.push(...medias.map(normalizeSeasonMedia))
-
-      if (medias.length < 40)
+      const mediaCount = res.data.info?.media_count
+      // 接口常无视 ps、一次返回全量；若仍按「满页继续翻」会连打同一批数据，拖垮后续「播放全部」请求
+      if (medias.length > 0) {
+        if (typeof mediaCount === 'number' && mediaCount >= 0 && medias.length >= mediaCount) {
+          favoriteResources.length = 0
+          favoriteResources.push(...medias.slice(0, mediaCount).map(normalizeSeasonMedia))
+          noMoreContent.value = true
+        }
+        else {
+          favoriteResources.push(...medias.map(normalizeSeasonMedia))
+          if (
+            medias.length < 40
+            || (typeof mediaCount === 'number' && mediaCount >= 0 && favoriteResources.length >= mediaCount)
+          ) {
+            noMoreContent.value = true
+          }
+        }
+      }
+      else {
         noMoreContent.value = true
+      }
 
       if (!(await haveScrollbar()) && !noMoreContent.value)
         await getFavoriteSeasonResources(season_id, ++currentPageNum.value)

--- a/src/contentScripts/views/Favorites/FavoritesNew.vue
+++ b/src/contentScripts/views/Favorites/FavoritesNew.vue
@@ -579,6 +579,7 @@ async function handlePlayAll() {
         preloaded: {
           medias: loadedSeasonMedias.value,
           complete: loadedSeasonComplete.value,
+          expectedCount: selectedCategory.value.media_count,
         },
       })
       if (result.usedFallback && result.reason !== 'beginning')

--- a/src/contentScripts/views/Favorites/FavoritesNew.vue
+++ b/src/contentScripts/views/Favorites/FavoritesNew.vue
@@ -12,6 +12,7 @@ import type { FavoritesResult, Media as FavoriteItem } from '~/models/video/favo
 import type { FavoritesCategoryResult, List as CategoryItem } from '~/models/video/favoriteCategory'
 import type { CollectedFavoriteSeason, CollectedFavoriteSeasonsResult, FavoriteSeasonMedia, FavoriteSeasonResourcesResult } from '~/models/video/favoriteSeason'
 import api from '~/utils/api'
+import { resolveFavoriteSeasonPlayAllUrl } from '~/utils/favoriteSeason'
 import { getCSRF, getUserID, openLinkToNewTab, removeHttpFromUrl } from '~/utils/main'
 import emitter from '~/utils/mitt'
 
@@ -46,6 +47,7 @@ const isFullPageLoading = ref<boolean>(true)
 const noMoreContent = ref<boolean>(false)
 const isBatchManaging = ref<boolean>(false)
 const isBatchOperating = ref<boolean>(false)
+const isResolvingSeasonPlayAll = ref<boolean>(false)
 const selectedResourceKeys = ref<string[]>([])
 const folderSectionExpanded = ref<boolean>(true)
 const seasonSectionExpanded = ref<boolean>(true)
@@ -538,24 +540,30 @@ function handleSearchScopeChange() {
   }
 }
 
-function handlePlayAll() {
+async function handlePlayAll() {
   if (searchScope.value === 'all') {
     return
   }
-  if (selectedCategory.value?.source === 'season')
-    openLinkToNewTab(getFavoriteSeasonUrl(selectedCategory.value))
-  else
-    openLinkToNewTab(`https://www.bilibili.com/list/ml${selectedCategory.value?.id}`)
-}
+  if (!selectedCategory.value || isResolvingSeasonPlayAll.value)
+    return
 
-function getFavoriteSeasonUrl(category: ViewCategory) {
-  const fallbackUrl = `https://www.bilibili.com/list/season/${category.id}`
-  const matchedVideoLink = category.link?.match(/^bilibili:\/\/video\/(\d+)(\?.*)?$/)
+  if (selectedCategory.value.source === 'season') {
+    isResolvingSeasonPlayAll.value = true
+    try {
+      const url = await resolveFavoriteSeasonPlayAllUrl({
+        seasonId: selectedCategory.value.id,
+        link: selectedCategory.value.link,
+        playFromLatest: settings.value.playCollectedSeasonFromLatest,
+      })
+      openLinkToNewTab(url)
+    }
+    finally {
+      isResolvingSeasonPlayAll.value = false
+    }
+    return
+  }
 
-  if (!matchedVideoLink)
-    return fallbackUrl
-
-  return `https://www.bilibili.com/video/av${matchedVideoLink[1]}${matchedVideoLink[2] || ''}`
+  openLinkToNewTab(`https://www.bilibili.com/list/ml${selectedCategory.value.id}`)
 }
 
 function jumpToLoginPage() {
@@ -778,7 +786,7 @@ function transformFavoriteItem(item: FavoriteItem): Video {
           <div class="favorites-hero-actions">
             <Button
               type="primary"
-              :disabled="searchScope === 'all' || !selectedCategory"
+              :disabled="searchScope === 'all' || !selectedCategory || isResolvingSeasonPlayAll"
               @click="handlePlayAll"
             >
               <template #left>

--- a/src/contentScripts/views/Favorites/FavoritesNew.vue
+++ b/src/contentScripts/views/Favorites/FavoritesNew.vue
@@ -553,7 +553,7 @@ async function handlePlayAll() {
       const url = await resolveFavoriteSeasonPlayAllUrl({
         seasonId: selectedCategory.value.id,
         link: selectedCategory.value.link,
-        playFromLatest: settings.value.playCollectedSeasonFromLatest,
+        mode: settings.value.collectedSeasonPlayAllMode,
       })
       openLinkToNewTab(url)
     }

--- a/src/contentScripts/views/Favorites/FavoritesNew.vue
+++ b/src/contentScripts/views/Favorites/FavoritesNew.vue
@@ -14,6 +14,7 @@ import type { FavoritesCategoryResult, List as CategoryItem } from '~/models/vid
 import type { CollectedFavoriteSeason, CollectedFavoriteSeasonsResult, FavoriteSeasonMedia } from '~/models/video/favoriteSeason'
 import api from '~/utils/api'
 import {
+  enrichFavoriteSeasonMediaFaces,
   FAVORITE_SEASON_PAGE_SIZE,
   fetchFavoriteSeasonPage,
   mergeFavoriteSeasonPage,
@@ -436,12 +437,12 @@ async function getFavoriteSeasonResources(
       pageSize: FAVORITE_SEASON_PAGE_SIZE,
     })
 
-    loadedSeasonMedias.value = merged.medias
+    loadedSeasonMedias.value = await enrichFavoriteSeasonMediaFaces(merged.medias)
     loadedSeasonComplete.value = !merged.hasMore
     noMoreContent.value = !merged.hasMore
 
     favoriteResources.length = 0
-    favoriteResources.push(...merged.medias.map(normalizeSeasonMedia))
+    favoriteResources.push(...loadedSeasonMedias.value.map(normalizeSeasonMedia))
 
     if (!(await haveScrollbar()) && merged.hasMore) {
       currentPageNum.value = pn + 1
@@ -464,8 +465,9 @@ function normalizeSeasonMedia(item: FavoriteSeasonMedia): FavoriteItem {
     page: 1,
     duration: item.duration,
     upper: {
-      ...item.upper,
-      face: '',
+      mid: item.upper.mid,
+      name: item.upper.name,
+      face: item.upper.face || '',
     },
     attr: 0,
     cnt_info: {

--- a/src/contentScripts/views/Favorites/FavoritesNew.vue
+++ b/src/contentScripts/views/Favorites/FavoritesNew.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { Ref } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useToast } from 'vue-toastification'
 
 import type { FavoriteResource } from '~/components/TopBar/types'
 import type { Video } from '~/components/VideoCard/types'
@@ -10,14 +11,20 @@ import { TOP_BAR_VISIBILITY_CHANGE } from '~/constants/globalEvents'
 import { settings } from '~/logic'
 import type { FavoritesResult, Media as FavoriteItem } from '~/models/video/favorite'
 import type { FavoritesCategoryResult, List as CategoryItem } from '~/models/video/favoriteCategory'
-import type { CollectedFavoriteSeason, CollectedFavoriteSeasonsResult, FavoriteSeasonMedia, FavoriteSeasonResourcesResult } from '~/models/video/favoriteSeason'
+import type { CollectedFavoriteSeason, CollectedFavoriteSeasonsResult, FavoriteSeasonMedia } from '~/models/video/favoriteSeason'
 import api from '~/utils/api'
-import { resolveFavoriteSeasonPlayAllUrl } from '~/utils/favoriteSeason'
+import {
+  FAVORITE_SEASON_PAGE_SIZE,
+  fetchFavoriteSeasonPage,
+  mergeFavoriteSeasonPage,
+  resolveFavoriteSeasonPlayAllUrl,
+} from '~/utils/favoriteSeason'
 import { getCSRF, getUserID, openLinkToNewTab, removeHttpFromUrl } from '~/utils/main'
 import emitter from '~/utils/mitt'
 
 // 新版收藏页支持收藏夹与订阅合集。
 const { t } = useI18n()
+const toast = useToast()
 
 type FavoriteCategorySource = 'folder' | 'season'
 type BatchTransferAction = 'copy' | 'move'
@@ -48,6 +55,9 @@ const noMoreContent = ref<boolean>(false)
 const isBatchManaging = ref<boolean>(false)
 const isBatchOperating = ref<boolean>(false)
 const isResolvingSeasonPlayAll = ref<boolean>(false)
+/** 当前订阅合集的原始 medias（与列表同套分页语义），供播放全部复用 */
+const loadedSeasonMedias = ref<FavoriteSeasonMedia[]>([])
+const loadedSeasonComplete = ref(false)
 const selectedResourceKeys = ref<string[]>([])
 const folderSectionExpanded = ref<boolean>(true)
 const seasonSectionExpanded = ref<boolean>(true)
@@ -402,47 +412,40 @@ async function getFavoriteSeasonResources(
   season_id: number,
   pn: number,
 ) {
-  if (pn === 1)
+  if (pn === 1) {
     isFullPageLoading.value = true
+    loadedSeasonMedias.value = []
+    loadedSeasonComplete.value = false
+  }
   isLoading.value = true
   try {
-    const res: FavoriteSeasonResourcesResult = await api.favorite.getFavoriteSeasonResources({
-      season_id,
+    const page = await fetchFavoriteSeasonPage(season_id, pn, FAVORITE_SEASON_PAGE_SIZE)
+    if (!page.ok) {
+      noMoreContent.value = true
+      loadedSeasonComplete.value = false
+      return
+    }
+
+    activatedCategoryCover.value = page.cover || selectedCategory.value?.cover || ''
+
+    const merged = mergeFavoriteSeasonPage({
       pn,
-      ps: 40,
+      pageMedias: page.pageMedias,
+      mediaCount: page.mediaCount,
+      previousMedias: loadedSeasonMedias.value,
+      pageSize: FAVORITE_SEASON_PAGE_SIZE,
     })
 
-    if (res.code === 0 && res.data) {
-      activatedCategoryCover.value = res.data.info?.cover || selectedCategory.value?.cover || ''
+    loadedSeasonMedias.value = merged.medias
+    loadedSeasonComplete.value = !merged.hasMore
+    noMoreContent.value = !merged.hasMore
 
-      const medias = Array.isArray(res.data.medias) ? res.data.medias.filter((m: any) => m != null) : []
-      const mediaCount = res.data.info?.media_count
-      // 接口常无视 ps、一次返回全量；若仍按「满页继续翻」会连打同一批数据，拖垮后续「播放全部」请求
-      if (medias.length > 0) {
-        if (typeof mediaCount === 'number' && mediaCount >= 0 && medias.length >= mediaCount) {
-          favoriteResources.length = 0
-          favoriteResources.push(...medias.slice(0, mediaCount).map(normalizeSeasonMedia))
-          noMoreContent.value = true
-        }
-        else {
-          favoriteResources.push(...medias.map(normalizeSeasonMedia))
-          if (
-            medias.length < 40
-            || (typeof mediaCount === 'number' && mediaCount >= 0 && favoriteResources.length >= mediaCount)
-          ) {
-            noMoreContent.value = true
-          }
-        }
-      }
-      else {
-        noMoreContent.value = true
-      }
+    favoriteResources.length = 0
+    favoriteResources.push(...merged.medias.map(normalizeSeasonMedia))
 
-      if (!(await haveScrollbar()) && !noMoreContent.value)
-        await getFavoriteSeasonResources(season_id, ++currentPageNum.value)
-    }
-    else {
-      noMoreContent.value = true
+    if (!(await haveScrollbar()) && merged.hasMore) {
+      currentPageNum.value = pn + 1
+      await getFavoriteSeasonResources(season_id, currentPageNum.value)
     }
   }
   finally {
@@ -494,6 +497,8 @@ async function changeCategory(categoryItem: ViewCategory) {
   if (targetCategory.value?.id === categoryItem.id)
     targetCategory.value = undefined
   favoriteResources.length = 0
+  loadedSeasonMedias.value = []
+  loadedSeasonComplete.value = false
   noMoreContent.value = false
 
   // 切换收藏夹时，如果是搜索当前收藏夹模式，则立即加载数据
@@ -567,12 +572,18 @@ async function handlePlayAll() {
   if (selectedCategory.value.source === 'season') {
     isResolvingSeasonPlayAll.value = true
     try {
-      const url = await resolveFavoriteSeasonPlayAllUrl({
+      const result = await resolveFavoriteSeasonPlayAllUrl({
         seasonId: selectedCategory.value.id,
         link: selectedCategory.value.link,
         mode: settings.value.collectedSeasonPlayAllMode,
+        preloaded: {
+          medias: loadedSeasonMedias.value,
+          complete: loadedSeasonComplete.value,
+        },
       })
-      openLinkToNewTab(url)
+      if (result.usedFallback && result.reason !== 'beginning')
+        toast.warning(t('favorites.season_play_all_fallback'))
+      openLinkToNewTab(result.url)
     }
     finally {
       isResolvingSeasonPlayAll.value = false

--- a/src/logic/storage.ts
+++ b/src/logic/storage.ts
@@ -693,17 +693,6 @@ watch(
       }
     }
 
-    // 迁移旧的布尔 playCollectedSeasonFromLatest → collectedSeasonPlayAllMode
-    if (typeof record.playCollectedSeasonFromLatest === 'boolean') {
-      record.collectedSeasonPlayAllMode = record.playCollectedSeasonFromLatest ? 'latest' : 'beginning'
-      Reflect.deleteProperty(record, 'playCollectedSeasonFromLatest')
-    }
-
-    if (!('collectedSeasonPlayAllMode' in record)
-      || !['beginning', 'latest', 'lastWatched'].includes(record.collectedSeasonPlayAllMode)) {
-      record.collectedSeasonPlayAllMode = originalSettings.collectedSeasonPlayAllMode
-    }
-
     // 确保 useBilibiliDefaultAutoPlay 存在（新用户或旧版本升级）
     if (!('useBilibiliDefaultAutoPlay' in record)) {
       record.useBilibiliDefaultAutoPlay = true

--- a/src/logic/storage.ts
+++ b/src/logic/storage.ts
@@ -117,6 +117,8 @@ export interface ShortcutsSettings {
 export type VideoCardFontSizeSetting = 'xs' | 'sm' | 'base' | 'lg'
 export type VideoCardLayoutSetting = 'modern' | 'compact' | 'old'
 export type AutoPlayMode = 'default' | 'autoPlay' | 'autoPlayWithRecommend' | 'pauseAtEnd' | 'loop'
+/** 订阅合集「播放全部」起播策略 */
+export type CollectedSeasonPlayAllMode = 'beginning' | 'latest' | 'lastWatched'
 export type DefaultVideoPlayerMode = 'default' | 'webFullscreen' | 'widescreen' | 'bewlyWidescreen'
 export type BewlyWidescreenSidebarPosition = 'left' | 'right'
 export type RecommendationMode = 'web' | 'app' | 'webNoCookie'
@@ -312,7 +314,7 @@ export interface Settings {
   followingFilterDynamicVideos: boolean // 过滤动态视频
   useFollowingNewLayout: boolean
   useFavoritesNewLayout: boolean
-  playCollectedSeasonFromLatest: boolean // 订阅合集「播放全部」从最新一期开始
+  collectedSeasonPlayAllMode: CollectedSeasonPlayAllMode // 订阅合集「播放全部」起播：开头 / 最新 / 上次观看
   enableFollowingInactiveBlacklist: boolean // 启用不活跃名单
   followingInactiveDays: number // UP主超过N天未更新则移至不活跃名单
 
@@ -544,7 +546,7 @@ export const originalSettings: Settings = {
   followingFilterDynamicVideos: false, // 默认不过滤动态视频
   useFollowingNewLayout: false, // 默认使用旧布局
   useFavoritesNewLayout: true, // 默认使用新版收藏页
-  playCollectedSeasonFromLatest: false, // 默认保持 B 站从合集开头播放
+  collectedSeasonPlayAllMode: 'beginning', // 默认从合集开头播放
   enableFollowingInactiveBlacklist: true, // 默认启用不活跃名单
   followingInactiveDays: 100, // 默认100天
 
@@ -689,6 +691,17 @@ watch(
           record[field] = record[field] ? 'autoPlay' : 'pauseAtEnd'
         }
       }
+    }
+
+    // 迁移旧的布尔 playCollectedSeasonFromLatest → collectedSeasonPlayAllMode
+    if (typeof record.playCollectedSeasonFromLatest === 'boolean') {
+      record.collectedSeasonPlayAllMode = record.playCollectedSeasonFromLatest ? 'latest' : 'beginning'
+      Reflect.deleteProperty(record, 'playCollectedSeasonFromLatest')
+    }
+
+    if (!('collectedSeasonPlayAllMode' in record)
+      || !['beginning', 'latest', 'lastWatched'].includes(record.collectedSeasonPlayAllMode)) {
+      record.collectedSeasonPlayAllMode = originalSettings.collectedSeasonPlayAllMode
     }
 
     // 确保 useBilibiliDefaultAutoPlay 存在（新用户或旧版本升级）

--- a/src/logic/storage.ts
+++ b/src/logic/storage.ts
@@ -312,6 +312,7 @@ export interface Settings {
   followingFilterDynamicVideos: boolean // 过滤动态视频
   useFollowingNewLayout: boolean
   useFavoritesNewLayout: boolean
+  playCollectedSeasonFromLatest: boolean // 订阅合集「播放全部」从最新一期开始
   enableFollowingInactiveBlacklist: boolean // 启用不活跃名单
   followingInactiveDays: number // UP主超过N天未更新则移至不活跃名单
 
@@ -543,6 +544,7 @@ export const originalSettings: Settings = {
   followingFilterDynamicVideos: false, // 默认不过滤动态视频
   useFollowingNewLayout: false, // 默认使用旧布局
   useFavoritesNewLayout: true, // 默认使用新版收藏页
+  playCollectedSeasonFromLatest: false, // 默认保持 B 站从合集开头播放
   enableFollowingInactiveBlacklist: true, // 默认启用不活跃名单
   followingInactiveDays: 100, // 默认100天
 

--- a/src/models/video/favoriteSeason.ts
+++ b/src/models/video/favoriteSeason.ts
@@ -86,6 +86,8 @@ export interface FavoriteSeasonMedia {
   upper: {
     mid: number
     name: string
+    /** fav/season/list 通常不返回；由客户端按 mid 补全 */
+    face?: string
   }
   cnt_info: {
     collect: number

--- a/src/tests/favoriteSeason.spec.ts
+++ b/src/tests/favoriteSeason.spec.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  buildFavoriteSeasonEntryUrl,
+  buildFavoriteSeasonListPlayUrl,
+  resolveFavoriteSeasonPlayAllUrl,
+} from '~/utils/favoriteSeason'
+
+const mocks = vi.hoisted(() => ({
+  getFavoriteSeasonResources: vi.fn(),
+}))
+
+vi.mock('~/utils/api', () => ({
+  default: {
+    favorite: {
+      getFavoriteSeasonResources: mocks.getFavoriteSeasonResources,
+    },
+  },
+}))
+
+describe('favoriteSeason utils', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('builds entry urls from bilibili deep links or season fallback', () => {
+    expect(buildFavoriteSeasonEntryUrl(123)).toBe('https://www.bilibili.com/list/season/123')
+    expect(buildFavoriteSeasonEntryUrl(123, 'bilibili://video/456789')).toBe('https://www.bilibili.com/video/av456789')
+    expect(buildFavoriteSeasonEntryUrl(123, 'bilibili://video/456789?from=fav')).toBe('https://www.bilibili.com/video/av456789?from=fav')
+  })
+
+  it('builds list play urls with bvid and optional oid', () => {
+    expect(buildFavoriteSeasonListPlayUrl(99, 'BV1Latest')).toBe('https://www.bilibili.com/list/season/99?bvid=BV1Latest')
+    expect(buildFavoriteSeasonListPlayUrl(99, 'BV1Latest', 888)).toBe('https://www.bilibili.com/list/season/99?bvid=BV1Latest&oid=888')
+  })
+
+  it('resolves play-all to the last media when playFromLatest is enabled', async () => {
+    mocks.getFavoriteSeasonResources
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          info: { media_count: 3 },
+          medias: [
+            { id: 1, bvid: 'BV1Old', title: 'old' },
+            { id: 2, bvid: 'BV1Mid', title: 'mid' },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          info: { media_count: 3 },
+          medias: [
+            { id: 3, bvid: 'BV1Latest', title: 'latest' },
+          ],
+        },
+      })
+
+    await expect(resolveFavoriteSeasonPlayAllUrl({
+      seasonId: 42,
+      link: 'bilibili://video/100',
+      playFromLatest: true,
+    })).resolves.toBe('https://www.bilibili.com/list/season/42?bvid=BV1Latest&oid=3')
+
+    expect(mocks.getFavoriteSeasonResources).toHaveBeenCalledTimes(2)
+  })
+
+  it('falls back to entry url when pagination fails mid-way instead of using a partial last item', async () => {
+    mocks.getFavoriteSeasonResources
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          info: { media_count: 80 },
+          medias: Array.from({ length: 40 }, (_, index) => ({
+            id: index + 1,
+            bvid: `BV1Page1_${index}`,
+            title: `p1-${index}`,
+          })),
+        },
+      })
+      .mockResolvedValueOnce({
+        code: -1,
+        data: null,
+      })
+
+    await expect(resolveFavoriteSeasonPlayAllUrl({
+      seasonId: 42,
+      link: 'bilibili://video/100',
+      playFromLatest: true,
+    })).resolves.toBe('https://www.bilibili.com/video/av100')
+  })
+
+  it('keeps the default entry url when playFromLatest is disabled', async () => {
+    await expect(resolveFavoriteSeasonPlayAllUrl({
+      seasonId: 42,
+      link: 'bilibili://video/100',
+      playFromLatest: false,
+    })).resolves.toBe('https://www.bilibili.com/video/av100')
+
+    expect(mocks.getFavoriteSeasonResources).not.toHaveBeenCalled()
+  })
+})

--- a/src/tests/favoriteSeason.spec.ts
+++ b/src/tests/favoriteSeason.spec.ts
@@ -132,13 +132,14 @@ describe('favoriteSeason utils', () => {
     expect(mocks.getFavoriteSeasonResources).toHaveBeenCalledTimes(1)
   })
 
-  it('reuses preloaded complete medias without refetching', async () => {
+  it('reuses preloaded medias when count matches even if complete flag is false', async () => {
     await expect(resolveFavoriteSeasonPlayAllUrl({
       seasonId: 42,
       link: 'bilibili://video/100',
       mode: 'latest',
       preloaded: {
-        complete: true,
+        complete: false,
+        expectedCount: 2,
         medias: [
           { id: 1, bvid: 'BV1Old', title: 'old' } as any,
           { id: 2, bvid: 'BV1Latest', title: 'latest' } as any,

--- a/src/tests/favoriteSeason.spec.ts
+++ b/src/tests/favoriteSeason.spec.ts
@@ -3,7 +3,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Business } from '~/models/history/history'
 import {
   buildFavoriteSeasonEntryUrl,
-  buildFavoriteSeasonListPlayUrl,
+  buildFavoriteSeasonVideoUrl,
+  FAVORITE_SEASON_PAGE_SIZE,
+  mergeFavoriteSeasonPage,
   resolveFavoriteSeasonPlayAllUrl,
 } from '~/utils/favoriteSeason'
 
@@ -35,13 +37,38 @@ describe('favoriteSeason utils', () => {
     expect(buildFavoriteSeasonEntryUrl(123, undefined, 'BV1Entry')).toBe('https://www.bilibili.com/video/BV1Entry/')
   })
 
-  it('builds play urls as normal video pages (list/season?bvid is 404 for ugc seasons)', () => {
-    expect(buildFavoriteSeasonListPlayUrl(99, 'BV1Latest')).toBe('https://www.bilibili.com/video/BV1Latest/')
-    expect(buildFavoriteSeasonListPlayUrl(99, 'BV1Latest', 888)).toBe('https://www.bilibili.com/video/BV1Latest/')
+  it('builds play urls as normal video pages', () => {
+    expect(buildFavoriteSeasonVideoUrl('BV1Latest')).toBe('https://www.bilibili.com/video/BV1Latest/')
+  })
+
+  it('mergeFavoriteSeasonPage stops when API returns a full dump', () => {
+    const pageMedias = Array.from({ length: 80 }, (_, index) => ({
+      id: index + 1,
+      bvid: `BV${index}`,
+      title: `${index}`,
+      cover: '',
+      duration: 1,
+      pubtime: index,
+      upper: { mid: 1, name: '' },
+      cnt_info: { collect: 0, play: 0, danmaku: 0, vt: 0 },
+      enable_vt: 0,
+      vt_display: '',
+      is_self_view: false,
+    }))
+
+    const merged = mergeFavoriteSeasonPage({
+      pn: 1,
+      pageMedias,
+      mediaCount: 80,
+      previousMedias: [],
+      pageSize: FAVORITE_SEASON_PAGE_SIZE,
+    })
+
+    expect(merged.hasMore).toBe(false)
+    expect(merged.medias).toHaveLength(80)
   })
 
   it('resolves latest mode to the last media', async () => {
-    // 正常分页：满页后续页，末页不足 ps
     mocks.getFavoriteSeasonResources
       .mockResolvedValueOnce({
         code: 0,
@@ -69,15 +96,17 @@ describe('favoriteSeason utils', () => {
       seasonId: 42,
       link: 'bilibili://video/100',
       mode: 'latest',
-    })).resolves.toBe('https://www.bilibili.com/video/BV1Latest/')
+    })).resolves.toEqual({
+      url: 'https://www.bilibili.com/video/BV1Latest/',
+      usedFallback: false,
+      reason: 'resolved',
+    })
 
     expect(mocks.getFavoriteSeasonResources).toHaveBeenCalledTimes(2)
     expect(mocks.getHistoryList).not.toHaveBeenCalled()
   })
 
   it('stops after one request when API ignores ps and returns the full season every page', async () => {
-    // 实测 fav/season/list 常无视 ps，每页都吐回全部 medias；若不按 media_count 提前结束，
-    // 会连打到页数上限或中途失败，最终回退到合集入口（第一期）。
     const fullList = Array.from({ length: 80 }, (_, index) => ({
       id: index + 1,
       bvid: `BV1Full_${index}`,
@@ -95,9 +124,32 @@ describe('favoriteSeason utils', () => {
       seasonId: 42,
       link: 'bilibili://video/100',
       mode: 'latest',
-    })).resolves.toBe('https://www.bilibili.com/video/BV1Full_79/')
+    })).resolves.toMatchObject({
+      url: 'https://www.bilibili.com/video/BV1Full_79/',
+      usedFallback: false,
+    })
 
     expect(mocks.getFavoriteSeasonResources).toHaveBeenCalledTimes(1)
+  })
+
+  it('reuses preloaded complete medias without refetching', async () => {
+    await expect(resolveFavoriteSeasonPlayAllUrl({
+      seasonId: 42,
+      link: 'bilibili://video/100',
+      mode: 'latest',
+      preloaded: {
+        complete: true,
+        medias: [
+          { id: 1, bvid: 'BV1Old', title: 'old' } as any,
+          { id: 2, bvid: 'BV1Latest', title: 'latest' } as any,
+        ],
+      },
+    })).resolves.toMatchObject({
+      url: 'https://www.bilibili.com/video/BV1Latest/',
+      usedFallback: false,
+    })
+
+    expect(mocks.getFavoriteSeasonResources).not.toHaveBeenCalled()
   })
 
   it('resolves lastWatched mode from recent archive history', async () => {
@@ -131,7 +183,10 @@ describe('favoriteSeason utils', () => {
       seasonId: 42,
       link: 'bilibili://video/100',
       mode: 'lastWatched',
-    })).resolves.toBe('https://www.bilibili.com/video/BV1Watched/')
+    })).resolves.toMatchObject({
+      url: 'https://www.bilibili.com/video/BV1Watched/',
+      usedFallback: false,
+    })
   })
 
   it('falls back to entry url when pagination fails mid-way instead of using a partial last item', async () => {
@@ -156,7 +211,11 @@ describe('favoriteSeason utils', () => {
       seasonId: 42,
       link: 'bilibili://video/100',
       mode: 'latest',
-    })).resolves.toBe('https://www.bilibili.com/video/av100')
+    })).resolves.toEqual({
+      url: 'https://www.bilibili.com/video/av100',
+      usedFallback: true,
+      reason: 'incomplete',
+    })
   })
 
   it('keeps the default entry url for beginning mode', async () => {
@@ -164,7 +223,11 @@ describe('favoriteSeason utils', () => {
       seasonId: 42,
       link: 'bilibili://video/100',
       mode: 'beginning',
-    })).resolves.toBe('https://www.bilibili.com/video/av100')
+    })).resolves.toEqual({
+      url: 'https://www.bilibili.com/video/av100',
+      usedFallback: false,
+      reason: 'beginning',
+    })
 
     expect(mocks.getFavoriteSeasonResources).not.toHaveBeenCalled()
   })

--- a/src/tests/favoriteSeason.spec.ts
+++ b/src/tests/favoriteSeason.spec.ts
@@ -25,38 +25,42 @@ vi.mock('~/utils/api', () => ({
 
 describe('favoriteSeason utils', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
+    vi.resetAllMocks()
   })
 
-  it('builds entry urls from bilibili deep links or season fallback', () => {
+  it('builds entry urls from bilibili deep links or video bvid', () => {
     expect(buildFavoriteSeasonEntryUrl(123)).toBe('https://www.bilibili.com/list/season/123')
     expect(buildFavoriteSeasonEntryUrl(123, 'bilibili://video/456789')).toBe('https://www.bilibili.com/video/av456789')
     expect(buildFavoriteSeasonEntryUrl(123, 'bilibili://video/456789?from=fav')).toBe('https://www.bilibili.com/video/av456789?from=fav')
+    expect(buildFavoriteSeasonEntryUrl(123, undefined, 'BV1Entry')).toBe('https://www.bilibili.com/video/BV1Entry/')
   })
 
-  it('builds list play urls with bvid and optional oid', () => {
-    expect(buildFavoriteSeasonListPlayUrl(99, 'BV1Latest')).toBe('https://www.bilibili.com/list/season/99?bvid=BV1Latest')
-    expect(buildFavoriteSeasonListPlayUrl(99, 'BV1Latest', 888)).toBe('https://www.bilibili.com/list/season/99?bvid=BV1Latest&oid=888')
+  it('builds play urls as normal video pages (list/season?bvid is 404 for ugc seasons)', () => {
+    expect(buildFavoriteSeasonListPlayUrl(99, 'BV1Latest')).toBe('https://www.bilibili.com/video/BV1Latest/')
+    expect(buildFavoriteSeasonListPlayUrl(99, 'BV1Latest', 888)).toBe('https://www.bilibili.com/video/BV1Latest/')
   })
 
   it('resolves latest mode to the last media', async () => {
+    // 正常分页：满页后续页，末页不足 ps
     mocks.getFavoriteSeasonResources
       .mockResolvedValueOnce({
         code: 0,
         data: {
-          info: { media_count: 3 },
-          medias: [
-            { id: 1, bvid: 'BV1Old', title: 'old' },
-            { id: 2, bvid: 'BV1Mid', title: 'mid' },
-          ],
+          info: { media_count: 42 },
+          medias: Array.from({ length: 40 }, (_, index) => ({
+            id: index + 1,
+            bvid: `BV1Page1_${index}`,
+            title: `p1-${index}`,
+          })),
         },
       })
       .mockResolvedValueOnce({
         code: 0,
         data: {
-          info: { media_count: 3 },
+          info: { media_count: 42 },
           medias: [
-            { id: 3, bvid: 'BV1Latest', title: 'latest' },
+            { id: 41, bvid: 'BV1Almost', title: 'almost' },
+            { id: 42, bvid: 'BV1Latest', title: 'latest' },
           ],
         },
       })
@@ -65,10 +69,35 @@ describe('favoriteSeason utils', () => {
       seasonId: 42,
       link: 'bilibili://video/100',
       mode: 'latest',
-    })).resolves.toBe('https://www.bilibili.com/list/season/42?bvid=BV1Latest&oid=3')
+    })).resolves.toBe('https://www.bilibili.com/video/BV1Latest/')
 
     expect(mocks.getFavoriteSeasonResources).toHaveBeenCalledTimes(2)
     expect(mocks.getHistoryList).not.toHaveBeenCalled()
+  })
+
+  it('stops after one request when API ignores ps and returns the full season every page', async () => {
+    // 实测 fav/season/list 常无视 ps，每页都吐回全部 medias；若不按 media_count 提前结束，
+    // 会连打到页数上限或中途失败，最终回退到合集入口（第一期）。
+    const fullList = Array.from({ length: 80 }, (_, index) => ({
+      id: index + 1,
+      bvid: `BV1Full_${index}`,
+      title: `full-${index}`,
+    }))
+    mocks.getFavoriteSeasonResources.mockResolvedValue({
+      code: 0,
+      data: {
+        info: { media_count: 80 },
+        medias: fullList,
+      },
+    })
+
+    await expect(resolveFavoriteSeasonPlayAllUrl({
+      seasonId: 42,
+      link: 'bilibili://video/100',
+      mode: 'latest',
+    })).resolves.toBe('https://www.bilibili.com/video/BV1Full_79/')
+
+    expect(mocks.getFavoriteSeasonResources).toHaveBeenCalledTimes(1)
   })
 
   it('resolves lastWatched mode from recent archive history', async () => {
@@ -102,7 +131,7 @@ describe('favoriteSeason utils', () => {
       seasonId: 42,
       link: 'bilibili://video/100',
       mode: 'lastWatched',
-    })).resolves.toBe('https://www.bilibili.com/list/season/42?bvid=BV1Watched&oid=2')
+    })).resolves.toBe('https://www.bilibili.com/video/BV1Watched/')
   })
 
   it('falls back to entry url when pagination fails mid-way instead of using a partial last item', async () => {

--- a/src/tests/favoriteSeason.spec.ts
+++ b/src/tests/favoriteSeason.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { Business } from '~/models/history/history'
 import {
   buildFavoriteSeasonEntryUrl,
   buildFavoriteSeasonListPlayUrl,
@@ -8,12 +9,16 @@ import {
 
 const mocks = vi.hoisted(() => ({
   getFavoriteSeasonResources: vi.fn(),
+  getHistoryList: vi.fn(),
 }))
 
 vi.mock('~/utils/api', () => ({
   default: {
     favorite: {
       getFavoriteSeasonResources: mocks.getFavoriteSeasonResources,
+    },
+    history: {
+      getHistoryList: mocks.getHistoryList,
     },
   },
 }))
@@ -34,7 +39,7 @@ describe('favoriteSeason utils', () => {
     expect(buildFavoriteSeasonListPlayUrl(99, 'BV1Latest', 888)).toBe('https://www.bilibili.com/list/season/99?bvid=BV1Latest&oid=888')
   })
 
-  it('resolves play-all to the last media when playFromLatest is enabled', async () => {
+  it('resolves latest mode to the last media', async () => {
     mocks.getFavoriteSeasonResources
       .mockResolvedValueOnce({
         code: 0,
@@ -59,10 +64,45 @@ describe('favoriteSeason utils', () => {
     await expect(resolveFavoriteSeasonPlayAllUrl({
       seasonId: 42,
       link: 'bilibili://video/100',
-      playFromLatest: true,
+      mode: 'latest',
     })).resolves.toBe('https://www.bilibili.com/list/season/42?bvid=BV1Latest&oid=3')
 
     expect(mocks.getFavoriteSeasonResources).toHaveBeenCalledTimes(2)
+    expect(mocks.getHistoryList).not.toHaveBeenCalled()
+  })
+
+  it('resolves lastWatched mode from recent archive history', async () => {
+    mocks.getFavoriteSeasonResources.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        info: { media_count: 2 },
+        medias: [
+          { id: 1, bvid: 'BV1Old', title: 'old' },
+          { id: 2, bvid: 'BV1Watched', title: 'watched' },
+        ],
+      },
+    })
+    mocks.getHistoryList.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        list: [
+          {
+            view_at: 200,
+            history: { business: Business.ARCHIVE, bvid: 'BV1Other', oid: 999 },
+          },
+          {
+            view_at: 100,
+            history: { business: Business.ARCHIVE, bvid: 'BV1Watched', oid: 2 },
+          },
+        ],
+      },
+    })
+
+    await expect(resolveFavoriteSeasonPlayAllUrl({
+      seasonId: 42,
+      link: 'bilibili://video/100',
+      mode: 'lastWatched',
+    })).resolves.toBe('https://www.bilibili.com/list/season/42?bvid=BV1Watched&oid=2')
   })
 
   it('falls back to entry url when pagination fails mid-way instead of using a partial last item', async () => {
@@ -86,15 +126,15 @@ describe('favoriteSeason utils', () => {
     await expect(resolveFavoriteSeasonPlayAllUrl({
       seasonId: 42,
       link: 'bilibili://video/100',
-      playFromLatest: true,
+      mode: 'latest',
     })).resolves.toBe('https://www.bilibili.com/video/av100')
   })
 
-  it('keeps the default entry url when playFromLatest is disabled', async () => {
+  it('keeps the default entry url for beginning mode', async () => {
     await expect(resolveFavoriteSeasonPlayAllUrl({
       seasonId: 42,
       link: 'bilibili://video/100',
-      playFromLatest: false,
+      mode: 'beginning',
     })).resolves.toBe('https://www.bilibili.com/video/av100')
 
     expect(mocks.getFavoriteSeasonResources).not.toHaveBeenCalled()

--- a/src/tests/favoriteSeasonFaces.spec.ts
+++ b/src/tests/favoriteSeasonFaces.spec.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { enrichFavoriteSeasonMediaFaces } from '~/utils/favoriteSeason'
+
+const mocks = vi.hoisted(() => ({
+  getUserCard: vi.fn(),
+}))
+
+vi.mock('~/utils/api', () => ({
+  default: {
+    favorite: {
+      getFavoriteSeasonResources: vi.fn(),
+    },
+    history: {
+      getHistoryList: vi.fn(),
+    },
+    user: {
+      getUserCard: mocks.getUserCard,
+    },
+  },
+}))
+
+describe('enrichFavoriteSeasonMediaFaces', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('fills missing upper.face by mid via user card api and caches', async () => {
+    mocks.getUserCard.mockResolvedValue({
+      code: 0,
+      data: {
+        card: {
+          mid: '1',
+          name: 'UP',
+          face: 'https://i0.hdslb.com/bfs/face/demo.jpg',
+        },
+      },
+    })
+
+    const medias = [
+      {
+        id: 1,
+        title: 'a',
+        cover: '',
+        duration: 1,
+        pubtime: 1,
+        bvid: 'BV1a',
+        upper: { mid: 1, name: 'UP' },
+        cnt_info: { collect: 0, play: 0, danmaku: 0, vt: 0 },
+        enable_vt: 0,
+        vt_display: '',
+        is_self_view: false,
+      },
+      {
+        id: 2,
+        title: 'b',
+        cover: '',
+        duration: 1,
+        pubtime: 1,
+        bvid: 'BV1b',
+        upper: { mid: 1, name: 'UP' },
+        cnt_info: { collect: 0, play: 0, danmaku: 0, vt: 0 },
+        enable_vt: 0,
+        vt_display: '',
+        is_self_view: false,
+      },
+    ]
+
+    const enriched = await enrichFavoriteSeasonMediaFaces(medias)
+    expect(enriched.every(item => item.upper.face === 'https://i0.hdslb.com/bfs/face/demo.jpg')).toBe(true)
+    expect(mocks.getUserCard).toHaveBeenCalledTimes(1)
+
+    // 缓存命中，不再请求
+    await enrichFavoriteSeasonMediaFaces(medias)
+    expect(mocks.getUserCard).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/tests/nativeFavoriteSeasonPlayAll.spec.ts
+++ b/src/tests/nativeFavoriteSeasonPlayAll.spec.ts
@@ -71,4 +71,28 @@ describe('nativeFavoriteSeasonPlayAll', () => {
     expect(isNativeSeasonPlayAllTarget(seasonBtn)).toBe(true)
     expect(isNativeSeasonPlayAllTarget(folderBtn)).toBe(false)
   })
+
+  it('recognizes new favlist playall-btn targets', async () => {
+    const { isNativeSeasonPlayAllTarget } = await import('~/utils/nativeFavoriteSeasonPlayAll')
+
+    document.body.innerHTML = `
+      <div class="favlist-info-detail__actions">
+        <button class="vui_button action-btn blue playall-btn">
+          <i class="vui_icon sic-fsp-play_fill icon"></i>
+          <span>播放全部</span>
+        </button>
+      </div>
+      <div class="other-actions">
+        <button class="action-btn">播放全部</button>
+      </div>
+    `
+
+    const playAllBtn = document.querySelector('.playall-btn')!
+    const playAllSpan = playAllBtn.querySelector('span')!
+    const otherBtn = document.querySelector('.other-actions .action-btn')!
+
+    expect(isNativeSeasonPlayAllTarget(playAllBtn)).toBe(true)
+    expect(isNativeSeasonPlayAllTarget(playAllSpan)).toBe(true)
+    expect(isNativeSeasonPlayAllTarget(otherBtn)).toBe(false)
+  })
 })

--- a/src/tests/nativeFavoriteSeasonPlayAll.spec.ts
+++ b/src/tests/nativeFavoriteSeasonPlayAll.spec.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('~/logic', () => ({
+  settings: { value: { collectedSeasonPlayAllMode: 'latest' } },
+}))
+
+vi.mock('~/utils/main', () => ({
+  openLinkToNewTab: vi.fn(),
+}))
+
+vi.mock('~/utils/favoriteSeason', () => ({
+  resolveFavoriteSeasonPlayAllUrl: vi.fn(async () => ({
+    url: 'https://www.bilibili.com/video/BV1Latest/',
+    usedFallback: false,
+    reason: 'resolved',
+  })),
+}))
+
+describe('nativeFavoriteSeasonPlayAll', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    document.body.innerHTML = ''
+  })
+
+  it('detects collected season favlist urls', async () => {
+    const {
+      isCollectedSeasonFavlistUrl,
+      getSeasonIdFromFavlistUrl,
+    } = await import('~/utils/nativeFavoriteSeasonPlayAll')
+
+    expect(isCollectedSeasonFavlistUrl(
+      'https://space.bilibili.com/3691001111644519/favlist?fid=4052670&ftype=collect&ctype=21',
+    )).toBe(true)
+
+    expect(isCollectedSeasonFavlistUrl(
+      'https://space.bilibili.com/123/favlist?fid=1&ftype=create',
+    )).toBe(false)
+
+    expect(isCollectedSeasonFavlistUrl(
+      'https://www.bilibili.com/video/BV1xx',
+    )).toBe(false)
+
+    expect(getSeasonIdFromFavlistUrl(
+      'https://space.bilibili.com/1/favlist?fid=4052670&ftype=collect&ctype=21',
+    )).toBe(4052670)
+
+    expect(getSeasonIdFromFavlistUrl(
+      'https://space.bilibili.com/1/favlist?ftype=collect',
+    )).toBeNull()
+  })
+
+  it('recognizes collection play-all button targets', async () => {
+    const { isNativeSeasonPlayAllTarget } = await import('~/utils/nativeFavoriteSeasonPlayAll')
+
+    document.body.innerHTML = `
+      <div class="favInfo-box">
+        <div class="collection-details">
+          <a class="collection-btn" href="https://www.bilibili.com/video/BV1mvKU6NE8S">播放全部</a>
+        </div>
+        <div class="favInfo-details">
+          <div class="fav-options">
+            <a class="fav-play" href="#">播放全部</a>
+          </div>
+        </div>
+      </div>
+    `
+
+    const seasonBtn = document.querySelector('.collection-btn')!
+    const folderBtn = document.querySelector('.fav-play')!
+
+    expect(isNativeSeasonPlayAllTarget(seasonBtn)).toBe(true)
+    expect(isNativeSeasonPlayAllTarget(folderBtn)).toBe(false)
+  })
+})

--- a/src/utils/favoriteSeason.ts
+++ b/src/utils/favoriteSeason.ts
@@ -3,17 +3,25 @@
  * 供 Dock 新版收藏页与顶栏收藏弹层共用
  */
 
+import type { CollectedSeasonPlayAllMode } from '~/logic/storage'
+import type { List as HistoryItem } from '~/models/history/history'
+import { Business } from '~/models/history/history'
 import type { FavoriteSeasonMedia } from '~/models/video/favoriteSeason'
 import api from '~/utils/api'
 
 const SEASON_PAGE_SIZE = 40
 /** 防止异常接口一直返回满页时死循环 */
 const MAX_SEASON_PAGES = 100
+const HISTORY_PAGE_SIZE = 20
+/** 在最近历史中查找合集内上次观看（约 300 条） */
+const MAX_HISTORY_PAGES = 15
+
+export type { CollectedSeasonPlayAllMode }
 
 export interface FavoriteSeasonPlayTarget {
   seasonId: number
   link?: string
-  playFromLatest?: boolean
+  mode?: CollectedSeasonPlayAllMode
 }
 
 interface FetchAllSeasonMediasResult {
@@ -102,23 +110,105 @@ export async function fetchAllFavoriteSeasonMedias(seasonId: number): Promise<Fe
   return { medias, complete: false }
 }
 
+function matchSeasonMediaFromHistory(
+  medias: FavoriteSeasonMedia[],
+  historyItems: HistoryItem[],
+): FavoriteSeasonMedia | undefined {
+  const byBvid = new Map(
+    medias
+      .filter(item => typeof item.bvid === 'string' && item.bvid.length > 0)
+      .map(item => [item.bvid, item]),
+  )
+  const byAid = new Map(medias.map(item => [item.id, item]))
+
+  for (const item of historyItems) {
+    if (item.history?.business && item.history.business !== Business.ARCHIVE)
+      continue
+
+    const byVid = item.history?.bvid ? byBvid.get(item.history.bvid) : undefined
+    if (byVid)
+      return byVid
+
+    const oid = item.history?.oid
+    if (typeof oid === 'number' && byAid.has(oid))
+      return byAid.get(oid)
+  }
+
+  return undefined
+}
+
+/**
+ * 在最近观看历史中找合集内最近一次看过的稿件（历史按时间倒序）
+ */
+export async function findLastWatchedSeasonMedia(
+  medias: FavoriteSeasonMedia[],
+): Promise<FavoriteSeasonMedia | undefined> {
+  if (medias.length === 0)
+    return undefined
+
+  let viewAt = 0
+
+  for (let page = 0; page < MAX_HISTORY_PAGES; page++) {
+    let res: Awaited<ReturnType<typeof api.history.getHistoryList>>
+    try {
+      res = await api.history.getHistoryList({
+        type: 'archive',
+        view_at: viewAt,
+        ps: HISTORY_PAGE_SIZE,
+      })
+    }
+    catch {
+      return undefined
+    }
+
+    if (res.code !== 0 || !res.data)
+      return undefined
+
+    const list = Array.isArray(res.data.list) ? res.data.list as HistoryItem[] : []
+    if (list.length === 0)
+      return undefined
+
+    const matched = matchSeasonMediaFromHistory(medias, list)
+    if (matched)
+      return matched
+
+    viewAt = list[list.length - 1]?.view_at ?? 0
+    if (!viewAt || list.length < HISTORY_PAGE_SIZE)
+      return undefined
+  }
+
+  return undefined
+}
+
 /**
  * 解析「播放全部」目标地址
- * playFromLatest：仅在完整拉完全部稿件后，用末项起播（API 默认可视为正序，末项≈最新）
+ * - beginning：合集入口（默认）
+ * - latest：完整列表末项（≈最新一期）
+ * - lastWatched：观看历史中该合集最近一次看过的稿件；找不到则回退 beginning
  */
 export async function resolveFavoriteSeasonPlayAllUrl(target: FavoriteSeasonPlayTarget): Promise<string> {
-  const { seasonId, link, playFromLatest = false } = target
+  const { seasonId, link, mode = 'beginning' } = target
+  const entryUrl = buildFavoriteSeasonEntryUrl(seasonId, link)
 
-  if (!playFromLatest)
-    return buildFavoriteSeasonEntryUrl(seasonId, link)
+  if (mode === 'beginning')
+    return entryUrl
 
   const { medias, complete } = await fetchAllFavoriteSeasonMedias(seasonId)
-  if (!complete)
-    return buildFavoriteSeasonEntryUrl(seasonId, link)
+  if (!complete || medias.length === 0)
+    return entryUrl
 
-  const latest = medias.at(-1)
-  if (!latest?.bvid)
-    return buildFavoriteSeasonEntryUrl(seasonId, link)
+  if (mode === 'latest') {
+    const latest = medias.at(-1)
+    if (!latest?.bvid)
+      return entryUrl
+    return buildFavoriteSeasonListPlayUrl(seasonId, latest.bvid, latest.id)
+  }
 
-  return buildFavoriteSeasonListPlayUrl(seasonId, latest.bvid, latest.id)
+  // lastWatched：历史扫描不要求「必须完整」以外的额外条件，但上面已要求 complete，
+  // 避免用残缺合集集合误匹配到其它历史项之外的错觉；找不到则回退入口
+  const lastWatched = await findLastWatchedSeasonMedia(medias)
+  if (!lastWatched?.bvid)
+    return entryUrl
+
+  return buildFavoriteSeasonListPlayUrl(seasonId, lastWatched.bvid, lastWatched.id)
 }

--- a/src/utils/favoriteSeason.ts
+++ b/src/utils/favoriteSeason.ts
@@ -18,6 +18,8 @@ const MAX_SEASON_PAGES = 100
 const HISTORY_PAGE_SIZE = 20
 /** 在最近历史中查找合集内上次观看（约 300 条） */
 const MAX_HISTORY_PAGES = 15
+/** mid → face，跨合集复用，避免重复打卡片接口 */
+const userFaceCache = new Map<number, string>()
 
 export type { CollectedSeasonPlayAllMode }
 
@@ -61,6 +63,45 @@ export interface FavoriteSeasonPageMergeResult {
 interface FetchAllSeasonMediasResult {
   medias: FavoriteSeasonMedia[]
   complete: boolean
+}
+
+/**
+ * 合集列表接口通常不带 upper.face；按 mid 补全头像（同 UP 只请求一次）
+ */
+export async function enrichFavoriteSeasonMediaFaces(
+  medias: FavoriteSeasonMedia[],
+): Promise<FavoriteSeasonMedia[]> {
+  const missingMids = [...new Set(
+    medias
+      .map(item => item.upper?.mid)
+      .filter((mid): mid is number => typeof mid === 'number' && mid > 0 && !userFaceCache.has(mid)),
+  )]
+
+  await Promise.all(missingMids.map(async (mid) => {
+    try {
+      const res = await api.user.getUserCard({ mid: String(mid) })
+      const face = res?.data?.card?.face
+      if (res?.code === 0 && typeof face === 'string' && face.length > 0)
+        userFaceCache.set(mid, face)
+    }
+    catch {
+      // 单个失败不影响其它
+    }
+  }))
+
+  return medias.map((item) => {
+    const mid = item.upper?.mid
+    const cachedFace = typeof mid === 'number' ? userFaceCache.get(mid) : undefined
+    if (!cachedFace || item.upper?.face === cachedFace)
+      return item
+    return {
+      ...item,
+      upper: {
+        ...item.upper,
+        face: cachedFace,
+      },
+    }
+  })
 }
 
 /**

--- a/src/utils/favoriteSeason.ts
+++ b/src/utils/favoriteSeason.ts
@@ -1,6 +1,8 @@
 /**
- * 收藏「订阅合集」相关工具
- * 供 Dock 新版收藏页与顶栏收藏弹层共用
+ * 订阅合集：单一数据层
+ * - 分页语义（含「接口一次返回全量」）
+ * - 播放全部起播解析
+ * Dock 收藏页与顶栏弹层共用，UI 只负责触发加载/展示。
  */
 
 import type { CollectedSeasonPlayAllMode } from '~/logic/storage'
@@ -9,7 +11,8 @@ import { Business } from '~/models/history/history'
 import type { FavoriteSeasonMedia } from '~/models/video/favoriteSeason'
 import api from '~/utils/api'
 
-const SEASON_PAGE_SIZE = 40
+/** 与 B 站 fav/season/list 默认 ps、以及收藏页「一屏约 40」展示一致 */
+export const FAVORITE_SEASON_PAGE_SIZE = 40
 /** 防止异常接口一直返回满页时死循环 */
 const MAX_SEASON_PAGES = 100
 const HISTORY_PAGE_SIZE = 20
@@ -22,17 +25,43 @@ export interface FavoriteSeasonPlayTarget {
   seasonId: number
   link?: string
   mode?: CollectedSeasonPlayAllMode
+  /**
+   * UI 已通过同一套分页语义加载过的列表。
+   * complete=true 时可跳过再次全量请求。
+   */
+  preloaded?: {
+    medias: FavoriteSeasonMedia[]
+    complete: boolean
+  }
+}
+
+export interface FavoriteSeasonPlayAllResult {
+  url: string
+  /** 是否回退到合集入口（开头 / 数据不完整 / 无历史等） */
+  usedFallback: boolean
+  reason: 'beginning' | 'resolved' | 'incomplete' | 'empty' | 'missing-bvid' | 'no-history'
+}
+
+export interface FavoriteSeasonPageFetchResult {
+  ok: boolean
+  pageMedias: FavoriteSeasonMedia[]
+  mediaCount?: number
+  cover?: string
+}
+
+export interface FavoriteSeasonPageMergeResult {
+  medias: FavoriteSeasonMedia[]
+  hasMore: boolean
 }
 
 interface FetchAllSeasonMediasResult {
   medias: FavoriteSeasonMedia[]
-  /** 是否完整拉完（失败中断时为 false，调用方不得把末项当「最新」） */
   complete: boolean
 }
 
 /**
- * 合集入口 URL（B 站默认「播放全部」行为）
- * 优先用 collected season 的 bilibili://video/{aid} link，否则用封面/入口 bvid
+ * 合集入口 URL（B 站默认「从开头播放」）
+ * 优先 collected season 的 bilibili://video/{aid} link，否则封面/入口 bvid
  */
 export function buildFavoriteSeasonEntryUrl(seasonId: number, link?: string, bvid?: string): string {
   const matchedVideoLink = link?.match(/^bilibili:\/\/video\/(\d+)(\?.*)?$/)
@@ -48,68 +77,133 @@ export function buildFavoriteSeasonEntryUrl(seasonId: number, link?: string, bvi
 }
 
 /**
- * 打开合集内指定稿件。
- * 实测 /list/season/{id}?bvid= 对订阅合集会 404；普通 /video/{bvid} 可播且仍带合集侧栏。
+ * 打开合集内指定稿件（普通视频页，仍可带合集侧栏）
+ * 实测 /list/season/{id}?bvid= 对订阅合集会 404
  */
-export function buildFavoriteSeasonListPlayUrl(_seasonId: number, bvid: string, _oid?: number): string {
+export function buildFavoriteSeasonVideoUrl(bvid: string): string {
   return `https://www.bilibili.com/video/${bvid}/`
 }
 
 /**
- * 拉取订阅合集全部稿件（API 无排序参数，只能翻页）
- * complete=false 表示中途失败或异常截断，medias 可能不完整
+ * 合并一页合集稿件，并给出是否还有更多。
+ * 顶栏滚动加载 / 收藏页列表 / 播放全部全量拉取 共用此语义。
  */
-export async function fetchAllFavoriteSeasonMedias(seasonId: number): Promise<FetchAllSeasonMediasResult> {
-  const medias: FavoriteSeasonMedia[] = []
-  let pn = 1
-  let expectedCount: number | undefined
+export function mergeFavoriteSeasonPage(input: {
+  pn: number
+  pageMedias: FavoriteSeasonMedia[]
+  mediaCount?: number
+  previousMedias: FavoriteSeasonMedia[]
+  pageSize?: number
+}): FavoriteSeasonPageMergeResult {
+  const pageSize = input.pageSize ?? FAVORITE_SEASON_PAGE_SIZE
+  const count = typeof input.mediaCount === 'number' && input.mediaCount >= 0
+    ? input.mediaCount
+    : undefined
+  const pageMedias = input.pageMedias
 
-  while (pn <= MAX_SEASON_PAGES) {
-    let res: Awaited<ReturnType<typeof api.favorite.getFavoriteSeasonResources>>
-    try {
-      res = await api.favorite.getFavoriteSeasonResources({
-        season_id: seasonId,
-        pn,
-        ps: SEASON_PAGE_SIZE,
-      })
+  if (pageMedias.length === 0) {
+    return {
+      medias: input.previousMedias,
+      hasMore: false,
     }
-    catch {
-      return { medias, complete: false }
+  }
+
+  // 接口无视 ps、一次返回 ≥ media_count：整表替换，不再翻页
+  if (count !== undefined && pageMedias.length >= count) {
+    return {
+      medias: pageMedias.slice(0, count),
+      hasMore: false,
     }
+  }
 
-    if (res.code !== 0 || !res.data)
-      return { medias, complete: false }
+  // 无可靠 count，但首页就超过 pageSize：视为一次性全量（避免狂翻）
+  if (input.pn === 1 && pageMedias.length > pageSize) {
+    return {
+      medias: pageMedias,
+      hasMore: false,
+    }
+  }
 
-    if (typeof res.data.info?.media_count === 'number' && res.data.info.media_count >= 0)
-      expectedCount = res.data.info.media_count
+  const medias = input.pn === 1
+    ? [...pageMedias]
+    : [...input.previousMedias, ...pageMedias]
+
+  if (count !== undefined && medias.length >= count) {
+    return {
+      medias: medias.slice(0, count),
+      hasMore: false,
+    }
+  }
+
+  return {
+    medias,
+    hasMore: pageMedias.length >= pageSize,
+  }
+}
+
+/** 拉取合集单页原始数据 */
+export async function fetchFavoriteSeasonPage(
+  seasonId: number,
+  pn: number,
+  pageSize: number = FAVORITE_SEASON_PAGE_SIZE,
+): Promise<FavoriteSeasonPageFetchResult> {
+  try {
+    const res = await api.favorite.getFavoriteSeasonResources({
+      season_id: seasonId,
+      pn,
+      ps: pageSize,
+    })
+
+    if (res.code !== 0 || !res.data) {
+      return { ok: false, pageMedias: [] }
+    }
 
     const pageMedias = Array.isArray(res.data.medias)
       ? res.data.medias.filter((item: FavoriteSeasonMedia | null | undefined): item is FavoriteSeasonMedia => item != null)
       : []
 
-    if (pageMedias.length === 0) {
-      // 首页就空：完整空合集；后续页突然空：视为异常截断
-      return { medias, complete: pn === 1 || (expectedCount !== undefined && medias.length >= expectedCount) }
+    const mediaCount = typeof res.data.info?.media_count === 'number' && res.data.info.media_count >= 0
+      ? res.data.info.media_count
+      : undefined
+
+    return {
+      ok: true,
+      pageMedias,
+      mediaCount,
+      cover: res.data.info?.cover,
     }
+  }
+  catch {
+    return { ok: false, pageMedias: [] }
+  }
+}
 
-    medias.push(...pageMedias)
+/**
+ * 拉取订阅合集全部稿件
+ * complete=false 表示中途失败或异常截断，不得把末项当「最新」
+ */
+export async function fetchAllFavoriteSeasonMedias(seasonId: number): Promise<FetchAllSeasonMediasResult> {
+  let medias: FavoriteSeasonMedia[] = []
+  let pn = 1
 
-    // 部分接口会无视 ps、一次返回全部；够数就停，避免重复翻页
-    if (expectedCount !== undefined && medias.length >= expectedCount)
-      return { medias: medias.slice(0, expectedCount), complete: true }
+  while (pn <= MAX_SEASON_PAGES) {
+    const page = await fetchFavoriteSeasonPage(seasonId, pn)
+    if (!page.ok)
+      return { medias, complete: false }
 
-    if (pageMedias.length < SEASON_PAGE_SIZE) {
-      if (expectedCount !== undefined && medias.length < expectedCount)
-        return { medias, complete: false }
+    const merged = mergeFavoriteSeasonPage({
+      pn,
+      pageMedias: page.pageMedias,
+      mediaCount: page.mediaCount,
+      previousMedias: medias,
+    })
+    medias = merged.medias
+
+    if (!merged.hasMore)
       return { medias, complete: true }
-    }
 
     pn += 1
   }
-
-  // 触达页数上限：若已知总数且已对齐，仍算完整；否则不信任末项
-  if (expectedCount !== undefined && medias.length >= expectedCount)
-    return { medias, complete: true }
 
   return { medias, complete: false }
 }
@@ -184,34 +278,48 @@ export async function findLastWatchedSeasonMedia(
   return undefined
 }
 
+async function resolveSeasonMedias(
+  seasonId: number,
+  preloaded?: FavoriteSeasonPlayTarget['preloaded'],
+): Promise<FetchAllSeasonMediasResult> {
+  if (preloaded?.complete && preloaded.medias.length > 0)
+    return { medias: preloaded.medias, complete: true }
+
+  return fetchAllFavoriteSeasonMedias(seasonId)
+}
+
 /**
  * 解析「播放全部」目标地址
- * - beginning：合集入口（默认）
- * - latest：完整列表末项（≈最新一期）
- * - lastWatched：观看历史中该合集最近一次看过的稿件；找不到则回退 beginning
+ * - beginning：合集入口
+ * - latest：完整列表末项
+ * - lastWatched：观看历史中该合集最近一次；找不到则回退入口
  */
-export async function resolveFavoriteSeasonPlayAllUrl(target: FavoriteSeasonPlayTarget): Promise<string> {
-  const { seasonId, link, mode = 'beginning' } = target
+export async function resolveFavoriteSeasonPlayAllUrl(
+  target: FavoriteSeasonPlayTarget,
+): Promise<FavoriteSeasonPlayAllResult> {
+  const { seasonId, link, mode = 'beginning', preloaded } = target
   const entryUrl = buildFavoriteSeasonEntryUrl(seasonId, link)
 
-  if (mode === 'beginning')
-    return entryUrl
+  if (mode === 'beginning') {
+    return { url: entryUrl, usedFallback: false, reason: 'beginning' }
+  }
 
-  const { medias, complete } = await fetchAllFavoriteSeasonMedias(seasonId)
-  if (!complete || medias.length === 0)
-    return entryUrl
+  const { medias, complete } = await resolveSeasonMedias(seasonId, preloaded)
+  if (!complete)
+    return { url: entryUrl, usedFallback: true, reason: 'incomplete' }
+  if (medias.length === 0)
+    return { url: entryUrl, usedFallback: true, reason: 'empty' }
 
   if (mode === 'latest') {
     const latest = medias.at(-1)
     if (!latest?.bvid)
-      return entryUrl
-    return buildFavoriteSeasonListPlayUrl(seasonId, latest.bvid, latest.id)
+      return { url: entryUrl, usedFallback: true, reason: 'missing-bvid' }
+    return { url: buildFavoriteSeasonVideoUrl(latest.bvid), usedFallback: false, reason: 'resolved' }
   }
 
-  // lastWatched：找不到则回退入口
   const lastWatched = await findLastWatchedSeasonMedia(medias)
   if (!lastWatched?.bvid)
-    return entryUrl
+    return { url: entryUrl, usedFallback: true, reason: 'no-history' }
 
-  return buildFavoriteSeasonListPlayUrl(seasonId, lastWatched.bvid, lastWatched.id)
+  return { url: buildFavoriteSeasonVideoUrl(lastWatched.bvid), usedFallback: false, reason: 'resolved' }
 }

--- a/src/utils/favoriteSeason.ts
+++ b/src/utils/favoriteSeason.ts
@@ -28,10 +28,12 @@ export interface FavoriteSeasonPlayTarget {
   /**
    * UI 已通过同一套分页语义加载过的列表。
    * complete=true 时可跳过再次全量请求。
+   * expectedCount 来自合集 media_count，用于 complete 标记未同步时的兜底判定。
    */
   preloaded?: {
     medias: FavoriteSeasonMedia[]
     complete: boolean
+    expectedCount?: number
   }
 }
 
@@ -282,8 +284,22 @@ async function resolveSeasonMedias(
   seasonId: number,
   preloaded?: FavoriteSeasonPlayTarget['preloaded'],
 ): Promise<FetchAllSeasonMediasResult> {
+  // 已完整加载：直接复用，避免收藏页再打一遍接口
   if (preloaded?.complete && preloaded.medias.length > 0)
     return { medias: preloaded.medias, complete: true }
+
+  // 未标 complete，但条数已达已知总数：也视为完整（避免 flag 与 media_count 不同步）
+  if (
+    preloaded
+    && typeof preloaded.expectedCount === 'number'
+    && preloaded.expectedCount > 0
+    && preloaded.medias.length >= preloaded.expectedCount
+  ) {
+    return {
+      medias: preloaded.medias.slice(0, preloaded.expectedCount),
+      complete: true,
+    }
+  }
 
   return fetchAllFavoriteSeasonMedias(seasonId)
 }

--- a/src/utils/favoriteSeason.ts
+++ b/src/utils/favoriteSeason.ts
@@ -1,0 +1,124 @@
+/**
+ * 收藏「订阅合集」相关工具
+ * 供 Dock 新版收藏页与顶栏收藏弹层共用
+ */
+
+import type { FavoriteSeasonMedia } from '~/models/video/favoriteSeason'
+import api from '~/utils/api'
+
+const SEASON_PAGE_SIZE = 40
+/** 防止异常接口一直返回满页时死循环 */
+const MAX_SEASON_PAGES = 100
+
+export interface FavoriteSeasonPlayTarget {
+  seasonId: number
+  link?: string
+  playFromLatest?: boolean
+}
+
+interface FetchAllSeasonMediasResult {
+  medias: FavoriteSeasonMedia[]
+  /** 是否完整拉完（失败中断时为 false，调用方不得把末项当「最新」） */
+  complete: boolean
+}
+
+/**
+ * 合集入口 URL（B 站默认「播放全部」行为）
+ * 优先用 collected season 的 bilibili://video/{aid} link，否则回退 list/season
+ */
+export function buildFavoriteSeasonEntryUrl(seasonId: number, link?: string): string {
+  const fallbackUrl = `https://www.bilibili.com/list/season/${seasonId}`
+  const matchedVideoLink = link?.match(/^bilibili:\/\/video\/(\d+)(\?.*)?$/)
+
+  if (!matchedVideoLink)
+    return fallbackUrl
+
+  return `https://www.bilibili.com/video/av${matchedVideoLink[1]}${matchedVideoLink[2] || ''}`
+}
+
+/**
+ * 在合集列表播放页打开指定稿件（保留侧栏连播上下文）
+ */
+export function buildFavoriteSeasonListPlayUrl(seasonId: number, bvid: string, oid?: number): string {
+  const url = new URL(`https://www.bilibili.com/list/season/${seasonId}`)
+  url.searchParams.set('bvid', bvid)
+  if (typeof oid === 'number' && Number.isFinite(oid) && oid > 0)
+    url.searchParams.set('oid', String(oid))
+  return url.toString()
+}
+
+/**
+ * 拉取订阅合集全部稿件（API 无排序参数，只能翻页）
+ * complete=false 表示中途失败或异常截断，medias 可能不完整
+ */
+export async function fetchAllFavoriteSeasonMedias(seasonId: number): Promise<FetchAllSeasonMediasResult> {
+  const medias: FavoriteSeasonMedia[] = []
+  let pn = 1
+  let expectedCount: number | undefined
+
+  while (pn <= MAX_SEASON_PAGES) {
+    let res: Awaited<ReturnType<typeof api.favorite.getFavoriteSeasonResources>>
+    try {
+      res = await api.favorite.getFavoriteSeasonResources({
+        season_id: seasonId,
+        pn,
+        ps: SEASON_PAGE_SIZE,
+      })
+    }
+    catch {
+      return { medias, complete: false }
+    }
+
+    if (res.code !== 0 || !res.data)
+      return { medias, complete: false }
+
+    if (typeof res.data.info?.media_count === 'number' && res.data.info.media_count >= 0)
+      expectedCount = res.data.info.media_count
+
+    const pageMedias = Array.isArray(res.data.medias)
+      ? res.data.medias.filter((item: FavoriteSeasonMedia | null | undefined): item is FavoriteSeasonMedia => item != null)
+      : []
+
+    if (pageMedias.length === 0) {
+      // 首页就空：完整空合集；后续页突然空：视为异常截断
+      return { medias, complete: pn === 1 || (expectedCount !== undefined && medias.length >= expectedCount) }
+    }
+
+    medias.push(...pageMedias)
+
+    if (pageMedias.length < SEASON_PAGE_SIZE) {
+      if (expectedCount !== undefined && medias.length < expectedCount)
+        return { medias, complete: false }
+      return { medias, complete: true }
+    }
+
+    pn += 1
+  }
+
+  // 触达页数上限：若已知总数且已对齐，仍算完整；否则不信任末项
+  if (expectedCount !== undefined && medias.length >= expectedCount)
+    return { medias, complete: true }
+
+  return { medias, complete: false }
+}
+
+/**
+ * 解析「播放全部」目标地址
+ * playFromLatest：仅在完整拉完全部稿件后，用末项起播（API 默认可视为正序，末项≈最新）
+ */
+export async function resolveFavoriteSeasonPlayAllUrl(target: FavoriteSeasonPlayTarget): Promise<string> {
+  const { seasonId, link, playFromLatest = false } = target
+
+  if (!playFromLatest)
+    return buildFavoriteSeasonEntryUrl(seasonId, link)
+
+  const { medias, complete } = await fetchAllFavoriteSeasonMedias(seasonId)
+  if (!complete)
+    return buildFavoriteSeasonEntryUrl(seasonId, link)
+
+  const latest = medias.at(-1)
+  if (!latest?.bvid)
+    return buildFavoriteSeasonEntryUrl(seasonId, link)
+
+  return buildFavoriteSeasonListPlayUrl(seasonId, latest.bvid, latest.id)
+}

--- a/src/utils/favoriteSeason.ts
+++ b/src/utils/favoriteSeason.ts
@@ -24,6 +24,8 @@ export type { CollectedSeasonPlayAllMode }
 export interface FavoriteSeasonPlayTarget {
   seasonId: number
   link?: string
+  /** beginning 模式入口补充（无 link 时用） */
+  bvid?: string
   mode?: CollectedSeasonPlayAllMode
   /**
    * UI 已通过同一套分页语义加载过的列表。
@@ -313,8 +315,8 @@ async function resolveSeasonMedias(
 export async function resolveFavoriteSeasonPlayAllUrl(
   target: FavoriteSeasonPlayTarget,
 ): Promise<FavoriteSeasonPlayAllResult> {
-  const { seasonId, link, mode = 'beginning', preloaded } = target
-  const entryUrl = buildFavoriteSeasonEntryUrl(seasonId, link)
+  const { seasonId, link, bvid, mode = 'beginning', preloaded } = target
+  const entryUrl = buildFavoriteSeasonEntryUrl(seasonId, link, bvid)
 
   if (mode === 'beginning') {
     return { url: entryUrl, usedFallback: false, reason: 'beginning' }

--- a/src/utils/favoriteSeason.ts
+++ b/src/utils/favoriteSeason.ts
@@ -32,27 +32,27 @@ interface FetchAllSeasonMediasResult {
 
 /**
  * 合集入口 URL（B 站默认「播放全部」行为）
- * 优先用 collected season 的 bilibili://video/{aid} link，否则回退 list/season
+ * 优先用 collected season 的 bilibili://video/{aid} link，否则用封面/入口 bvid
  */
-export function buildFavoriteSeasonEntryUrl(seasonId: number, link?: string): string {
-  const fallbackUrl = `https://www.bilibili.com/list/season/${seasonId}`
+export function buildFavoriteSeasonEntryUrl(seasonId: number, link?: string, bvid?: string): string {
   const matchedVideoLink = link?.match(/^bilibili:\/\/video\/(\d+)(\?.*)?$/)
 
-  if (!matchedVideoLink)
-    return fallbackUrl
+  if (matchedVideoLink)
+    return `https://www.bilibili.com/video/av${matchedVideoLink[1]}${matchedVideoLink[2] || ''}`
 
-  return `https://www.bilibili.com/video/av${matchedVideoLink[1]}${matchedVideoLink[2] || ''}`
+  if (bvid)
+    return `https://www.bilibili.com/video/${bvid}/`
+
+  // list/season/{id} 对 UGC 订阅合集常 404，仅作无 link/bvid 时的最后兜底
+  return `https://www.bilibili.com/list/season/${seasonId}`
 }
 
 /**
- * 在合集列表播放页打开指定稿件（保留侧栏连播上下文）
+ * 打开合集内指定稿件。
+ * 实测 /list/season/{id}?bvid= 对订阅合集会 404；普通 /video/{bvid} 可播且仍带合集侧栏。
  */
-export function buildFavoriteSeasonListPlayUrl(seasonId: number, bvid: string, oid?: number): string {
-  const url = new URL(`https://www.bilibili.com/list/season/${seasonId}`)
-  url.searchParams.set('bvid', bvid)
-  if (typeof oid === 'number' && Number.isFinite(oid) && oid > 0)
-    url.searchParams.set('oid', String(oid))
-  return url.toString()
+export function buildFavoriteSeasonListPlayUrl(_seasonId: number, bvid: string, _oid?: number): string {
+  return `https://www.bilibili.com/video/${bvid}/`
 }
 
 /**
@@ -93,6 +93,10 @@ export async function fetchAllFavoriteSeasonMedias(seasonId: number): Promise<Fe
     }
 
     medias.push(...pageMedias)
+
+    // 部分接口会无视 ps、一次返回全部；够数就停，避免重复翻页
+    if (expectedCount !== undefined && medias.length >= expectedCount)
+      return { medias: medias.slice(0, expectedCount), complete: true }
 
     if (pageMedias.length < SEASON_PAGE_SIZE) {
       if (expectedCount !== undefined && medias.length < expectedCount)
@@ -204,8 +208,7 @@ export async function resolveFavoriteSeasonPlayAllUrl(target: FavoriteSeasonPlay
     return buildFavoriteSeasonListPlayUrl(seasonId, latest.bvid, latest.id)
   }
 
-  // lastWatched：历史扫描不要求「必须完整」以外的额外条件，但上面已要求 complete，
-  // 避免用残缺合集集合误匹配到其它历史项之外的错觉；找不到则回退入口
+  // lastWatched：找不到则回退入口
   const lastWatched = await findLastWatchedSeasonMedia(medias)
   if (!lastWatched?.bvid)
     return entryUrl

--- a/src/utils/nativeFavoriteSeasonPlayAll.ts
+++ b/src/utils/nativeFavoriteSeasonPlayAll.ts
@@ -1,0 +1,147 @@
+/**
+ * 拦截 B 站原生空间页「订阅合集」的播放全部
+ * 例：https://space.bilibili.com/{mid}/favlist?fid={seasonId}&ftype=collect&ctype=21
+ */
+
+import { settings } from '~/logic'
+import { resolveFavoriteSeasonPlayAllUrl } from '~/utils/favoriteSeason'
+import { openLinkToNewTab } from '~/utils/main'
+
+const PLAY_ALL_TEXT = /播放全部/
+
+let interceptInstalled = false
+let isResolving = false
+
+export function isCollectedSeasonFavlistUrl(url: string = location.href): boolean {
+  try {
+    const parsed = new URL(url)
+    if (!/^space\.bilibili\.com$/i.test(parsed.hostname))
+      return false
+    if (!/\/favlist\/?$/i.test(parsed.pathname) && !/\/favlist/i.test(parsed.pathname))
+      return false
+    return parsed.searchParams.get('ftype') === 'collect'
+  }
+  catch {
+    return false
+  }
+}
+
+export function getSeasonIdFromFavlistUrl(url: string = location.href): number | null {
+  try {
+    const fid = new URL(url).searchParams.get('fid')
+    if (!fid)
+      return null
+    const seasonId = Number(fid)
+    return Number.isFinite(seasonId) && seasonId > 0 ? seasonId : null
+  }
+  catch {
+    return null
+  }
+}
+
+export function isNativeSeasonPlayAllTarget(el: Element): boolean {
+  if (el.closest('.favInfo-box .collection-details .collection-btn'))
+    return true
+
+  // 文本兜底：合集详情区内的「播放全部」
+  const inCollectionDetails = el.closest('.favInfo-box .collection-details')
+  if (!inCollectionDetails)
+    return false
+
+  const clickable = el.closest('a,button,[role="button"],.collection-btn')
+  if (!(clickable instanceof HTMLElement))
+    return false
+
+  return PLAY_ALL_TEXT.test(clickable.textContent || '')
+}
+
+function extractEntryFromClickTarget(el: Element): { link?: string, bvid?: string } {
+  const anchor = el.closest('a[href]')
+  if (anchor instanceof HTMLAnchorElement) {
+    const fromHref = extractVideoIdsFromHref(anchor.href)
+    if (fromHref.bvid || fromHref.link)
+      return fromHref
+  }
+
+  const firstCard = document.querySelector<HTMLAnchorElement>(
+    '#page-fav .fav-main a[href*="/video/"], .favInfo-box ~ * a[href*="/video/"], #page-fav a[href*="/video/"]',
+  )
+  if (firstCard)
+    return extractVideoIdsFromHref(firstCard.href)
+
+  return {}
+}
+
+function extractVideoIdsFromHref(href: string): { link?: string, bvid?: string } {
+  try {
+    const url = new URL(href, location.origin)
+    const bvidMatch = url.pathname.match(/\/video\/(BV[a-z0-9]+)/i)
+    if (bvidMatch)
+      return { bvid: bvidMatch[1] }
+
+    const avidMatch = url.pathname.match(/\/video\/av(\d+)/i)
+    if (avidMatch)
+      return { link: `bilibili://video/${avidMatch[1]}` }
+  }
+  catch {
+    // ignore
+  }
+  return {}
+}
+
+async function handleNativeSeasonPlayAll(event: MouseEvent) {
+  if (!isCollectedSeasonFavlistUrl())
+    return
+
+  const target = event.target
+  if (!(target instanceof Element))
+    return
+
+  if (!isNativeSeasonPlayAllTarget(target))
+    return
+
+  // 保留用户显式新标签手势给浏览器；仍走我们的解析
+  event.preventDefault()
+  event.stopPropagation()
+
+  if (isResolving)
+    return
+
+  const seasonId = getSeasonIdFromFavlistUrl()
+  if (!seasonId)
+    return
+
+  isResolving = true
+  try {
+    const entry = extractEntryFromClickTarget(target)
+    const result = await resolveFavoriteSeasonPlayAllUrl({
+      seasonId,
+      link: entry.link,
+      bvid: entry.bvid,
+      mode: settings.value.collectedSeasonPlayAllMode,
+    })
+
+    // SPA 可能已切走：打开前再确认仍是同一合集
+    if (getSeasonIdFromFavlistUrl() !== seasonId)
+      return
+
+    openLinkToNewTab(result.url)
+  }
+  finally {
+    isResolving = false
+  }
+}
+
+export function initNativeFavoriteSeasonPlayAllIntercept(): void {
+  if (interceptInstalled)
+    return
+  interceptInstalled = true
+  document.addEventListener('click', handleNativeSeasonPlayAll, true)
+}
+
+export function stopNativeFavoriteSeasonPlayAllIntercept(): void {
+  if (!interceptInstalled)
+    return
+  interceptInstalled = false
+  document.removeEventListener('click', handleNativeSeasonPlayAll, true)
+}

--- a/src/utils/nativeFavoriteSeasonPlayAll.ts
+++ b/src/utils/nativeFavoriteSeasonPlayAll.ts
@@ -40,15 +40,22 @@ export function getSeasonIdFromFavlistUrl(url: string = location.href): number |
 }
 
 export function isNativeSeasonPlayAllTarget(el: Element): boolean {
+  // 新版空间收藏：.favlist-info-detail__actions .playall-btn
+  if (el.closest('.favlist-info-detail__actions .playall-btn, button.playall-btn'))
+    return true
+
+  // 旧版：.collection-details .collection-btn
   if (el.closest('.favInfo-box .collection-details .collection-btn'))
     return true
 
   // 文本兜底：合集详情区内的「播放全部」
-  const inCollectionDetails = el.closest('.favInfo-box .collection-details')
-  if (!inCollectionDetails)
+  const inSeasonDetail = el.closest(
+    '.favlist-info-detail__actions, .favlist-info-detail, .favInfo-box .collection-details',
+  )
+  if (!inSeasonDetail)
     return false
 
-  const clickable = el.closest('a,button,[role="button"],.collection-btn')
+  const clickable = el.closest('a,button,[role="button"],.collection-btn,.playall-btn,.action-btn')
   if (!(clickable instanceof HTMLElement))
     return false
 
@@ -63,9 +70,15 @@ function extractEntryFromClickTarget(el: Element): { link?: string, bvid?: strin
       return fromHref
   }
 
-  const firstCard = document.querySelector<HTMLAnchorElement>(
-    '#page-fav .fav-main a[href*="/video/"], .favInfo-box ~ * a[href*="/video/"], #page-fav a[href*="/video/"]',
-  )
+  // 新按钮是 <button> 无 href；尽量从列表首卡取入口
+  const firstCard = document.querySelector<HTMLAnchorElement>([
+    '#page-fav .fav-main a[href*="/video/"]',
+    '.favlist-main a[href*="/video/"]',
+    '.favlist-content a[href*="/video/"]',
+    '.favInfo-box ~ * a[href*="/video/"]',
+    '#page-fav a[href*="/video/"]',
+    'a[href*="/video/BV"]',
+  ].join(', '))
   if (firstCard)
     return extractVideoIdsFromHref(firstCard.href)
 
@@ -100,8 +113,9 @@ async function handleNativeSeasonPlayAll(event: MouseEvent) {
   if (!isNativeSeasonPlayAllTarget(target))
     return
 
-  // 保留用户显式新标签手势给浏览器；仍走我们的解析
+  // 新 UI 是 button + 捕获阶段拦截，需 stopImmediatePropagation 阻止原生起播
   event.preventDefault()
+  event.stopImmediatePropagation()
   event.stopPropagation()
 
   if (isResolving)


### PR DESCRIPTION
Close #768

## Summary
- 为订阅合集「播放全部」增加三态起播设置：合集开头（默认）、最新一期、上次观看；覆盖扩展收藏页、顶栏收藏弹层，以及原生空间页 `favlist?ftype=collect`。
- 抽出统一合集数据层（`favoriteSeason`），修复最新一期回退、全量接口暴力翻页、顶栏误带入口 href、新版 `.playall-btn` 无法拦截等问题。
- 补全订阅合集卡片 UP 头像；精简相关设置多语言说明。

<img width="801" height="258" alt="截屏2026-07-23 下午5 05 03" src="https://github.com/user-attachments/assets/f873ab27-8ab1-4b56-baa4-538b2219f940" />
