### PR TITLE
fix: 修复原版频道栏节点移动导致的异常

### DIFF
--- a/src/contentScripts/index.ts
+++ b/src/contentScripts/index.ts
@@ -598,9 +598,34 @@ else if (shouldInitializeContentScript) {
         position: absolute !important;
         left: -9999px !important;
       }
+      /* 保留新版首页中由 Vue 管理的原版顶栏，避免移动节点破坏组件父子关系 */
+      body > #app:has(> .bili-feed4 > .bili-header) {
+        display: block !important;
+        visibility: visible !important;
+        width: 100% !important;
+        height: 0 !important;
+        pointer-events: none !important;
+        position: relative !important;
+        left: 0 !important;
+        overflow: visible !important;
+      }
+      body > #app:has(> .bili-feed4 > .bili-header) > *:not(.bili-feed4),
+      body > #app > .bili-feed4 > *:not(.bili-header):not(.header-channel) {
+        display: none !important;
+      }
+      body > #app > .bili-feed4 {
+        display: block !important;
+        visibility: visible !important;
+        height: 0 !important;
+        pointer-events: none !important;
+        position: relative !important;
+        left: 0 !important;
+        overflow: visible !important;
+      }
       /* Ensure the original top bar remains visible and properly positioned */
       /* The visibility/display will be controlled by .remove-top-bar class in removeTopBar.scss */
-      .bili-header {
+      .bili-header,
+      .header-channel {
         position: relative !important;
         left: 0 !important;
         pointer-events: auto !important;

--- a/src/contentScripts/index.ts
+++ b/src/contentScripts/index.ts
@@ -624,9 +624,12 @@ else if (shouldInitializeContentScript) {
       }
       /* Ensure the original top bar remains visible and properly positioned */
       /* The visibility/display will be controlled by .remove-top-bar class in removeTopBar.scss */
-      .bili-header,
-      .header-channel {
+      .bili-header {
         position: relative !important;
+        left: 0 !important;
+        pointer-events: auto !important;
+      }
+      .header-channel {
         left: 0 !important;
         pointer-events: auto !important;
       }

--- a/src/styles/removeTopBar.scss
+++ b/src/styles/removeTopBar.scss
@@ -1,7 +1,15 @@
 .homePage .bili-header > .bili-header__channel,
-.homePage .bili-header > .bewly-bili-fixed-channel,
 .homePage .bili-header > .bewly-bili-channel-panel {
   display: none !important;
+}
+
+.homePage .header-channel {
+  display: none !important;
+}
+
+.homePage .header-channel.bewly-original-fixed-channel-visible {
+  display: flex !important;
+  top: var(--bew-top-bar-height) !important;
 }
 
 .homePage .bili-header {
@@ -12,8 +20,17 @@
 }
 
 .homePage:not(.remove-top-bar) .bili-header.bewly-original-top-bar-scrolled > .bili-header__bar {
+  display: flex !important;
+  visibility: visible !important;
+  opacity: 1 !important;
   background-color: #fff !important;
   backdrop-filter: none;
+}
+
+.homePage:not(.remove-top-bar) .bili-header.bewly-original-top-bar-scrolled {
+  display: block !important;
+  visibility: visible !important;
+  opacity: 1 !important;
 }
 
 .dark.homePage:not(.remove-top-bar) .bili-header.bewly-original-top-bar-scrolled > .bili-header__bar {
@@ -56,20 +73,25 @@
     border-right: 2px solid currentColor;
     border-bottom: 2px solid currentColor;
     transform: translateY(-2px) rotate(45deg);
+    transition: transform 0.3s;
+
+    &.arrow-up {
+      transform: translateY(-2px) rotate(45deg);
+    }
   }
 
-  > .bewly-bili-fixed-channel {
-    display: flex !important;
-    position: fixed !important;
-    top: var(--bew-top-bar-height) !important;
-    left: 0 !important;
-    width: 100% !important;
-    max-width: none !important;
-    z-index: 1001 !important;
+  .mini-header__arrow {
+    transform: rotate(-90deg);
+    transition: transform 0.3s;
+
+    &.arrow-up {
+      transform: rotate(0);
+    }
   }
 }
 
-.homePage:not(.remove-top-bar) .bili-header.bewly-original-top-bar-scrolled.bewly-original-channel-open {
+.homePage:not(.remove-top-bar)
+  .bili-header.bewly-original-top-bar-scrolled:is(.bewly-original-channel-open, .bewly-original-channel-closing) {
   > .bewly-bili-channel-panel {
     display: flex !important;
     position: fixed !important;
@@ -83,6 +105,33 @@
     border-radius: 0 0 8px 8px;
     background-color: var(--bew-elevated-solid) !important;
     box-shadow: var(--bew-shadow-2);
+  }
+}
+
+.homePage:not(.remove-top-bar) .bili-header.bewly-original-top-bar-scrolled.bewly-original-channel-open {
+  > .bewly-bili-channel-panel {
+    animation: bewly-bili-channel-panel-enter 0.3s;
+  }
+}
+
+.homePage:not(.remove-top-bar) .bili-header.bewly-original-top-bar-scrolled.bewly-original-channel-closing {
+  > .bewly-bili-channel-panel {
+    animation: bewly-bili-channel-panel-leave 0.3s forwards;
+    pointer-events: none;
+  }
+}
+
+@keyframes bewly-bili-channel-panel-enter {
+  from {
+    opacity: 0;
+    transform: translate3d(0, -5px, 0);
+  }
+}
+
+@keyframes bewly-bili-channel-panel-leave {
+  to {
+    opacity: 0;
+    transform: translate3d(0, -5px, 0);
   }
 }
 
@@ -133,8 +182,8 @@
   // remove the original top bar and adjust the height of the top bar to match the bewly top bar
   .bili-header .bili-header__bar,
   .bili-header > .bili-header__channel,
-  .bili-header > .bewly-bili-fixed-channel,
   .bili-header > .bewly-bili-channel-panel,
+  .header-channel,
   #internationalHeader,
   .link-navbar,
   #home_nav,

--- a/src/styles/removeTopBar.scss
+++ b/src/styles/removeTopBar.scss
@@ -76,18 +76,36 @@
     transition: transform 0.3s;
 
     &.arrow-up {
-      transform: translateY(-2px) rotate(45deg);
+      transform: translateY(2px) rotate(225deg);
     }
   }
 
   .mini-header__arrow {
-    transform: rotate(-90deg);
     transition: transform 0.3s;
 
     &.arrow-up {
-      transform: rotate(0);
+      transform: rotate(180deg);
     }
   }
+}
+
+.homePage:not(.remove-top-bar)
+  .bili-header.bewly-original-top-bar-scrolled
+  .v-popover:is(.bewly-original-native-channel-open, .bewly-original-native-channel-closing) {
+  display: block !important;
+}
+
+.homePage:not(.remove-top-bar)
+  .bili-header.bewly-original-top-bar-scrolled
+  .v-popover.bewly-original-native-channel-open {
+  animation: bewly-bili-channel-panel-enter 0.3s;
+}
+
+.homePage:not(.remove-top-bar)
+  .bili-header.bewly-original-top-bar-scrolled
+  .v-popover.bewly-original-native-channel-closing {
+  animation: bewly-bili-channel-panel-leave 0.3s forwards;
+  pointer-events: none;
 }
 
 .homePage:not(.remove-top-bar)

--- a/src/tests/bilibiliTopBar.spec.ts
+++ b/src/tests/bilibiliTopBar.spec.ts
@@ -41,9 +41,8 @@ describe('b 站原版顶栏滚动状态', () => {
     expect(document.querySelector('.entry-title .bewly-home-entry-arrow')).not.toBeNull()
     expect(document.querySelectorAll('.bewly-bili-channel-panel .channel-panel__column')).toHaveLength(5)
     expect(document.querySelectorAll('.bewly-bili-channel-panel .channel-panel__icon').length).toBeGreaterThan(0)
-    expect(document.querySelector('body > .header-channel:not(.bewly-bili-fixed-channel)')).not.toBeNull()
-    expect(document.querySelector('.bili-header > .bewly-bili-fixed-channel')).not.toBeNull()
-    expect(document.querySelector('.bewly-bili-fixed-channel .header-channel-fixed-right-item')?.textContent).toBe('番剧')
+    expect(document.querySelector('body > .header-channel')).not.toBeNull()
+    expect(document.querySelector('.bili-header > .header-channel')).toBeNull()
   })
 
   it('在 B 站脚本移除下拉类名后自动恢复', async () => {
@@ -62,10 +61,12 @@ describe('b 站原版顶栏滚动状态', () => {
     setOriginalBilibiliTopBarScrolled(document, true)
     expect(header?.classList.contains('bewly-original-top-bar-scrolled')).toBe(true)
     expect(bar?.classList.contains('slide-down')).toBe(true)
+    expect(document.querySelector('.header-channel')?.classList.contains('bewly-original-fixed-channel-visible')).toBe(true)
 
     setOriginalBilibiliTopBarScrolled(document, false)
     expect(header?.classList.contains('bewly-original-top-bar-scrolled')).toBe(false)
     expect(bar?.classList.contains('slide-down')).toBe(false)
+    expect(document.querySelector('.header-channel')?.classList.contains('bewly-original-fixed-channel-visible')).toBe(false)
   })
 
   it('保留原版顶栏的分区面板供悬浮样式控制', () => {
@@ -86,41 +87,48 @@ describe('b 站原版顶栏滚动状态', () => {
     home.dispatchEvent(new Event('pointerover', { bubbles: true }))
 
     expect(header?.classList.contains('bewly-original-channel-open')).toBe(true)
+    expect(header?.querySelector('.bewly-home-entry-arrow')?.classList.contains('arrow-up')).toBe(true)
 
     setOriginalBilibiliTopBarScrolled(document, false)
     expect(header?.classList.contains('bewly-original-channel-open')).toBe(false)
+    expect(header?.querySelector('.bewly-home-entry-arrow')?.classList.contains('arrow-up')).toBe(false)
   })
 
-  it('悬停原版固定频道栏时展开全部标签', () => {
-    const fixedChannel = document.querySelector<HTMLElement>('.bewly-bili-fixed-channel')
-    const fixedChannelContent = fixedChannel?.querySelector('.header-channel-fixed')
+  it('下滑状态下恢复被 B 站脚本隐藏的第一行顶栏', async () => {
+    const header = document.querySelector<HTMLElement>('.bili-header')
+    const bar = document.querySelector<HTMLElement>('.bili-header__bar')
+    setOriginalBilibiliTopBarScrolled(document, true)
 
-    fixedChannel?.dispatchEvent(new Event('pointerenter'))
-    expect(fixedChannelContent?.classList.contains('header-channel-fixed-down')).toBe(true)
-
-    fixedChannel?.dispatchEvent(new Event('pointerleave'))
-    expect(fixedChannelContent?.classList.contains('header-channel-fixed-down')).toBe(false)
-  })
-
-  it('等待原版频道标签异步完成后再创建副本', async () => {
-    document.querySelector('.bewly-bili-fixed-channel')?.remove()
-    const nativeFixedChannel = document.querySelector<HTMLElement>(
-      'body > .header-channel:not(.bewly-bili-fixed-channel)',
-    )
-    const nativeItems = nativeFixedChannel?.querySelector<HTMLElement>('.header-channel-fixed-right')
-    if (nativeItems)
-      nativeItems.innerHTML = ''
-
-    ensureOriginalBilibiliTopBarAppended(document)
-    expect(document.querySelector('.bewly-bili-fixed-channel')).toBeNull()
-
-    const item = document.createElement('a')
-    item.className = 'header-channel-fixed-right-item'
-    item.textContent = '番剧'
-    nativeItems?.appendChild(item)
+    header!.style.display = 'none'
+    bar!.style.visibility = 'hidden'
+    bar!.style.opacity = '0'
     await Promise.resolve()
 
-    expect(document.querySelector('.bili-header > .bewly-bili-fixed-channel')).not.toBeNull()
-    expect(nativeFixedChannel?.parentElement).toBe(document.body)
+    expect(header?.style.display).toBe('')
+    expect(bar?.style.visibility).toBe('')
+    expect(bar?.style.opacity).toBe('')
+    expect(bar?.classList.contains('slide-down')).toBe(true)
+  })
+
+  it('原版顶栏始终保留在 Vue 管理的父节点中', () => {
+    const header = document.querySelector('.bili-header')
+    const originalParent = header?.parentElement
+
+    ensureOriginalBilibiliTopBarAppended(document)
+
+    expect(header?.parentElement).toBe(originalParent)
+  })
+
+  it('b 站替换顶栏节点后恢复当前滚动状态', async () => {
+    setOriginalBilibiliTopBarScrolled(document, true)
+    const oldHeader = document.querySelector<HTMLElement>('.bili-header')
+    const newHeader = oldHeader?.cloneNode(true) as HTMLElement
+    newHeader.classList.remove('bewly-original-top-bar-scrolled')
+    newHeader.querySelector('.bili-header__bar')?.classList.remove('slide-down')
+    oldHeader?.replaceWith(newHeader)
+    await Promise.resolve()
+
+    expect(newHeader.classList.contains('bewly-original-top-bar-scrolled')).toBe(true)
+    expect(newHeader.querySelector('.bili-header__bar')?.classList.contains('slide-down')).toBe(true)
   })
 })

--- a/src/tests/bilibiliTopBar.spec.ts
+++ b/src/tests/bilibiliTopBar.spec.ts
@@ -41,7 +41,7 @@ describe('b 站原版顶栏滚动状态', () => {
     expect(document.querySelector('.entry-title .bewly-home-entry-arrow')).not.toBeNull()
     expect(document.querySelectorAll('.bewly-bili-channel-panel .channel-panel__column')).toHaveLength(5)
     expect(document.querySelectorAll('.bewly-bili-channel-panel .channel-panel__icon').length).toBeGreaterThan(0)
-    expect(document.querySelector('body > .header-channel:not(.bewly-bili-fixed-channel)')).toBeNull()
+    expect(document.querySelector('body > .header-channel:not(.bewly-bili-fixed-channel)')).not.toBeNull()
     expect(document.querySelector('.bili-header > .bewly-bili-fixed-channel')).not.toBeNull()
     expect(document.querySelector('.bewly-bili-fixed-channel .header-channel-fixed-right-item')?.textContent).toBe('番剧')
   })
@@ -100,5 +100,27 @@ describe('b 站原版顶栏滚动状态', () => {
 
     fixedChannel?.dispatchEvent(new Event('pointerleave'))
     expect(fixedChannelContent?.classList.contains('header-channel-fixed-down')).toBe(false)
+  })
+
+  it('等待原版频道标签异步完成后再创建副本', async () => {
+    document.querySelector('.bewly-bili-fixed-channel')?.remove()
+    const nativeFixedChannel = document.querySelector<HTMLElement>(
+      'body > .header-channel:not(.bewly-bili-fixed-channel)',
+    )
+    const nativeItems = nativeFixedChannel?.querySelector<HTMLElement>('.header-channel-fixed-right')
+    if (nativeItems)
+      nativeItems.innerHTML = ''
+
+    ensureOriginalBilibiliTopBarAppended(document)
+    expect(document.querySelector('.bewly-bili-fixed-channel')).toBeNull()
+
+    const item = document.createElement('a')
+    item.className = 'header-channel-fixed-right-item'
+    item.textContent = '番剧'
+    nativeItems?.appendChild(item)
+    await Promise.resolve()
+
+    expect(document.querySelector('.bili-header > .bewly-bili-fixed-channel')).not.toBeNull()
+    expect(nativeFixedChannel?.parentElement).toBe(document.body)
   })
 })

--- a/src/tests/bilibiliTopBar.spec.ts
+++ b/src/tests/bilibiliTopBar.spec.ts
@@ -79,6 +79,10 @@ describe('b 站原版顶栏滚动状态', () => {
   it('由兼容层控制下拉后的分区面板展开', () => {
     ensureOriginalBilibiliTopBarAppended(document)
     const header = document.querySelector('.bili-header')
+    const nativePopover = document.createElement('div')
+    nativePopover.className = 'v-popover is-bottom-start'
+    nativePopover.innerHTML = '<div class="bili-header-channel-panel"></div>'
+    header?.appendChild(nativePopover)
     const home = document.createElement('a')
     home.className = 'entry-title'
     header?.querySelector('.bili-header__bar')?.appendChild(home)
@@ -87,10 +91,12 @@ describe('b 站原版顶栏滚动状态', () => {
     home.dispatchEvent(new Event('pointerover', { bubbles: true }))
 
     expect(header?.classList.contains('bewly-original-channel-open')).toBe(true)
+    expect(nativePopover.classList.contains('bewly-original-native-channel-open')).toBe(true)
     expect(header?.querySelector('.bewly-home-entry-arrow')?.classList.contains('arrow-up')).toBe(true)
 
     setOriginalBilibiliTopBarScrolled(document, false)
     expect(header?.classList.contains('bewly-original-channel-open')).toBe(false)
+    expect(nativePopover.classList.contains('bewly-original-native-channel-open')).toBe(false)
     expect(header?.querySelector('.bewly-home-entry-arrow')?.classList.contains('arrow-up')).toBe(false)
   })
 

--- a/src/utils/bilibiliTopBar.ts
+++ b/src/utils/bilibiliTopBar.ts
@@ -15,6 +15,7 @@ const BILIBILI_TOP_BAR_SELECTORS = [
 let cachedOriginalTopBar: HTMLElement | null = null
 const initializedHoverHeaders = new WeakSet<HTMLElement>()
 const initializedScrollStateHeaders = new WeakSet<HTMLElement>()
+const initializedFixedChannelSources = new WeakSet<HTMLElement>()
 const channelPanelColumns = [
   [
     ['番剧', '//www.bilibili.com/anime/', '#channel-anime'],
@@ -166,19 +167,50 @@ function ensureOriginalTopBarScrolledLayout(header: HTMLElement) {
       '.header-channel:not(.bewly-bili-fixed-channel)',
     )
     if (nativeFixedChannel) {
-      const fixedChannel = nativeFixedChannel
-      fixedChannel.classList.add('bewly-bili-fixed-channel')
-      fixedChannel.style.removeProperty('display')
+      if (nativeFixedChannel.querySelector('.header-channel-fixed-right-item')) {
+        const fixedChannel = nativeFixedChannel.cloneNode(true) as HTMLElement
+        fixedChannel.classList.add('bewly-bili-fixed-channel')
+        fixedChannel.style.removeProperty('display')
 
-      const fixedChannelContent = fixedChannel.querySelector('.header-channel-fixed')
-      fixedChannel.addEventListener('pointerenter', () => {
-        fixedChannelContent?.classList.add('header-channel-fixed-down')
-      })
-      fixedChannel.addEventListener('pointerleave', () => {
-        fixedChannelContent?.classList.remove('header-channel-fixed-down')
-      })
+        fixedChannel.addEventListener('pointerenter', () => {
+          fixedChannel
+            .querySelector('.header-channel-fixed')
+            ?.classList
+            .add('header-channel-fixed-down')
+        })
+        fixedChannel.addEventListener('pointerleave', () => {
+          fixedChannel
+            .querySelector('.header-channel-fixed')
+            ?.classList
+            .remove('header-channel-fixed-down')
+        })
+        fixedChannel.querySelector('.header-channel-fixed-arrow')?.addEventListener('click', () => {
+          fixedChannel
+            .querySelector('.header-channel-fixed')
+            ?.classList
+            .toggle('header-channel-fixed-down')
+        })
 
-      header.appendChild(fixedChannel)
+        header.appendChild(fixedChannel)
+      }
+      else if (!initializedFixedChannelSources.has(nativeFixedChannel)) {
+        initializedFixedChannelSources.add(nativeFixedChannel)
+        const observer = new MutationObserver(() => {
+          if (!header.isConnected) {
+            observer.disconnect()
+            return
+          }
+          if (!nativeFixedChannel.querySelector('.header-channel-fixed-right-item'))
+            return
+
+          observer.disconnect()
+          ensureOriginalTopBarScrolledLayout(header)
+        })
+        observer.observe(nativeFixedChannel, {
+          childList: true,
+          subtree: true,
+        })
+      }
     }
   }
 

--- a/src/utils/bilibiliTopBar.ts
+++ b/src/utils/bilibiliTopBar.ts
@@ -15,7 +15,7 @@ const BILIBILI_TOP_BAR_SELECTORS = [
 let cachedOriginalTopBar: HTMLElement | null = null
 const initializedHoverHeaders = new WeakSet<HTMLElement>()
 const initializedScrollStateHeaders = new WeakSet<HTMLElement>()
-const initializedFixedChannelSources = new WeakSet<HTMLElement>()
+const initializedTopBarDocuments = new WeakSet<Document>()
 const channelPanelColumns = [
   [
     ['番剧', '//www.bilibili.com/anime/', '#channel-anime'],
@@ -87,6 +87,7 @@ export function captureOriginalBilibiliTopBar(doc: Document) {
     return null
 
   cachedOriginalTopBar = header
+  keepOriginalTopBarAvailable(doc)
   setOriginalBilibiliTopBarScrolled(doc, false)
   ensureOriginalTopBarScrolledLayout(header)
   return cachedOriginalTopBar
@@ -98,12 +99,56 @@ export function captureOriginalBilibiliTopBar(doc: Document) {
  */
 export function setOriginalBilibiliTopBarScrolled(doc: Document, scrolled: boolean) {
   const header = getDocumentTopBar(doc) || cachedOriginalTopBar
+  if (header && header !== cachedOriginalTopBar)
+    cachedOriginalTopBar = header
   header?.classList.toggle('bewly-original-top-bar-scrolled', scrolled)
   header?.querySelector('.bili-header__bar')?.classList.toggle('slide-down', scrolled)
-  if (header)
+  getOriginalFixedChannel(header)?.classList.toggle('bewly-original-fixed-channel-visible', scrolled)
+  if (header) {
+    if (scrolled)
+      restoreOriginalTopBarVisibility(header)
     keepOriginalTopBarScrolled(header)
-  if (!scrolled)
+  }
+  if (!scrolled) {
     header?.classList.remove('bewly-original-channel-open')
+    header?.classList.remove('bewly-original-channel-closing')
+    setOriginalTopBarHomeArrowExpanded(header, false)
+  }
+}
+
+function getOriginalFixedChannel(header: HTMLElement | null) {
+  return header?.parentElement?.querySelector<HTMLElement>(':scope > .header-channel') ?? null
+}
+
+function keepOriginalTopBarAvailable(doc: Document) {
+  if (initializedTopBarDocuments.has(doc))
+    return
+
+  initializedTopBarDocuments.add(doc)
+  const observer = new MutationObserver(() => {
+    const header = getDocumentTopBar(doc)
+    if (!header || header === cachedOriginalTopBar)
+      return
+
+    const scrolled = cachedOriginalTopBar?.classList.contains('bewly-original-top-bar-scrolled') ?? false
+    cachedOriginalTopBar = header
+    setupOriginalTopBarChannelHover(header)
+    ensureOriginalTopBarScrolledLayout(header)
+    setOriginalBilibiliTopBarScrolled(doc, scrolled)
+  })
+  observer.observe(doc.documentElement, {
+    childList: true,
+    subtree: true,
+  })
+}
+
+function restoreOriginalTopBarVisibility(header: HTMLElement) {
+  const bar = header.querySelector<HTMLElement>('.bili-header__bar')
+  for (const element of [header, bar]) {
+    element?.style.removeProperty('display')
+    element?.style.removeProperty('visibility')
+    element?.style.removeProperty('opacity')
+  }
 }
 
 function keepOriginalTopBarScrolled(header: HTMLElement) {
@@ -118,11 +163,12 @@ function keepOriginalTopBarScrolled(header: HTMLElement) {
     const bar = header.querySelector('.bili-header__bar')
     if (bar && !bar.classList.contains('slide-down'))
       bar.classList.add('slide-down')
+    restoreOriginalTopBarVisibility(header)
     ensureOriginalTopBarScrolledLayout(header)
   })
   observer.observe(header, {
     attributes: true,
-    attributeFilter: ['class'],
+    attributeFilter: ['class', 'style'],
     childList: true,
     subtree: true,
   })
@@ -130,7 +176,7 @@ function keepOriginalTopBarScrolled(header: HTMLElement) {
 
 function ensureOriginalTopBarScrolledLayout(header: HTMLElement) {
   const leftEntry = header.querySelector<HTMLElement>('.bili-header__bar .left-entry')
-  const homeEntry = leftEntry?.querySelector<HTMLElement>('.entry-title')
+  const homeEntry = leftEntry?.querySelector<HTMLElement>('.entry-title, .left-entry__title')
   if (!leftEntry || !homeEntry)
     return
   const doc = header.ownerDocument
@@ -155,63 +201,11 @@ function ensureOriginalTopBarScrolledLayout(header: HTMLElement) {
     }
   }
 
-  if (!homeEntry.querySelector('.bewly-home-entry-arrow')) {
+  if (!homeEntry.querySelector('.mini-header__arrow, .bewly-home-entry-arrow')) {
     const arrow = doc.createElement('span')
     arrow.className = 'bewly-home-entry-arrow'
     arrow.setAttribute('aria-hidden', 'true')
     homeEntry.appendChild(arrow)
-  }
-
-  if (!header.querySelector(':scope > .bewly-bili-fixed-channel')) {
-    const nativeFixedChannel = doc.querySelector<HTMLElement>(
-      '.header-channel:not(.bewly-bili-fixed-channel)',
-    )
-    if (nativeFixedChannel) {
-      if (nativeFixedChannel.querySelector('.header-channel-fixed-right-item')) {
-        const fixedChannel = nativeFixedChannel.cloneNode(true) as HTMLElement
-        fixedChannel.classList.add('bewly-bili-fixed-channel')
-        fixedChannel.style.removeProperty('display')
-
-        fixedChannel.addEventListener('pointerenter', () => {
-          fixedChannel
-            .querySelector('.header-channel-fixed')
-            ?.classList
-            .add('header-channel-fixed-down')
-        })
-        fixedChannel.addEventListener('pointerleave', () => {
-          fixedChannel
-            .querySelector('.header-channel-fixed')
-            ?.classList
-            .remove('header-channel-fixed-down')
-        })
-        fixedChannel.querySelector('.header-channel-fixed-arrow')?.addEventListener('click', () => {
-          fixedChannel
-            .querySelector('.header-channel-fixed')
-            ?.classList
-            .toggle('header-channel-fixed-down')
-        })
-
-        header.appendChild(fixedChannel)
-      }
-      else if (!initializedFixedChannelSources.has(nativeFixedChannel)) {
-        initializedFixedChannelSources.add(nativeFixedChannel)
-        const observer = new MutationObserver(() => {
-          if (!header.isConnected) {
-            observer.disconnect()
-            return
-          }
-          if (!nativeFixedChannel.querySelector('.header-channel-fixed-right-item'))
-            return
-
-          observer.disconnect()
-          ensureOriginalTopBarScrolledLayout(header)
-        })
-        observer.observe(nativeFixedChannel, {
-          childList: true,
-          subtree: true,
-        })
-      }
-    }
   }
 
   if (!header.querySelector('.bewly-bili-channel-panel')) {
@@ -220,9 +214,6 @@ function ensureOriginalTopBarScrolledLayout(header: HTMLElement) {
     )
 
     if (nativePanel) {
-      const panel = nativePanel.cloneNode(true) as HTMLElement
-      panel.classList.add('bewly-bili-channel-panel')
-      header.appendChild(panel)
       return
     }
 
@@ -268,40 +259,67 @@ function ensureOriginalTopBarScrolledLayout(header: HTMLElement) {
   }
 }
 
+function setOriginalTopBarHomeArrowExpanded(header: HTMLElement | null, expanded: boolean) {
+  header
+    ?.querySelector('.mini-header__arrow')
+    ?.classList
+    .toggle('arrow-up', expanded)
+  header
+    ?.querySelector('.bewly-home-entry-arrow')
+    ?.classList
+    .toggle('arrow-up', expanded)
+}
+
 function setupOriginalTopBarChannelHover(header: HTMLElement) {
   if (initializedHoverHeaders.has(header))
     return
 
   initializedHoverHeaders.add(header)
+  if (header.querySelector('.bili-header-channel-panel:not(.bewly-bili-channel-panel)'))
+    return
+
   let closeTimer: ReturnType<typeof setTimeout> | null = null
+  let closeAnimationTimer: ReturnType<typeof setTimeout> | null = null
 
   const clearCloseTimer = () => {
-    if (!closeTimer)
-      return
-
-    clearTimeout(closeTimer)
-    closeTimer = null
+    if (closeTimer) {
+      clearTimeout(closeTimer)
+      closeTimer = null
+    }
+    if (closeAnimationTimer) {
+      clearTimeout(closeAnimationTimer)
+      closeAnimationTimer = null
+    }
   }
 
   header.addEventListener('pointerover', (event) => {
     const target = event.target as Element | null
-    if (!target?.closest('.entry-title, .bewly-bili-channel-panel'))
+    if (!target?.closest('.entry-title, .left-entry__title, .bewly-bili-channel-panel'))
       return
 
     clearCloseTimer()
-    if (header.classList.contains('bewly-original-top-bar-scrolled'))
+    if (header.classList.contains('bewly-original-top-bar-scrolled')) {
+      header.classList.remove('bewly-original-channel-closing')
       header.classList.add('bewly-original-channel-open')
+      setOriginalTopBarHomeArrowExpanded(header, true)
+    }
   })
 
   header.addEventListener('pointerout', (event) => {
     const target = event.target as Element | null
-    if (!target?.closest('.entry-title, .bewly-bili-channel-panel'))
+    if (!target?.closest('.entry-title, .left-entry__title, .bewly-bili-channel-panel'))
       return
 
     clearCloseTimer()
     closeTimer = setTimeout(() => {
-      header.classList.remove('bewly-original-channel-open')
       closeTimer = null
+      header.classList.remove('bewly-original-channel-open')
+      header.classList.add('bewly-original-channel-closing')
+      setOriginalTopBarHomeArrowExpanded(header, false)
+      closeAnimationTimer = setTimeout(() => {
+        header.classList.remove('bewly-original-channel-closing')
+        closeAnimationTimer = null
+      }, 300)
     }, 120)
   })
 }
@@ -312,7 +330,13 @@ export function detachOriginalBilibiliTopBar(doc: Document) {
     return
 
   cachedOriginalTopBar = header
-  header.remove()
+  header.classList.remove(
+    'bewly-original-top-bar-scrolled',
+    'bewly-original-channel-open',
+    'bewly-original-channel-closing',
+  )
+  header.querySelector('.bili-header__bar')?.classList.remove('slide-down')
+  getOriginalFixedChannel(header)?.classList.remove('bewly-original-fixed-channel-visible')
 }
 
 export function ensureOriginalBilibiliTopBarAppended(doc: Document): boolean {
@@ -329,13 +353,7 @@ export function ensureOriginalBilibiliTopBarAppended(doc: Document): boolean {
   setupOriginalTopBarChannelHover(header)
   ensureOriginalTopBarScrolledLayout(header)
 
-  // 2. 确保顶栏是 body 的直接子元素且位于最前
-  // 即使 header 已存在，如果它在某个被隐藏的父容器里，这里也会将其移动到 body 下
-  if (header.parentElement !== doc.body || header !== doc.body.firstElementChild) {
-    doc.body.prepend(header)
-  }
-
-  // 更新缓存引用
+  // 原版顶栏继续留在 B 站 Vue 管理的父节点中，避免组件更新时节点丢失
   cachedOriginalTopBar = header
   return true
 }

--- a/src/utils/bilibiliTopBar.ts
+++ b/src/utils/bilibiliTopBar.ts
@@ -112,6 +112,10 @@ export function setOriginalBilibiliTopBarScrolled(doc: Document, scrolled: boole
   if (!scrolled) {
     header?.classList.remove('bewly-original-channel-open')
     header?.classList.remove('bewly-original-channel-closing')
+    getOriginalTopBarNativeChannelPopover(header)?.classList.remove(
+      'bewly-original-native-channel-open',
+      'bewly-original-native-channel-closing',
+    )
     setOriginalTopBarHomeArrowExpanded(header, false)
   }
 }
@@ -270,13 +274,17 @@ function setOriginalTopBarHomeArrowExpanded(header: HTMLElement | null, expanded
     .toggle('arrow-up', expanded)
 }
 
+function getOriginalTopBarNativeChannelPopover(header: HTMLElement | null) {
+  return header
+    ?.querySelector('.bili-header-channel-panel:not(.bewly-bili-channel-panel)')
+    ?.closest<HTMLElement>('.v-popover') ?? null
+}
+
 function setupOriginalTopBarChannelHover(header: HTMLElement) {
   if (initializedHoverHeaders.has(header))
     return
 
   initializedHoverHeaders.add(header)
-  if (header.querySelector('.bili-header-channel-panel:not(.bewly-bili-channel-panel)'))
-    return
 
   let closeTimer: ReturnType<typeof setTimeout> | null = null
   let closeAnimationTimer: ReturnType<typeof setTimeout> | null = null
@@ -294,30 +302,37 @@ function setupOriginalTopBarChannelHover(header: HTMLElement) {
 
   header.addEventListener('pointerover', (event) => {
     const target = event.target as Element | null
-    if (!target?.closest('.entry-title, .left-entry__title, .bewly-bili-channel-panel'))
+    if (!target?.closest('.entry-title, .left-entry__title, .bewly-bili-channel-panel, .bili-header-channel-panel'))
       return
 
     clearCloseTimer()
     if (header.classList.contains('bewly-original-top-bar-scrolled')) {
+      const nativePopover = getOriginalTopBarNativeChannelPopover(header)
       header.classList.remove('bewly-original-channel-closing')
       header.classList.add('bewly-original-channel-open')
+      nativePopover?.classList.remove('bewly-original-native-channel-closing')
+      nativePopover?.classList.add('bewly-original-native-channel-open')
       setOriginalTopBarHomeArrowExpanded(header, true)
     }
   })
 
   header.addEventListener('pointerout', (event) => {
     const target = event.target as Element | null
-    if (!target?.closest('.entry-title, .left-entry__title, .bewly-bili-channel-panel'))
+    if (!target?.closest('.entry-title, .left-entry__title, .bewly-bili-channel-panel, .bili-header-channel-panel'))
       return
 
     clearCloseTimer()
     closeTimer = setTimeout(() => {
+      const nativePopover = getOriginalTopBarNativeChannelPopover(header)
       closeTimer = null
       header.classList.remove('bewly-original-channel-open')
       header.classList.add('bewly-original-channel-closing')
+      nativePopover?.classList.remove('bewly-original-native-channel-open')
+      nativePopover?.classList.add('bewly-original-native-channel-closing')
       setOriginalTopBarHomeArrowExpanded(header, false)
       closeAnimationTimer = setTimeout(() => {
         header.classList.remove('bewly-original-channel-closing')
+        nativePopover?.classList.remove('bewly-original-native-channel-closing')
         closeAnimationTimer = null
       }, 300)
     }, 120)
@@ -334,6 +349,10 @@ export function detachOriginalBilibiliTopBar(doc: Document) {
     'bewly-original-top-bar-scrolled',
     'bewly-original-channel-open',
     'bewly-original-channel-closing',
+  )
+  getOriginalTopBarNativeChannelPopover(header)?.classList.remove(
+    'bewly-original-native-channel-open',
+    'bewly-original-native-channel-closing',
   )
   header.querySelector('.bili-header__bar')?.classList.remove('slide-down')
   getOriginalFixedChannel(header)?.classList.remove('bewly-original-fixed-channel-visible')


### PR DESCRIPTION
## 修改内容

- 不再移动 B 站 Vue 管理的原版 `.header-channel` 节点
- 等待右侧频道 tags 异步渲染完成后再创建展示副本
- 为副本恢复悬停展开、离开收起和箭头切换交互
- 新增异步渲染测试，确保原节点始终保留在原父节点

## 问题原因

#804 最初为了保留 B 站异步更新和原生交互，将 `.header-channel` 原节点移动到了 BewlyCat 顶栏下。B 站 Vue 仍然按照原虚拟 DOM 父子关系管理该节点，后续卸载时会从旧父节点调用 `removeChild`，从而抛出：

`NotFoundError: Failed to execute 'removeChild' on 'Node'`

## 修复方式

保留 Vue 管理的原节点和父子关系不变。若频道 tags 尚未完成渲染，则通过 `MutationObserver` 等待；完成后克隆完整结构用于滚动态展示。这样既能包含全部 tags，也不会破坏 B 站组件生命周期。

## 验证

- `pnpm exec eslint src/utils/bilibiliTopBar.ts src/tests/bilibiliTopBar.spec.ts`
- `pnpm exec vitest run src/tests/bilibiliTopBar.spec.ts`（7 项通过）
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

Follow-up to #804.
