### PR TITLE
fix: 修复多标签页顶栏重复请求

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -4,6 +4,7 @@ import { setupAppAuthScheduler } from './appAuthScheduler'
 import { setupContentScriptRecovery } from './contentScriptRecovery'
 import { setupApiMsgListeners } from './messageListeners/api'
 import { setupTabMsgListeners } from './messageListeners/tabs'
+import { setupTopBarStateBroker } from './topBarStateBroker'
 import { initWbiKeys } from './wbiSign'
 
 // Initialize extension and set up message handlers
@@ -52,5 +53,6 @@ if (process.env.FIREFOX) {
 // Setup all message listeners
 setupApiMsgListeners()
 setupTabMsgListeners()
+setupTopBarStateBroker()
 setupAppAuthScheduler()
 setupContentScriptRecovery()

--- a/src/background/topBarStateBroker.ts
+++ b/src/background/topBarStateBroker.ts
@@ -1,70 +1,263 @@
 import type Browser from 'webextension-polyfill'
+import browser from 'webextension-polyfill'
 
-import { TOP_BAR_STATE_MESSAGE } from '~/constants/topBarState'
+import { CONTENT_SCRIPT_MATCHES } from '~/constants/contentScript'
+import type {
+  TopBarRefreshClaim,
+  TopBarSharedState,
+  TopBarStatePublish,
+  TopBarStateRelease,
+} from '~/constants/topBarState'
+import {
+  TOP_BAR_STATE_MESSAGE,
+} from '~/constants/topBarState'
 import { onMessage } from '~/utils/messaging'
 
 interface TopBarStateEntry {
-  snapshot?: unknown
+  snapshot?: TopBarSharedState
   updatedAt: number
   refreshStartedAt: number
+  refreshId: number
+}
+
+export interface TopBarStateBrokerBrowser {
+  storage?: {
+    session?: Pick<Browser.Storage.StorageAreaWithUsage, 'get' | 'set'>
+  }
+  tabs: Pick<Browser.Tabs.Static, 'query' | 'sendMessage'>
+}
+
+export interface TopBarStateBroker {
+  claimRefresh: (
+    data: { maxAge: number },
+    sender?: Browser.Runtime.MessageSender,
+  ) => Promise<TopBarRefreshClaim>
+  publish: (
+    data: TopBarStatePublish,
+    sender?: Browser.Runtime.MessageSender,
+  ) => Promise<void>
+  releaseRefresh: (
+    data: TopBarStateRelease,
+    sender?: Browser.Runtime.MessageSender,
+  ) => Promise<void>
 }
 
 const REFRESH_LEASE_TIMEOUT = 30_000
-const stateByCookieStore = new Map<string, TopBarStateEntry>()
+const TOP_BAR_STATE_STORAGE_KEY = 'topBarStateBroker:v1'
+const TOP_BAR_STATE_STORAGE_VERSION = 1
 
-function getStateKey(sender?: Browser.Runtime.MessageSender) {
-  return sender?.tab?.cookieStoreId || 'default'
+interface PersistedTopBarState {
+  version: typeof TOP_BAR_STATE_STORAGE_VERSION
+  entries: Record<string, TopBarStateEntry>
 }
 
-function getEntry(sender?: Browser.Runtime.MessageSender) {
-  const key = getStateKey(sender)
-  let entry = stateByCookieStore.get(key)
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
 
-  if (!entry) {
-    entry = {
-      updatedAt: 0,
-      refreshStartedAt: 0,
-    }
-    stateByCookieStore.set(key, entry)
+function isTopBarSharedState(value: unknown): value is TopBarSharedState {
+  return isRecord(value)
+    && isRecord(value.unReadMessage)
+    && isRecord(value.unReadDm)
+    && typeof value.newMomentsCount === 'number'
+    && typeof value.watchLaterCount === 'number'
+}
+
+function isTopBarStateEntry(value: unknown): value is TopBarStateEntry {
+  return isRecord(value)
+    && typeof value.updatedAt === 'number'
+    && typeof value.refreshStartedAt === 'number'
+    && typeof value.refreshId === 'number'
+    && (value.snapshot === undefined || isTopBarSharedState(value.snapshot))
+}
+
+function isPersistedTopBarState(value: unknown): value is PersistedTopBarState {
+  return isRecord(value)
+    && value.version === TOP_BAR_STATE_STORAGE_VERSION
+    && isRecord(value.entries)
+    && Object.values(value.entries).every(isTopBarStateEntry)
+}
+
+function getStateKey(tab?: Browser.Tabs.Tab) {
+  const cookieStoreId = tab?.cookieStoreId || 'default'
+  const privacyContext = tab?.incognito ? 'private' : 'normal'
+  return `${privacyContext}:${cookieStoreId}`
+}
+
+export function createTopBarStateBroker(
+  extensionApi: TopBarStateBrokerBrowser = browser,
+): TopBarStateBroker {
+  const stateByCookieStore = new Map<string, TopBarStateEntry>()
+  const sessionStorage = extensionApi.storage?.session
+  let stateLoadPromise: Promise<void> | undefined
+  let operationQueue: Promise<void> = Promise.resolve()
+
+  function runExclusive<T>(operation: () => T | Promise<T>): Promise<T> {
+    const result = operationQueue.then(operation, operation)
+    operationQueue = result.then(() => undefined, () => undefined)
+    return result
   }
 
-  return entry
+  async function loadPersistedState(): Promise<void> {
+    if (!sessionStorage)
+      return
+
+    try {
+      const stored = await sessionStorage.get(TOP_BAR_STATE_STORAGE_KEY)
+      const persistedState = stored[TOP_BAR_STATE_STORAGE_KEY]
+
+      if (!isPersistedTopBarState(persistedState))
+        return
+
+      Object.entries(persistedState.entries).forEach(([key, entry]) => {
+        stateByCookieStore.set(key, entry)
+      })
+    }
+    catch {
+      // 不支持会话存储时继续使用当前后台进程内的状态
+    }
+  }
+
+  async function ensureStateLoaded(): Promise<void> {
+    stateLoadPromise ??= loadPersistedState()
+    await stateLoadPromise
+  }
+
+  async function persistState(): Promise<void> {
+    if (!sessionStorage)
+      return
+
+    const persistedState: PersistedTopBarState = {
+      version: TOP_BAR_STATE_STORAGE_VERSION,
+      entries: Object.fromEntries(stateByCookieStore),
+    }
+
+    try {
+      await sessionStorage.set({
+        [TOP_BAR_STATE_STORAGE_KEY]: persistedState,
+      })
+    }
+    catch {
+      // 写入失败不影响当前后台进程继续协调刷新
+    }
+  }
+
+  function getEntry(sender?: Browser.Runtime.MessageSender) {
+    const key = getStateKey(sender?.tab)
+    let entry = stateByCookieStore.get(key)
+
+    if (!entry) {
+      entry = {
+        updatedAt: 0,
+        refreshStartedAt: 0,
+        refreshId: 0,
+      }
+      stateByCookieStore.set(key, entry)
+    }
+
+    return entry
+  }
+
+  async function broadcastSnapshot(
+    snapshot: TopBarSharedState,
+    sender?: Browser.Runtime.MessageSender,
+  ): Promise<void> {
+    const stateKey = getStateKey(sender?.tab)
+    let tabs: Browser.Tabs.Tab[]
+
+    try {
+      tabs = await extensionApi.tabs.query({
+        url: [...CONTENT_SCRIPT_MATCHES],
+      })
+    }
+    catch {
+      return
+    }
+
+    await Promise.allSettled(
+      tabs
+        .filter(tab => tab.id !== undefined && getStateKey(tab) === stateKey)
+        .map(tab => extensionApi.tabs.sendMessage(tab.id!, {
+          type: TOP_BAR_STATE_MESSAGE.UPDATED,
+          data: { snapshot },
+        })),
+    )
+  }
+
+  return {
+    claimRefresh({ maxAge }, sender) {
+      return runExclusive(async () => {
+        await ensureStateLoaded()
+
+        const entry = getEntry(sender)
+        const now = Date.now()
+        const snapshotFresh = entry.snapshot !== undefined && now - entry.updatedAt < maxAge
+        const refreshInProgress = entry.refreshStartedAt > 0
+          && now - entry.refreshStartedAt < REFRESH_LEASE_TIMEOUT
+        const shouldRefresh = !snapshotFresh && !refreshInProgress
+
+        if (shouldRefresh) {
+          entry.refreshStartedAt = now
+          entry.refreshId += 1
+          await persistState()
+        }
+
+        return {
+          shouldRefresh,
+          snapshot: entry.snapshot,
+          ...(shouldRefresh ? { refreshId: entry.refreshId } : {}),
+        }
+      })
+    },
+
+    async publish({ snapshot, refreshId }, sender) {
+      const published = await runExclusive(async () => {
+        await ensureStateLoaded()
+
+        const entry = getEntry(sender)
+        if (entry.refreshId !== refreshId)
+          return false
+
+        entry.snapshot = snapshot
+        entry.updatedAt = Date.now()
+        entry.refreshStartedAt = 0
+        await persistState()
+        return true
+      })
+
+      if (published)
+        await broadcastSnapshot(snapshot, sender)
+    },
+
+    releaseRefresh({ refreshId }, sender) {
+      return runExclusive(async () => {
+        await ensureStateLoaded()
+        const entry = getEntry(sender)
+        if (entry.refreshId !== refreshId)
+          return
+
+        entry.refreshStartedAt = 0
+        await persistState()
+      })
+    },
+  }
 }
 
 export function setupTopBarStateBroker() {
+  const broker = createTopBarStateBroker()
+
   onMessage<{ maxAge: number }>(
     TOP_BAR_STATE_MESSAGE.CLAIM_REFRESH,
-    ({ maxAge }, sender) => {
-      const entry = getEntry(sender)
-      const now = Date.now()
-      const snapshotFresh = entry.snapshot !== undefined && now - entry.updatedAt < maxAge
-      const refreshInProgress = entry.refreshStartedAt > 0
-        && now - entry.refreshStartedAt < REFRESH_LEASE_TIMEOUT
-
-      if (!snapshotFresh && !refreshInProgress)
-        entry.refreshStartedAt = now
-
-      return {
-        shouldRefresh: !snapshotFresh && !refreshInProgress,
-        snapshot: entry.snapshot,
-      }
-    },
+    (data, sender) => broker.claimRefresh(data, sender),
   )
 
-  onMessage<{ snapshot: unknown }>(
+  onMessage<TopBarStatePublish>(
     TOP_BAR_STATE_MESSAGE.PUBLISH,
-    ({ snapshot }, sender) => {
-      const entry = getEntry(sender)
-      entry.snapshot = snapshot
-      entry.updatedAt = Date.now()
-      entry.refreshStartedAt = 0
-    },
+    (data, sender) => broker.publish(data, sender),
   )
 
-  onMessage(
+  onMessage<TopBarStateRelease>(
     TOP_BAR_STATE_MESSAGE.RELEASE_REFRESH,
-    (_, sender) => {
-      getEntry(sender).refreshStartedAt = 0
-    },
+    (data, sender) => broker.releaseRefresh(data, sender),
   )
 }

--- a/src/background/topBarStateBroker.ts
+++ b/src/background/topBarStateBroker.ts
@@ -5,6 +5,7 @@ import { CONTENT_SCRIPT_MATCHES } from '~/constants/contentScript'
 import type {
   TopBarRefreshClaim,
   TopBarSharedState,
+  TopBarStateClaim,
   TopBarStatePublish,
   TopBarStateRelease,
 } from '~/constants/topBarState'
@@ -29,7 +30,7 @@ export interface TopBarStateBrokerBrowser {
 
 export interface TopBarStateBroker {
   claimRefresh: (
-    data: { maxAge: number },
+    data: TopBarStateClaim,
     sender?: Browser.Runtime.MessageSender,
   ) => Promise<TopBarRefreshClaim>
   publish: (
@@ -43,8 +44,8 @@ export interface TopBarStateBroker {
 }
 
 const REFRESH_LEASE_TIMEOUT = 30_000
-const TOP_BAR_STATE_STORAGE_KEY = 'topBarStateBroker:v1'
-const TOP_BAR_STATE_STORAGE_VERSION = 1
+const TOP_BAR_STATE_STORAGE_KEY = 'topBarStateBroker:v2'
+const TOP_BAR_STATE_STORAGE_VERSION = 2
 
 interface PersistedTopBarState {
   version: typeof TOP_BAR_STATE_STORAGE_VERSION
@@ -61,6 +62,9 @@ function isTopBarSharedState(value: unknown): value is TopBarSharedState {
     && isRecord(value.unReadDm)
     && typeof value.newMomentsCount === 'number'
     && typeof value.watchLaterCount === 'number'
+    && typeof value.hasBCoinToReceive === 'boolean'
+    && typeof value.bCoinAlreadyReceived === 'boolean'
+    && typeof value.vipExpAlreadyReceived === 'boolean'
 }
 
 function isTopBarStateEntry(value: unknown): value is TopBarStateEntry {
@@ -78,7 +82,13 @@ function isPersistedTopBarState(value: unknown): value is PersistedTopBarState {
     && Object.values(value.entries).every(isTopBarStateEntry)
 }
 
-function getStateKey(tab?: Browser.Tabs.Tab) {
+function getStateKey(tab: Browser.Tabs.Tab | undefined, accountId: number) {
+  const cookieStoreId = tab?.cookieStoreId || 'default'
+  const privacyContext = tab?.incognito ? 'private' : 'normal'
+  return `${privacyContext}:${cookieStoreId}:${accountId}`
+}
+
+function getBrowserContextKey(tab?: Browser.Tabs.Tab) {
   const cookieStoreId = tab?.cookieStoreId || 'default'
   const privacyContext = tab?.incognito ? 'private' : 'normal'
   return `${privacyContext}:${cookieStoreId}`
@@ -142,8 +152,8 @@ export function createTopBarStateBroker(
     }
   }
 
-  function getEntry(sender?: Browser.Runtime.MessageSender) {
-    const key = getStateKey(sender?.tab)
+  function getEntry(accountId: number, sender?: Browser.Runtime.MessageSender) {
+    const key = getStateKey(sender?.tab, accountId)
     let entry = stateByCookieStore.get(key)
 
     if (!entry) {
@@ -159,10 +169,10 @@ export function createTopBarStateBroker(
   }
 
   async function broadcastSnapshot(
-    snapshot: TopBarSharedState,
+    data: TopBarStatePublish,
     sender?: Browser.Runtime.MessageSender,
   ): Promise<void> {
-    const stateKey = getStateKey(sender?.tab)
+    const browserContextKey = getBrowserContextKey(sender?.tab)
     let tabs: Browser.Tabs.Tab[]
 
     try {
@@ -176,20 +186,20 @@ export function createTopBarStateBroker(
 
     await Promise.allSettled(
       tabs
-        .filter(tab => tab.id !== undefined && getStateKey(tab) === stateKey)
+        .filter(tab => tab.id !== undefined && getBrowserContextKey(tab) === browserContextKey)
         .map(tab => extensionApi.tabs.sendMessage(tab.id!, {
           type: TOP_BAR_STATE_MESSAGE.UPDATED,
-          data: { snapshot },
+          data,
         })),
     )
   }
 
   return {
-    claimRefresh({ maxAge }, sender) {
+    claimRefresh({ accountId, maxAge }, sender) {
       return runExclusive(async () => {
         await ensureStateLoaded()
 
-        const entry = getEntry(sender)
+        const entry = getEntry(accountId, sender)
         const now = Date.now()
         const snapshotFresh = entry.snapshot !== undefined && now - entry.updatedAt < maxAge
         const refreshInProgress = entry.refreshStartedAt > 0
@@ -210,11 +220,12 @@ export function createTopBarStateBroker(
       })
     },
 
-    async publish({ snapshot, refreshId }, sender) {
+    async publish(data, sender) {
+      const { accountId, snapshot, refreshId } = data
       const published = await runExclusive(async () => {
         await ensureStateLoaded()
 
-        const entry = getEntry(sender)
+        const entry = getEntry(accountId, sender)
         if (entry.refreshId !== refreshId)
           return false
 
@@ -226,13 +237,13 @@ export function createTopBarStateBroker(
       })
 
       if (published)
-        await broadcastSnapshot(snapshot, sender)
+        await broadcastSnapshot(data, sender)
     },
 
-    releaseRefresh({ refreshId }, sender) {
+    releaseRefresh({ accountId, refreshId }, sender) {
       return runExclusive(async () => {
         await ensureStateLoaded()
-        const entry = getEntry(sender)
+        const entry = getEntry(accountId, sender)
         if (entry.refreshId !== refreshId)
           return
 
@@ -246,7 +257,7 @@ export function createTopBarStateBroker(
 export function setupTopBarStateBroker() {
   const broker = createTopBarStateBroker()
 
-  onMessage<{ maxAge: number }>(
+  onMessage<TopBarStateClaim>(
     TOP_BAR_STATE_MESSAGE.CLAIM_REFRESH,
     (data, sender) => broker.claimRefresh(data, sender),
   )

--- a/src/background/topBarStateBroker.ts
+++ b/src/background/topBarStateBroker.ts
@@ -1,0 +1,70 @@
+import type Browser from 'webextension-polyfill'
+
+import { TOP_BAR_STATE_MESSAGE } from '~/constants/topBarState'
+import { onMessage } from '~/utils/messaging'
+
+interface TopBarStateEntry {
+  snapshot?: unknown
+  updatedAt: number
+  refreshStartedAt: number
+}
+
+const REFRESH_LEASE_TIMEOUT = 30_000
+const stateByCookieStore = new Map<string, TopBarStateEntry>()
+
+function getStateKey(sender?: Browser.Runtime.MessageSender) {
+  return sender?.tab?.cookieStoreId || 'default'
+}
+
+function getEntry(sender?: Browser.Runtime.MessageSender) {
+  const key = getStateKey(sender)
+  let entry = stateByCookieStore.get(key)
+
+  if (!entry) {
+    entry = {
+      updatedAt: 0,
+      refreshStartedAt: 0,
+    }
+    stateByCookieStore.set(key, entry)
+  }
+
+  return entry
+}
+
+export function setupTopBarStateBroker() {
+  onMessage<{ maxAge: number }>(
+    TOP_BAR_STATE_MESSAGE.CLAIM_REFRESH,
+    ({ maxAge }, sender) => {
+      const entry = getEntry(sender)
+      const now = Date.now()
+      const snapshotFresh = entry.snapshot !== undefined && now - entry.updatedAt < maxAge
+      const refreshInProgress = entry.refreshStartedAt > 0
+        && now - entry.refreshStartedAt < REFRESH_LEASE_TIMEOUT
+
+      if (!snapshotFresh && !refreshInProgress)
+        entry.refreshStartedAt = now
+
+      return {
+        shouldRefresh: !snapshotFresh && !refreshInProgress,
+        snapshot: entry.snapshot,
+      }
+    },
+  )
+
+  onMessage<{ snapshot: unknown }>(
+    TOP_BAR_STATE_MESSAGE.PUBLISH,
+    ({ snapshot }, sender) => {
+      const entry = getEntry(sender)
+      entry.snapshot = snapshot
+      entry.updatedAt = Date.now()
+      entry.refreshStartedAt = 0
+    },
+  )
+
+  onMessage(
+    TOP_BAR_STATE_MESSAGE.RELEASE_REFRESH,
+    (_, sender) => {
+      getEntry(sender).refreshStartedAt = 0
+    },
+  )
+}

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -334,9 +334,14 @@ function handleClickOutsidePopup(event: MouseEvent) {
 
 // 生命周期钩子
 onMounted(() => {
-  nextTick(() => {
+  nextTick(async () => {
     // 初始化数据和更新定时器
-    topBarStore.initData()
+    try {
+      await topBarStore.initData()
+    }
+    catch (error) {
+      console.error('初始化顶栏数据失败:', error)
+    }
     // 只有在登录状态下才启动更新定时器
     if (topBarStore.isLogin)
       topBarStore.startUpdateTimer()

--- a/src/components/TopBar/components/TopBarRight.vue
+++ b/src/components/TopBar/components/TopBarRight.vue
@@ -36,7 +36,7 @@ const {
   hasBCoinToReceive,
 } = storeToRefs(topBarStore)
 
-const { getUnreadMessageCount, getTopBarNewMomentsCount, checkBCoinReceiveStatus } = topBarStore
+const { getUnreadMessageCount, getTopBarNewMomentsCount, syncSharedData } = topBarStore
 
 // 将 DOM 引用移到组件内部
 const avatarImg = ref<HTMLElement | null>(null)
@@ -121,9 +121,9 @@ if (isComponentVisible('notifications')) {
 const focused = useWindowFocus()
 watch(() => focused.value, (newVal, _) => {
   if (newVal && isLogin.value) {
-    getUnreadMessageCount()
-    getTopBarNewMomentsCount('video')
-    checkBCoinReceiveStatus()
+    syncSharedData().catch((error) => {
+      console.error('同步顶栏共享状态失败:', error)
+    })
   }
 })
 

--- a/src/constants/topBarState.ts
+++ b/src/constants/topBarState.ts
@@ -1,5 +1,30 @@
+import type { UnReadDm, UnReadMessage } from '~/components/TopBar/types'
+
+export interface TopBarSharedState {
+  unReadMessage: UnReadMessage
+  unReadDm: UnReadDm
+  newMomentsCount: number
+  watchLaterCount: number
+}
+
+export interface TopBarRefreshClaim {
+  shouldRefresh: boolean
+  snapshot?: TopBarSharedState
+  refreshId?: number
+}
+
+export interface TopBarStatePublish {
+  snapshot: TopBarSharedState
+  refreshId: number
+}
+
+export interface TopBarStateRelease {
+  refreshId: number
+}
+
 export const TOP_BAR_STATE_MESSAGE = {
   CLAIM_REFRESH: 'topBarState:claimRefresh',
   PUBLISH: 'topBarState:publish',
   RELEASE_REFRESH: 'topBarState:releaseRefresh',
+  UPDATED: 'topBarState:updated',
 } as const

--- a/src/constants/topBarState.ts
+++ b/src/constants/topBarState.ts
@@ -1,0 +1,5 @@
+export const TOP_BAR_STATE_MESSAGE = {
+  CLAIM_REFRESH: 'topBarState:claimRefresh',
+  PUBLISH: 'topBarState:publish',
+  RELEASE_REFRESH: 'topBarState:releaseRefresh',
+} as const

--- a/src/constants/topBarState.ts
+++ b/src/constants/topBarState.ts
@@ -5,6 +5,14 @@ export interface TopBarSharedState {
   unReadDm: UnReadDm
   newMomentsCount: number
   watchLaterCount: number
+  hasBCoinToReceive: boolean
+  bCoinAlreadyReceived: boolean
+  vipExpAlreadyReceived: boolean
+}
+
+export interface TopBarStateClaim {
+  accountId: number
+  maxAge: number
 }
 
 export interface TopBarRefreshClaim {
@@ -14,11 +22,13 @@ export interface TopBarRefreshClaim {
 }
 
 export interface TopBarStatePublish {
+  accountId: number
   snapshot: TopBarSharedState
   refreshId: number
 }
 
 export interface TopBarStateRelease {
+  accountId: number
   refreshId: number
 }
 

--- a/src/stores/topBarStore.ts
+++ b/src/stores/topBarStore.ts
@@ -15,31 +15,20 @@ import {
 } from '~/components/TopBar/constants/urls'
 import { updateInterval } from '~/components/TopBar/notify'
 import type { PrivilegeInfo, UnReadDm, UnReadMessage, UserInfo } from '~/components/TopBar/types'
-import { TOP_BAR_STATE_MESSAGE } from '~/constants/topBarState'
+import type {
+  TopBarRefreshClaim,
+  TopBarSharedState,
+  TopBarStatePublish,
+  TopBarStateRelease,
+} from '~/constants/topBarState'
+import {
+  TOP_BAR_STATE_MESSAGE,
+} from '~/constants/topBarState'
 import { settings } from '~/logic'
 import type { List as VideoItem } from '~/models/video/watchLater'
 import api from '~/utils/api'
 import { getCSRF, isHomePage } from '~/utils/main'
-import { sendMessage } from '~/utils/messaging'
-
-interface TopBarSharedState {
-  isLogin: boolean
-  userInfo: UserInfo
-  unReadMessage: UnReadMessage
-  unReadDm: UnReadDm
-  newMomentsCount: number
-  watchLaterCount: number
-  watchLaterList: VideoItem[]
-  privilegeInfo: PrivilegeInfo
-  hasBCoinToReceive: boolean
-  bCoinAlreadyReceived: boolean
-  vipExpAlreadyReceived: boolean
-}
-
-interface TopBarRefreshClaim {
-  shouldRefresh: boolean
-  snapshot?: TopBarSharedState
-}
+import { onMessage, sendMessage } from '~/utils/messaging'
 
 export const useTopBarStore = defineStore('topBar', () => {
   const toast = useToast()
@@ -198,10 +187,8 @@ export const useTopBarStore = defineStore('topBar', () => {
         // 其他错误码
         // 对于非未登录的错误，如果还有重试机会，则重试
         if (retryCount < maxRetries) {
-          setTimeout(() => {
-            getUserInfo(retryCount + 1)
-          }, retryDelay)
-          return
+          await new Promise(resolve => setTimeout(resolve, retryDelay))
+          return getUserInfo(retryCount + 1)
         }
 
         isLogin.value = false
@@ -213,10 +200,8 @@ export const useTopBarStore = defineStore('topBar', () => {
     catch {
       // 如果还有重试机会，则重试
       if (retryCount < maxRetries) {
-        setTimeout(() => {
-          getUserInfo(retryCount + 1)
-        }, retryDelay)
-        return
+        await new Promise(resolve => setTimeout(resolve, retryDelay))
+        return getUserInfo(retryCount + 1)
       }
 
       // 重试次数用尽，标记为未登录
@@ -390,7 +375,6 @@ export const useTopBarStore = defineStore('topBar', () => {
       })
       if (res.code === 0) {
         watchLaterCount.value = res.data.count
-        Object.assign(watchLaterList, res.data.list)
       }
     }
     catch (error) {
@@ -760,54 +744,40 @@ export const useTopBarStore = defineStore('topBar', () => {
   }
 
   let updateTimer: ReturnType<typeof setInterval> | null = null
-  let sharedStateRetryTimer: ReturnType<typeof setTimeout> | null = null
 
   function createSharedStateSnapshot(): TopBarSharedState {
     return {
-      isLogin: isLogin.value,
-      userInfo: { ...userInfo },
       unReadMessage: { ...unReadMessage },
       unReadDm: { ...unReadDm },
       newMomentsCount: newMomentsCount.value,
       watchLaterCount: watchLaterCount.value,
-      watchLaterList: [...watchLaterList],
-      privilegeInfo: { ...privilegeInfo },
-      hasBCoinToReceive: hasBCoinToReceive.value,
-      bCoinAlreadyReceived: bCoinAlreadyReceived.value,
-      vipExpAlreadyReceived: vipExpAlreadyReceived.value,
     }
   }
 
   function applySharedState(snapshot: TopBarSharedState) {
-    isLogin.value = snapshot.isLogin
-    Object.assign(userInfo, snapshot.userInfo)
     Object.assign(unReadMessage, snapshot.unReadMessage)
     Object.assign(unReadDm, snapshot.unReadDm)
     newMomentsCount.value = snapshot.newMomentsCount
     watchLaterCount.value = snapshot.watchLaterCount
-    watchLaterList.splice(0, watchLaterList.length, ...snapshot.watchLaterList)
-    Object.assign(privilegeInfo, snapshot.privilegeInfo)
-    hasBCoinToReceive.value = snapshot.hasBCoinToReceive
-    bCoinAlreadyReceived.value = snapshot.bCoinAlreadyReceived
-    vipExpAlreadyReceived.value = snapshot.vipExpAlreadyReceived
   }
 
-  async function refreshSharedData() {
-    await getUserInfo()
+  onMessage<TopBarStatePublish>(
+    TOP_BAR_STATE_MESSAGE.UPDATED,
+    ({ snapshot }) => applySharedState(snapshot),
+  )
 
-    // 只有在登录状态下才调用这些需要登录的API
-    if (isLogin.value) {
-      await Promise.all([
-        checkBCoinReceiveStatus(),
-        autoReceiveVipExp(),
-        getUnreadMessageCount(),
-        getTopBarNewMomentsCount(),
-        getAllWatchLaterList(),
-      ])
-    }
+  async function refreshSharedData() {
+    await Promise.all([
+      getUnreadMessageCount(),
+      getTopBarNewMomentsCount(),
+      getWatchLaterCount(),
+    ])
   }
 
   async function syncSharedData() {
+    if (!isLogin.value)
+      return
+
     const claim = await sendMessage<{ maxAge: number }, TopBarRefreshClaim>(
       TOP_BAR_STATE_MESSAGE.CLAIM_REFRESH,
       { maxAge: updateInterval },
@@ -816,34 +786,44 @@ export const useTopBarStore = defineStore('topBar', () => {
     if (claim.snapshot)
       applySharedState(claim.snapshot)
 
-    if (!claim.shouldRefresh) {
-      // 首次并发加载时等待负责刷新的标签页发布快照，避免其他标签页空白到下个周期
-      if (!claim.snapshot && !sharedStateRetryTimer) {
-        sharedStateRetryTimer = setTimeout(() => {
-          sharedStateRetryTimer = null
-          syncSharedData().catch((error) => {
-            console.error('重试同步顶栏共享状态失败:', error)
-          })
-        }, 1000)
-      }
+    if (!claim.shouldRefresh)
       return
-    }
+
+    if (claim.refreshId === undefined)
+      return
+
+    const refreshId = claim.refreshId
 
     try {
       await refreshSharedData()
-      await sendMessage(
+      await sendMessage<TopBarStatePublish>(
         TOP_BAR_STATE_MESSAGE.PUBLISH,
-        { snapshot: createSharedStateSnapshot() },
+        {
+          snapshot: createSharedStateSnapshot(),
+          refreshId,
+        },
       )
     }
     catch (error) {
-      await sendMessage(TOP_BAR_STATE_MESSAGE.RELEASE_REFRESH)
+      await sendMessage<TopBarStateRelease>(
+        TOP_BAR_STATE_MESSAGE.RELEASE_REFRESH,
+        { refreshId },
+      )
       throw error
     }
   }
 
   async function initData() {
-    await syncSharedData()
+    await getUserInfo()
+
+    if (!isLogin.value)
+      return
+
+    await Promise.all([
+      checkBCoinReceiveStatus(),
+      autoReceiveVipExp(),
+      syncSharedData(),
+    ])
   }
 
   function startUpdateTimer() {
@@ -852,7 +832,14 @@ export const useTopBarStore = defineStore('topBar', () => {
       updateTimer = null
     }
     updateTimer = setInterval(() => {
-      syncSharedData().catch((error) => {
+      if (!isLogin.value)
+        return
+
+      Promise.all([
+        checkBCoinReceiveStatus(),
+        autoReceiveVipExp(),
+        syncSharedData(),
+      ]).catch((error) => {
         console.error('同步顶栏共享状态失败:', error)
       })
     }, updateInterval)
@@ -866,10 +853,6 @@ export const useTopBarStore = defineStore('topBar', () => {
 
   function cleanup() {
     stopUpdateTimer()
-    if (sharedStateRetryTimer) {
-      clearTimeout(sharedStateRetryTimer)
-      sharedStateRetryTimer = null
-    }
 
     Object.keys(unReadMessage).forEach((key) => {
       unReadMessage[key as keyof UnReadMessage] = 0

--- a/src/stores/topBarStore.ts
+++ b/src/stores/topBarStore.ts
@@ -15,10 +15,31 @@ import {
 } from '~/components/TopBar/constants/urls'
 import { updateInterval } from '~/components/TopBar/notify'
 import type { PrivilegeInfo, UnReadDm, UnReadMessage, UserInfo } from '~/components/TopBar/types'
+import { TOP_BAR_STATE_MESSAGE } from '~/constants/topBarState'
 import { settings } from '~/logic'
 import type { List as VideoItem } from '~/models/video/watchLater'
 import api from '~/utils/api'
 import { getCSRF, isHomePage } from '~/utils/main'
+import { sendMessage } from '~/utils/messaging'
+
+interface TopBarSharedState {
+  isLogin: boolean
+  userInfo: UserInfo
+  unReadMessage: UnReadMessage
+  unReadDm: UnReadDm
+  newMomentsCount: number
+  watchLaterCount: number
+  watchLaterList: VideoItem[]
+  privilegeInfo: PrivilegeInfo
+  hasBCoinToReceive: boolean
+  bCoinAlreadyReceived: boolean
+  vipExpAlreadyReceived: boolean
+}
+
+interface TopBarRefreshClaim {
+  shouldRefresh: boolean
+  snapshot?: TopBarSharedState
+}
 
 export const useTopBarStore = defineStore('topBar', () => {
   const toast = useToast()
@@ -739,18 +760,90 @@ export const useTopBarStore = defineStore('topBar', () => {
   }
 
   let updateTimer: ReturnType<typeof setInterval> | null = null
+  let sharedStateRetryTimer: ReturnType<typeof setTimeout> | null = null
 
-  async function initData() {
+  function createSharedStateSnapshot(): TopBarSharedState {
+    return {
+      isLogin: isLogin.value,
+      userInfo: { ...userInfo },
+      unReadMessage: { ...unReadMessage },
+      unReadDm: { ...unReadDm },
+      newMomentsCount: newMomentsCount.value,
+      watchLaterCount: watchLaterCount.value,
+      watchLaterList: [...watchLaterList],
+      privilegeInfo: { ...privilegeInfo },
+      hasBCoinToReceive: hasBCoinToReceive.value,
+      bCoinAlreadyReceived: bCoinAlreadyReceived.value,
+      vipExpAlreadyReceived: vipExpAlreadyReceived.value,
+    }
+  }
+
+  function applySharedState(snapshot: TopBarSharedState) {
+    isLogin.value = snapshot.isLogin
+    Object.assign(userInfo, snapshot.userInfo)
+    Object.assign(unReadMessage, snapshot.unReadMessage)
+    Object.assign(unReadDm, snapshot.unReadDm)
+    newMomentsCount.value = snapshot.newMomentsCount
+    watchLaterCount.value = snapshot.watchLaterCount
+    watchLaterList.splice(0, watchLaterList.length, ...snapshot.watchLaterList)
+    Object.assign(privilegeInfo, snapshot.privilegeInfo)
+    hasBCoinToReceive.value = snapshot.hasBCoinToReceive
+    bCoinAlreadyReceived.value = snapshot.bCoinAlreadyReceived
+    vipExpAlreadyReceived.value = snapshot.vipExpAlreadyReceived
+  }
+
+  async function refreshSharedData() {
     await getUserInfo()
 
     // 只有在登录状态下才调用这些需要登录的API
     if (isLogin.value) {
-      checkBCoinReceiveStatus()
-      autoReceiveVipExp()
-      getUnreadMessageCount()
-      getTopBarNewMomentsCount()
-      getAllWatchLaterList()
+      await Promise.all([
+        checkBCoinReceiveStatus(),
+        autoReceiveVipExp(),
+        getUnreadMessageCount(),
+        getTopBarNewMomentsCount(),
+        getAllWatchLaterList(),
+      ])
     }
+  }
+
+  async function syncSharedData() {
+    const claim = await sendMessage<{ maxAge: number }, TopBarRefreshClaim>(
+      TOP_BAR_STATE_MESSAGE.CLAIM_REFRESH,
+      { maxAge: updateInterval },
+    )
+
+    if (claim.snapshot)
+      applySharedState(claim.snapshot)
+
+    if (!claim.shouldRefresh) {
+      // 首次并发加载时等待负责刷新的标签页发布快照，避免其他标签页空白到下个周期
+      if (!claim.snapshot && !sharedStateRetryTimer) {
+        sharedStateRetryTimer = setTimeout(() => {
+          sharedStateRetryTimer = null
+          syncSharedData().catch((error) => {
+            console.error('重试同步顶栏共享状态失败:', error)
+          })
+        }, 1000)
+      }
+      return
+    }
+
+    try {
+      await refreshSharedData()
+      await sendMessage(
+        TOP_BAR_STATE_MESSAGE.PUBLISH,
+        { snapshot: createSharedStateSnapshot() },
+      )
+    }
+    catch (error) {
+      await sendMessage(TOP_BAR_STATE_MESSAGE.RELEASE_REFRESH)
+      throw error
+    }
+  }
+
+  async function initData() {
+    await syncSharedData()
   }
 
   function startUpdateTimer() {
@@ -759,16 +852,9 @@ export const useTopBarStore = defineStore('topBar', () => {
       updateTimer = null
     }
     updateTimer = setInterval(() => {
-      if (isLogin.value) {
-        getUnreadMessageCount()
-        // 只有在弹窗未显示时才更新计数，避免与 watch 重复调用
-        if (!popupVisible.moments)
-          getTopBarNewMomentsCount()
-        if (!popupVisible.watchLater)
-          getWatchLaterCount()
-        checkBCoinReceiveStatus()
-        autoReceiveVipExp()
-      }
+      syncSharedData().catch((error) => {
+        console.error('同步顶栏共享状态失败:', error)
+      })
     }, updateInterval)
   }
   function stopUpdateTimer() {
@@ -780,6 +866,10 @@ export const useTopBarStore = defineStore('topBar', () => {
 
   function cleanup() {
     stopUpdateTimer()
+    if (sharedStateRetryTimer) {
+      clearTimeout(sharedStateRetryTimer)
+      sharedStateRetryTimer = null
+    }
 
     Object.keys(unReadMessage).forEach((key) => {
       unReadMessage[key as keyof UnReadMessage] = 0

--- a/src/stores/topBarStore.ts
+++ b/src/stores/topBarStore.ts
@@ -18,6 +18,7 @@ import type { PrivilegeInfo, UnReadDm, UnReadMessage, UserInfo } from '~/compone
 import type {
   TopBarRefreshClaim,
   TopBarSharedState,
+  TopBarStateClaim,
   TopBarStatePublish,
   TopBarStateRelease,
 } from '~/constants/topBarState'
@@ -751,6 +752,9 @@ export const useTopBarStore = defineStore('topBar', () => {
       unReadDm: { ...unReadDm },
       newMomentsCount: newMomentsCount.value,
       watchLaterCount: watchLaterCount.value,
+      hasBCoinToReceive: hasBCoinToReceive.value,
+      bCoinAlreadyReceived: bCoinAlreadyReceived.value,
+      vipExpAlreadyReceived: vipExpAlreadyReceived.value,
     }
   }
 
@@ -759,11 +763,17 @@ export const useTopBarStore = defineStore('topBar', () => {
     Object.assign(unReadDm, snapshot.unReadDm)
     newMomentsCount.value = snapshot.newMomentsCount
     watchLaterCount.value = snapshot.watchLaterCount
+    hasBCoinToReceive.value = snapshot.hasBCoinToReceive
+    bCoinAlreadyReceived.value = snapshot.bCoinAlreadyReceived
+    vipExpAlreadyReceived.value = snapshot.vipExpAlreadyReceived
   }
 
   onMessage<TopBarStatePublish>(
     TOP_BAR_STATE_MESSAGE.UPDATED,
-    ({ snapshot }) => applySharedState(snapshot),
+    ({ accountId, snapshot }) => {
+      if (accountId === userInfo.mid)
+        applySharedState(snapshot)
+    },
   )
 
   async function refreshSharedData() {
@@ -771,6 +781,8 @@ export const useTopBarStore = defineStore('topBar', () => {
       getUnreadMessageCount(),
       getTopBarNewMomentsCount(),
       getWatchLaterCount(),
+      checkBCoinReceiveStatus(),
+      autoReceiveVipExp(),
     ])
   }
 
@@ -778,9 +790,16 @@ export const useTopBarStore = defineStore('topBar', () => {
     if (!isLogin.value)
       return
 
-    const claim = await sendMessage<{ maxAge: number }, TopBarRefreshClaim>(
+    const accountId = userInfo.mid
+    if (!accountId)
+      return
+
+    const claim = await sendMessage<TopBarStateClaim, TopBarRefreshClaim>(
       TOP_BAR_STATE_MESSAGE.CLAIM_REFRESH,
-      { maxAge: updateInterval },
+      {
+        accountId,
+        maxAge: updateInterval,
+      },
     )
 
     if (claim.snapshot)
@@ -799,6 +818,7 @@ export const useTopBarStore = defineStore('topBar', () => {
       await sendMessage<TopBarStatePublish>(
         TOP_BAR_STATE_MESSAGE.PUBLISH,
         {
+          accountId,
           snapshot: createSharedStateSnapshot(),
           refreshId,
         },
@@ -807,7 +827,10 @@ export const useTopBarStore = defineStore('topBar', () => {
     catch (error) {
       await sendMessage<TopBarStateRelease>(
         TOP_BAR_STATE_MESSAGE.RELEASE_REFRESH,
-        { refreshId },
+        {
+          accountId,
+          refreshId,
+        },
       )
       throw error
     }
@@ -819,11 +842,7 @@ export const useTopBarStore = defineStore('topBar', () => {
     if (!isLogin.value)
       return
 
-    await Promise.all([
-      checkBCoinReceiveStatus(),
-      autoReceiveVipExp(),
-      syncSharedData(),
-    ])
+    await syncSharedData()
   }
 
   function startUpdateTimer() {
@@ -835,11 +854,7 @@ export const useTopBarStore = defineStore('topBar', () => {
       if (!isLogin.value)
         return
 
-      Promise.all([
-        checkBCoinReceiveStatus(),
-        autoReceiveVipExp(),
-        syncSharedData(),
-      ]).catch((error) => {
+      syncSharedData().catch((error) => {
         console.error('同步顶栏共享状态失败:', error)
       })
     }, updateInterval)
@@ -921,11 +936,9 @@ export const useTopBarStore = defineStore('topBar', () => {
     isMouseOverPopup,
     setMouseOverPopup,
     getMouseOverPopup,
+    syncSharedData,
     startUpdateTimer,
     stopUpdateTimer,
-    checkBCoinReceiveStatus,
-    autoReceiveBCoin,
-    autoReceiveVipExp,
 
     moments,
     addedWatchLaterList,

--- a/src/tests/topBarStateBroker.spec.ts
+++ b/src/tests/topBarStateBroker.spec.ts
@@ -1,0 +1,324 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type Browser from 'webextension-polyfill'
+
+import type { TopBarStateBrokerBrowser } from '~/background/topBarStateBroker'
+import {
+  createTopBarStateBroker,
+} from '~/background/topBarStateBroker'
+import type { TopBarSharedState } from '~/constants/topBarState'
+import { TOP_BAR_STATE_MESSAGE } from '~/constants/topBarState'
+
+vi.mock('webextension-polyfill', () => ({
+  default: {
+    runtime: {
+      onMessage: {
+        addListener: vi.fn(),
+      },
+    },
+    tabs: {},
+  },
+}))
+
+const MAX_AGE = 5 * 60 * 1000
+
+function createSnapshot(seed: number): TopBarSharedState {
+  return {
+    unReadMessage: {
+      at: seed,
+      chat: seed,
+      like: seed,
+      reply: seed,
+      sys_msg: seed,
+      up: seed,
+    },
+    unReadDm: {
+      unfollow_unread: seed,
+      follow_unread: seed,
+      unfollow_push_msg: seed,
+      dustbin_push_msg: seed,
+      dustbin_unread: seed,
+      biz_msg_unfollow_unread: seed,
+      biz_msg_follow_unread: seed,
+    },
+    newMomentsCount: seed,
+    watchLaterCount: seed,
+  }
+}
+
+function createSender(
+  id: number,
+  cookieStoreId?: string,
+  incognito = false,
+): Browser.Runtime.MessageSender {
+  return {
+    tab: {
+      id,
+      cookieStoreId,
+      incognito,
+    },
+  } as Browser.Runtime.MessageSender
+}
+
+function cloneStoredValue<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
+function createSessionStorage() {
+  const values: Record<string, unknown> = {}
+
+  return {
+    get: vi.fn(async (key: null | string | string[] | Record<string, unknown> = null) => {
+      if (typeof key === 'string' && key in values)
+        return { [key]: cloneStoredValue(values[key]) }
+
+      return {}
+    }),
+    set: vi.fn(async (items: Record<string, unknown>) => {
+      Object.assign(values, cloneStoredValue(items))
+    }),
+  }
+}
+
+function createExtensionApi(session = createSessionStorage()) {
+  const tabs = {
+    query: vi.fn(),
+    sendMessage: vi.fn(),
+  }
+
+  return {
+    extensionApi: {
+      storage: { session },
+      tabs,
+    } as unknown as TopBarStateBrokerBrowser,
+    session,
+    tabs,
+  }
+}
+
+describe('顶栏共享状态协调器', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-23T12:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('并发申请时只允许一个标签页成为刷新者', async () => {
+    const { extensionApi } = createExtensionApi()
+    const broker = createTopBarStateBroker(extensionApi)
+
+    const [firstClaim, secondClaim] = await Promise.all([
+      broker.claimRefresh({ maxAge: MAX_AGE }, createSender(1)),
+      broker.claimRefresh({ maxAge: MAX_AGE }, createSender(2)),
+    ])
+
+    expect(firstClaim).toEqual({
+      shouldRefresh: true,
+      snapshot: undefined,
+      refreshId: 1,
+    })
+    expect(secondClaim).toEqual({
+      shouldRefresh: false,
+      snapshot: undefined,
+    })
+  })
+
+  it('发布后立即广播给同一容器和隐私上下文的标签页', async () => {
+    const { extensionApi, tabs } = createExtensionApi()
+    const broker = createTopBarStateBroker(extensionApi)
+    const snapshot = createSnapshot(3)
+    tabs.query.mockResolvedValue([
+      { id: 1, incognito: false },
+      { id: 2, incognito: false },
+      { id: 3, cookieStoreId: 'firefox-container-2', incognito: false },
+      { id: 4, incognito: true },
+    ])
+    tabs.sendMessage.mockResolvedValue(undefined)
+
+    const claim = await broker.claimRefresh({ maxAge: MAX_AGE }, createSender(1))
+    await broker.publish({
+      snapshot,
+      refreshId: claim.refreshId!,
+    }, createSender(1))
+
+    expect(tabs.sendMessage).toHaveBeenCalledTimes(2)
+    expect(tabs.sendMessage).toHaveBeenNthCalledWith(1, 1, {
+      type: TOP_BAR_STATE_MESSAGE.UPDATED,
+      data: { snapshot },
+    })
+    expect(tabs.sendMessage).toHaveBeenNthCalledWith(2, 2, {
+      type: TOP_BAR_STATE_MESSAGE.UPDATED,
+      data: { snapshot },
+    })
+    await expect(broker.claimRefresh({ maxAge: MAX_AGE }, createSender(2))).resolves.toEqual({
+      shouldRefresh: false,
+      snapshot,
+    })
+  })
+
+  it('旧快照刷新期间仍返回旧值并通过新广播完成追平', async () => {
+    const { extensionApi, tabs } = createExtensionApi()
+    const broker = createTopBarStateBroker(extensionApi)
+    const oldSnapshot = createSnapshot(1)
+    const newSnapshot = createSnapshot(2)
+    tabs.query.mockResolvedValue([
+      { id: 1, incognito: false },
+      { id: 2, incognito: false },
+    ])
+    tabs.sendMessage.mockResolvedValue(undefined)
+
+    const initialClaim = await broker.claimRefresh({ maxAge: MAX_AGE }, createSender(1))
+    await broker.publish({
+      snapshot: oldSnapshot,
+      refreshId: initialClaim.refreshId!,
+    }, createSender(1))
+    vi.advanceTimersByTime(MAX_AGE + 1)
+
+    const refreshClaim = await broker.claimRefresh({ maxAge: MAX_AGE }, createSender(1))
+    expect(refreshClaim).toEqual({
+      shouldRefresh: true,
+      snapshot: oldSnapshot,
+      refreshId: 2,
+    })
+    await expect(broker.claimRefresh({ maxAge: MAX_AGE }, createSender(2))).resolves.toEqual({
+      shouldRefresh: false,
+      snapshot: oldSnapshot,
+    })
+
+    tabs.sendMessage.mockClear()
+    await broker.publish({
+      snapshot: newSnapshot,
+      refreshId: refreshClaim.refreshId!,
+    }, createSender(1))
+
+    expect(tabs.sendMessage).toHaveBeenCalledTimes(2)
+    expect(tabs.sendMessage).toHaveBeenCalledWith(2, {
+      type: TOP_BAR_STATE_MESSAGE.UPDATED,
+      data: { snapshot: newSnapshot },
+    })
+  })
+
+  it('不同 Firefox 容器可以各自获取刷新权', async () => {
+    const { extensionApi } = createExtensionApi()
+    const broker = createTopBarStateBroker(extensionApi)
+
+    await expect(broker.claimRefresh(
+      { maxAge: MAX_AGE },
+      createSender(1, 'firefox-container-1'),
+    )).resolves.toMatchObject({ shouldRefresh: true })
+    await expect(broker.claimRefresh(
+      { maxAge: MAX_AGE },
+      createSender(2, 'firefox-container-2'),
+    )).resolves.toMatchObject({ shouldRefresh: true })
+  })
+
+  it('后台重建后从会话存储恢复新鲜快照', async () => {
+    const session = createSessionStorage()
+    const firstExtension = createExtensionApi(session)
+    const snapshot = createSnapshot(6)
+    firstExtension.tabs.query.mockResolvedValue([])
+
+    const firstBroker = createTopBarStateBroker(firstExtension.extensionApi)
+    const claim = await firstBroker.claimRefresh({ maxAge: MAX_AGE }, createSender(1))
+    await firstBroker.publish({
+      snapshot,
+      refreshId: claim.refreshId!,
+    }, createSender(1))
+
+    const rebuiltExtension = createExtensionApi(session)
+    const rebuiltBroker = createTopBarStateBroker(rebuiltExtension.extensionApi)
+
+    await expect(
+      rebuiltBroker.claimRefresh({ maxAge: MAX_AGE }, createSender(2)),
+    ).resolves.toEqual({
+      shouldRefresh: false,
+      snapshot,
+    })
+  })
+
+  it('后台重建后保留刷新租约并在超时后允许接管', async () => {
+    const session = createSessionStorage()
+    const firstExtension = createExtensionApi(session)
+    const firstBroker = createTopBarStateBroker(firstExtension.extensionApi)
+
+    const firstClaim = await firstBroker.claimRefresh(
+      { maxAge: MAX_AGE },
+      createSender(1),
+    )
+    expect(firstClaim).toMatchObject({
+      shouldRefresh: true,
+      refreshId: 1,
+    })
+
+    const rebuiltExtension = createExtensionApi(session)
+    const rebuiltBroker = createTopBarStateBroker(rebuiltExtension.extensionApi)
+
+    await expect(
+      rebuiltBroker.claimRefresh({ maxAge: MAX_AGE }, createSender(2)),
+    ).resolves.toMatchObject({ shouldRefresh: false })
+
+    vi.advanceTimersByTime(30_001)
+
+    const takeoverClaim = await rebuiltBroker.claimRefresh(
+      { maxAge: MAX_AGE },
+      createSender(2),
+    )
+    expect(takeoverClaim).toMatchObject({
+      shouldRefresh: true,
+      refreshId: 2,
+    })
+
+    const staleSnapshot = createSnapshot(9)
+    await rebuiltBroker.publish({
+      snapshot: staleSnapshot,
+      refreshId: firstClaim.refreshId!,
+    }, createSender(1))
+
+    await expect(
+      rebuiltBroker.claimRefresh({ maxAge: MAX_AGE }, createSender(3)),
+    ).resolves.toEqual({
+      shouldRefresh: false,
+      snapshot: undefined,
+    })
+
+    rebuiltExtension.tabs.query.mockResolvedValue([])
+    const currentSnapshot = createSnapshot(10)
+    await rebuiltBroker.publish({
+      snapshot: currentSnapshot,
+      refreshId: takeoverClaim.refreshId!,
+    }, createSender(2))
+
+    await expect(
+      rebuiltBroker.claimRefresh({ maxAge: MAX_AGE }, createSender(3)),
+    ).resolves.toEqual({
+      shouldRefresh: false,
+      snapshot: currentSnapshot,
+    })
+  })
+
+  it('浏览器不支持会话存储时退回后台内存状态', async () => {
+    const tabs = {
+      query: vi.fn().mockResolvedValue([]),
+      sendMessage: vi.fn(),
+    }
+    const broker = createTopBarStateBroker({
+      tabs,
+    } as unknown as TopBarStateBrokerBrowser)
+    const snapshot = createSnapshot(8)
+
+    const claim = await broker.claimRefresh({ maxAge: MAX_AGE }, createSender(1))
+    await broker.publish({
+      snapshot,
+      refreshId: claim.refreshId!,
+    }, createSender(1))
+
+    await expect(
+      broker.claimRefresh({ maxAge: MAX_AGE }, createSender(2)),
+    ).resolves.toEqual({
+      shouldRefresh: false,
+      snapshot,
+    })
+  })
+})

--- a/src/tests/topBarStateBroker.spec.ts
+++ b/src/tests/topBarStateBroker.spec.ts
@@ -20,6 +20,7 @@ vi.mock('webextension-polyfill', () => ({
 }))
 
 const MAX_AGE = 5 * 60 * 1000
+const ACCOUNT_ID = 100
 
 function createSnapshot(seed: number): TopBarSharedState {
   return {
@@ -42,6 +43,16 @@ function createSnapshot(seed: number): TopBarSharedState {
     },
     newMomentsCount: seed,
     watchLaterCount: seed,
+    hasBCoinToReceive: seed % 2 === 1,
+    bCoinAlreadyReceived: seed % 3 === 0,
+    vipExpAlreadyReceived: seed % 2 === 0,
+  }
+}
+
+function createClaimData(accountId = ACCOUNT_ID) {
+  return {
+    accountId,
+    maxAge: MAX_AGE,
   }
 }
 
@@ -110,8 +121,8 @@ describe('顶栏共享状态协调器', () => {
     const broker = createTopBarStateBroker(extensionApi)
 
     const [firstClaim, secondClaim] = await Promise.all([
-      broker.claimRefresh({ maxAge: MAX_AGE }, createSender(1)),
-      broker.claimRefresh({ maxAge: MAX_AGE }, createSender(2)),
+      broker.claimRefresh(createClaimData(), createSender(1)),
+      broker.claimRefresh(createClaimData(), createSender(2)),
     ])
 
     expect(firstClaim).toEqual({
@@ -137,8 +148,9 @@ describe('顶栏共享状态协调器', () => {
     ])
     tabs.sendMessage.mockResolvedValue(undefined)
 
-    const claim = await broker.claimRefresh({ maxAge: MAX_AGE }, createSender(1))
+    const claim = await broker.claimRefresh(createClaimData(), createSender(1))
     await broker.publish({
+      accountId: ACCOUNT_ID,
       snapshot,
       refreshId: claim.refreshId!,
     }, createSender(1))
@@ -146,13 +158,21 @@ describe('顶栏共享状态协调器', () => {
     expect(tabs.sendMessage).toHaveBeenCalledTimes(2)
     expect(tabs.sendMessage).toHaveBeenNthCalledWith(1, 1, {
       type: TOP_BAR_STATE_MESSAGE.UPDATED,
-      data: { snapshot },
+      data: {
+        accountId: ACCOUNT_ID,
+        snapshot,
+        refreshId: claim.refreshId,
+      },
     })
     expect(tabs.sendMessage).toHaveBeenNthCalledWith(2, 2, {
       type: TOP_BAR_STATE_MESSAGE.UPDATED,
-      data: { snapshot },
+      data: {
+        accountId: ACCOUNT_ID,
+        snapshot,
+        refreshId: claim.refreshId,
+      },
     })
-    await expect(broker.claimRefresh({ maxAge: MAX_AGE }, createSender(2))).resolves.toEqual({
+    await expect(broker.claimRefresh(createClaimData(), createSender(2))).resolves.toEqual({
       shouldRefresh: false,
       snapshot,
     })
@@ -169,26 +189,28 @@ describe('顶栏共享状态协调器', () => {
     ])
     tabs.sendMessage.mockResolvedValue(undefined)
 
-    const initialClaim = await broker.claimRefresh({ maxAge: MAX_AGE }, createSender(1))
+    const initialClaim = await broker.claimRefresh(createClaimData(), createSender(1))
     await broker.publish({
+      accountId: ACCOUNT_ID,
       snapshot: oldSnapshot,
       refreshId: initialClaim.refreshId!,
     }, createSender(1))
     vi.advanceTimersByTime(MAX_AGE + 1)
 
-    const refreshClaim = await broker.claimRefresh({ maxAge: MAX_AGE }, createSender(1))
+    const refreshClaim = await broker.claimRefresh(createClaimData(), createSender(1))
     expect(refreshClaim).toEqual({
       shouldRefresh: true,
       snapshot: oldSnapshot,
       refreshId: 2,
     })
-    await expect(broker.claimRefresh({ maxAge: MAX_AGE }, createSender(2))).resolves.toEqual({
+    await expect(broker.claimRefresh(createClaimData(), createSender(2))).resolves.toEqual({
       shouldRefresh: false,
       snapshot: oldSnapshot,
     })
 
     tabs.sendMessage.mockClear()
     await broker.publish({
+      accountId: ACCOUNT_ID,
       snapshot: newSnapshot,
       refreshId: refreshClaim.refreshId!,
     }, createSender(1))
@@ -196,7 +218,11 @@ describe('顶栏共享状态协调器', () => {
     expect(tabs.sendMessage).toHaveBeenCalledTimes(2)
     expect(tabs.sendMessage).toHaveBeenCalledWith(2, {
       type: TOP_BAR_STATE_MESSAGE.UPDATED,
-      data: { snapshot: newSnapshot },
+      data: {
+        accountId: ACCOUNT_ID,
+        snapshot: newSnapshot,
+        refreshId: refreshClaim.refreshId,
+      },
     })
   })
 
@@ -205,13 +231,38 @@ describe('顶栏共享状态协调器', () => {
     const broker = createTopBarStateBroker(extensionApi)
 
     await expect(broker.claimRefresh(
-      { maxAge: MAX_AGE },
+      createClaimData(),
       createSender(1, 'firefox-container-1'),
     )).resolves.toMatchObject({ shouldRefresh: true })
     await expect(broker.claimRefresh(
-      { maxAge: MAX_AGE },
+      createClaimData(),
       createSender(2, 'firefox-container-2'),
     )).resolves.toMatchObject({ shouldRefresh: true })
+  })
+
+  it('同一容器切换账号后不会复用旧账号快照', async () => {
+    const { extensionApi, tabs } = createExtensionApi()
+    const broker = createTopBarStateBroker(extensionApi)
+    const oldAccountSnapshot = createSnapshot(5)
+    tabs.query.mockResolvedValue([])
+
+    const oldAccountClaim = await broker.claimRefresh(
+      createClaimData(ACCOUNT_ID),
+      createSender(1),
+    )
+    await broker.publish({
+      accountId: ACCOUNT_ID,
+      snapshot: oldAccountSnapshot,
+      refreshId: oldAccountClaim.refreshId!,
+    }, createSender(1))
+
+    await expect(
+      broker.claimRefresh(createClaimData(ACCOUNT_ID + 1), createSender(1)),
+    ).resolves.toEqual({
+      shouldRefresh: true,
+      snapshot: undefined,
+      refreshId: 1,
+    })
   })
 
   it('后台重建后从会话存储恢复新鲜快照', async () => {
@@ -221,8 +272,9 @@ describe('顶栏共享状态协调器', () => {
     firstExtension.tabs.query.mockResolvedValue([])
 
     const firstBroker = createTopBarStateBroker(firstExtension.extensionApi)
-    const claim = await firstBroker.claimRefresh({ maxAge: MAX_AGE }, createSender(1))
+    const claim = await firstBroker.claimRefresh(createClaimData(), createSender(1))
     await firstBroker.publish({
+      accountId: ACCOUNT_ID,
       snapshot,
       refreshId: claim.refreshId!,
     }, createSender(1))
@@ -231,7 +283,7 @@ describe('顶栏共享状态协调器', () => {
     const rebuiltBroker = createTopBarStateBroker(rebuiltExtension.extensionApi)
 
     await expect(
-      rebuiltBroker.claimRefresh({ maxAge: MAX_AGE }, createSender(2)),
+      rebuiltBroker.claimRefresh(createClaimData(), createSender(2)),
     ).resolves.toEqual({
       shouldRefresh: false,
       snapshot,
@@ -244,7 +296,7 @@ describe('顶栏共享状态协调器', () => {
     const firstBroker = createTopBarStateBroker(firstExtension.extensionApi)
 
     const firstClaim = await firstBroker.claimRefresh(
-      { maxAge: MAX_AGE },
+      createClaimData(),
       createSender(1),
     )
     expect(firstClaim).toMatchObject({
@@ -256,13 +308,13 @@ describe('顶栏共享状态协调器', () => {
     const rebuiltBroker = createTopBarStateBroker(rebuiltExtension.extensionApi)
 
     await expect(
-      rebuiltBroker.claimRefresh({ maxAge: MAX_AGE }, createSender(2)),
+      rebuiltBroker.claimRefresh(createClaimData(), createSender(2)),
     ).resolves.toMatchObject({ shouldRefresh: false })
 
     vi.advanceTimersByTime(30_001)
 
     const takeoverClaim = await rebuiltBroker.claimRefresh(
-      { maxAge: MAX_AGE },
+      createClaimData(),
       createSender(2),
     )
     expect(takeoverClaim).toMatchObject({
@@ -272,12 +324,13 @@ describe('顶栏共享状态协调器', () => {
 
     const staleSnapshot = createSnapshot(9)
     await rebuiltBroker.publish({
+      accountId: ACCOUNT_ID,
       snapshot: staleSnapshot,
       refreshId: firstClaim.refreshId!,
     }, createSender(1))
 
     await expect(
-      rebuiltBroker.claimRefresh({ maxAge: MAX_AGE }, createSender(3)),
+      rebuiltBroker.claimRefresh(createClaimData(), createSender(3)),
     ).resolves.toEqual({
       shouldRefresh: false,
       snapshot: undefined,
@@ -286,12 +339,13 @@ describe('顶栏共享状态协调器', () => {
     rebuiltExtension.tabs.query.mockResolvedValue([])
     const currentSnapshot = createSnapshot(10)
     await rebuiltBroker.publish({
+      accountId: ACCOUNT_ID,
       snapshot: currentSnapshot,
       refreshId: takeoverClaim.refreshId!,
     }, createSender(2))
 
     await expect(
-      rebuiltBroker.claimRefresh({ maxAge: MAX_AGE }, createSender(3)),
+      rebuiltBroker.claimRefresh(createClaimData(), createSender(3)),
     ).resolves.toEqual({
       shouldRefresh: false,
       snapshot: currentSnapshot,
@@ -308,14 +362,15 @@ describe('顶栏共享状态协调器', () => {
     } as unknown as TopBarStateBrokerBrowser)
     const snapshot = createSnapshot(8)
 
-    const claim = await broker.claimRefresh({ maxAge: MAX_AGE }, createSender(1))
+    const claim = await broker.claimRefresh(createClaimData(), createSender(1))
     await broker.publish({
+      accountId: ACCOUNT_ID,
       snapshot,
       refreshId: claim.refreshId!,
     }, createSender(1))
 
     await expect(
-      broker.claimRefresh({ maxAge: MAX_AGE }, createSender(2)),
+      broker.claimRefresh(createClaimData(), createSender(2)),
     ).resolves.toEqual({
       shouldRefresh: false,
       snapshot,


### PR DESCRIPTION
## 变更内容

- 新增后台顶栏状态协调器，在多个标签页之间共享顶栏数据快照
- 将未读消息、动态数量、稍后再看和会员权益状态纳入共享
- 首次并发加载时等待刷新标签页发布快照，避免其他标签页长时间显示空状态
- 按 Firefox `cookieStoreId` 隔离状态，避免容器标签页之间串用账号数据

## 问题原因

每个 Bilibili 标签页都会独立初始化顶栏 Pinia Store 并启动定时器，因此标签页数量增加时，顶栏接口请求和自动领取操作也会成倍增加。

修复后，各标签页先向后台协调器申请刷新。刷新周期内只有一个标签页会执行远端请求，其他标签页直接应用后台保存的最新快照。

## 影响

多开标签页时，顶栏相关远端请求不再随标签页数量线性增长，同时各标签页仍保留独立的弹窗和可见性 UI 状态。

## 验证

- `pnpm typecheck`
- ESLint（修改文件）
- `git diff --check`

Closes #808
