### PR TITLE
fix: 修复顶栏收藏夹封面尺寸错乱

### DIFF
--- a/src/components/TopBar/components/pops/FavoritesPop.vue
+++ b/src/components/TopBar/components/pops/FavoritesPop.vue
@@ -372,21 +372,21 @@ defineExpose({
             class="group"
             transition="~ duration-300"
           >
-            <section flex="~ gap-4" item-start>
+            <section flex="~ gap-4" items-start>
               <div
                 bg="$bew-skeleton"
                 w="120px"
                 flex="shrink-0"
                 rounded="$bew-radius-half"
                 overflow="hidden"
+                class="aspect-video"
               >
-                <div pos="relative">
+                <div pos="relative" w-full h-full>
                   <img
-                    w="120px"
-                    class="aspect-video"
+                    w-full h-full
                     :src="`${removeHttpFromUrl(item.cover)}@256w_144h_1c`"
                     :alt="item.title"
-                    bg="contain"
+                    object-cover
                   >
                   <div
                     pos="absolute bottom-0 right-0"


### PR DESCRIPTION
## 修改内容

- 修正收藏夹卡片横向布局中错误的 `item-start` 属性。
- 将 16:9 比例约束从图片元素移到封面容器。
- 让封面图片完整填充容器并使用 `object-cover` 裁切。

## 问题原因

封面容器本身没有稳定的宽高比，并且卡片使用了无效的 Flex 对齐属性。图片加载、缓存切换或返回尺寸变化时，容器可能被拉伸或采用异常高度，从而出现封面尺寸错乱以及大面积背景边缘。

## 影响

顶栏收藏夹中的封面将稳定保持原有的 120px 宽度和 16:9 比例，不会改变卡片整体设计尺寸。

## 验证

- `pnpm exec eslint src/components/TopBar/components/pops/FavoritesPop.vue`
- `git diff --check`
