### PR TITLE
fix: 修复 BiliBili 主页模式广告拦截空白卡片

### DIFF
--- a/src/contentScripts/features/blockUselessFeedCards.ts
+++ b/src/contentScripts/features/blockUselessFeedCards.ts
@@ -17,6 +17,19 @@ let observeRoot: Element | null = null
 let flushScheduled = false
 const pendingRoots = new Set<Element>()
 
+interface UselessFeedCardBlockerContext {
+  blockAds: boolean
+  homePage: boolean
+  inIframe: boolean
+}
+
+export function shouldEnableUselessFeedCardBlocker({
+  blockAds,
+  homePage,
+}: UselessFeedCardBlockerContext) {
+  return blockAds && homePage
+}
+
 function getObserveRoot(): Element {
   // Prefer the feed container if it exists; fallback to body.
   const firstFeedCard = document.querySelector('.feed-card')

--- a/src/contentScripts/features/blockUselessFeedCards.ts
+++ b/src/contentScripts/features/blockUselessFeedCards.ts
@@ -3,7 +3,7 @@ const VIDEO_CARD_CLASS = 'bili-video-card'
 
 // Homepage recommended cards (that do NOT support "not interested")
 const RCMD_VIDEO_CARD_SELECTOR = '.bili-video-card.is-rcmd:not(.enable-no-interest)'
-const FEED_CARD_SELECTOR = '.feed-card'
+const FEED_CARD_SELECTOR = '.feed-card, .bili-feed-card'
 const OBSERVER_OPTIONS: MutationObserverInit = {
   attributeFilter: ['class'],
   attributeOldValue: true,
@@ -61,15 +61,29 @@ function syncFeedCard(feedCard: HTMLElement) {
   )
 }
 
+function getFeedCardSlot(element: Element): HTMLElement | null {
+  // 首屏卡片有 .feed-card 外层，后续懒加载卡片则可能直接使用 .bili-feed-card。
+  return element.closest<HTMLElement>('.feed-card')
+    || element.closest<HTMLElement>('.bili-feed-card')
+}
+
 function scanForRcmdCards(root: ParentNode) {
-  // An inserted or updated node can be inside an existing feed card.
+  const feedCardSlots = new Set<HTMLElement>()
+
+  // 新增或更新的节点可能位于已有卡片内部。
   if (root instanceof Element) {
-    const closestFeedCard = root.closest<HTMLElement>(FEED_CARD_SELECTOR)
+    const closestFeedCard = getFeedCardSlot(root)
     if (closestFeedCard)
-      syncFeedCard(closestFeedCard)
+      feedCardSlots.add(closestFeedCard)
   }
 
-  root.querySelectorAll?.<HTMLElement>(FEED_CARD_SELECTOR).forEach(syncFeedCard)
+  root.querySelectorAll?.<HTMLElement>(FEED_CARD_SELECTOR).forEach((feedCard) => {
+    const feedCardSlot = getFeedCardSlot(feedCard)
+    if (feedCardSlot)
+      feedCardSlots.add(feedCardSlot)
+  })
+
+  feedCardSlots.forEach(syncFeedCard)
 }
 
 function flushPending() {

--- a/src/contentScripts/views/necessarySettingsWatchers.ts
+++ b/src/contentScripts/views/necessarySettingsWatchers.ts
@@ -1,7 +1,7 @@
 import { useI18n } from 'vue-i18n'
 
 import { IFRAME_TOP_BAR_CHANGE } from '~/constants/globalEvents'
-import { setUselessFeedCardBlockerEnabled } from '~/contentScripts/features/blockUselessFeedCards'
+import { setUselessFeedCardBlockerEnabled, shouldEnableUselessFeedCardBlocker } from '~/contentScripts/features/blockUselessFeedCards'
 import { LanguageType } from '~/enums/appEnums'
 import { appAuthTokens, FROSTED_GLASS_BLUR_MAX_PX, FROSTED_GLASS_BLUR_MIN_PX, localSettings, originalSettings, settings } from '~/logic'
 import { resetBilibiliTopBarInlineStyles, setOriginalBilibiliTopBarScrolled } from '~/utils/bilibiliTopBar'
@@ -225,27 +225,32 @@ export function setupNecessarySettingsWatchers() {
     }
   }, { immediate: true })
 
+  const refreshUselessFeedCardBlocker = () => {
+    // 原版 Bilibili 页面也可能运行在 BewlyCat 的 iframe 中，每个文档都要独立标记外层卡片。
+    setUselessFeedCardBlockerEnabled(
+      shouldEnableUselessFeedCardBlocker({
+        blockAds: settings.value.blockAds,
+        homePage: isHomePage(),
+        inIframe: isInIframe(),
+      }),
+    )
+  }
+
   watch(() => settings.value.blockAds, () => {
-    // Do not use the "ads" keyword. AdGuard, AdBlock, and some ad-blocking extensions will
-    // detect and remove it when the class name contains "ads"
+    // 不要在类名中使用 "ads"，否则可能被 AdGuard、AdBlock 等扩展误删。
     if (settings.value.blockAds)
       document.documentElement.classList.add('block-useless-contents')
     else
       document.documentElement.classList.remove('block-useless-contents')
 
-    // Avoid expensive :has() selectors by using a JS marker on homepage feed cards.
-    setUselessFeedCardBlockerEnabled(settings.value.blockAds && isHomePage() && !isInIframe())
+    // 使用 JS 标记首页信息流卡片，避免代价较高的 :has() 选择器。
+    refreshUselessFeedCardBlocker()
   }, { immediate: true })
 
-  // SPA navigation: homepage state can change without a full reload.
-  if (!isInIframe()) {
-    const refreshUselessFeedCardBlocker = () => {
-      setUselessFeedCardBlockerEnabled(settings.value.blockAds && isHomePage() && !isInIframe())
-    }
-    window.addEventListener('pushstate', refreshUselessFeedCardBlocker)
-    window.addEventListener('popstate', refreshUselessFeedCardBlocker)
-    window.addEventListener('hashchange', refreshUselessFeedCardBlocker)
-  }
+  // iframe 内的原版页面同样可能通过 SPA 导航离开或返回首页。
+  window.addEventListener('pushstate', refreshUselessFeedCardBlocker)
+  window.addEventListener('popstate', refreshUselessFeedCardBlocker)
+  window.addEventListener('hashchange', refreshUselessFeedCardBlocker)
 
   /**
    * 搜尋結果的上方的廣告，但有時是年末總結、年度報告這些

--- a/src/styles/blockAds.scss
+++ b/src/styles/blockAds.scss
@@ -6,6 +6,7 @@
   // 首頁不能使用不感興趣的影片都當廣告殺了
   // NOTE: 避免使用 :has()，會在滾動動態插入卡片時引發大範圍樣式重算
   .feed-card.bewly-blocked-feed-card,
+  .bili-feed-card.bewly-blocked-feed-card,
   .bili-video-card.is-rcmd:not(.enable-no-interest),
   .ad-report,
   .brand-ad-list,

--- a/src/tests/blockUselessFeedCards.spec.ts
+++ b/src/tests/blockUselessFeedCards.spec.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { setUselessFeedCardBlockerEnabled } from '~/contentScripts/features/blockUselessFeedCards'
+import {
+  setUselessFeedCardBlockerEnabled,
+  shouldEnableUselessFeedCardBlocker,
+} from '~/contentScripts/features/blockUselessFeedCards'
 
 const BLOCKED_FEED_CARD_CLASS = 'bewly-blocked-feed-card'
 
@@ -22,6 +25,14 @@ describe('useless homepage feed card blocker', () => {
     setUselessFeedCardBlockerEnabled(false)
     vi.unstubAllGlobals()
     document.body.replaceChildren()
+  })
+
+  it('enables the blocker for an embedded Bilibili homepage', () => {
+    expect(shouldEnableUselessFeedCardBlocker({
+      blockAds: true,
+      homePage: true,
+      inIframe: true,
+    })).toBe(true)
   })
 
   it('marks the outer feed card when recommendation classes are attached asynchronously', async () => {

--- a/src/tests/blockUselessFeedCards.spec.ts
+++ b/src/tests/blockUselessFeedCards.spec.ts
@@ -53,6 +53,39 @@ describe('useless homepage feed card blocker', () => {
     expect(feedCard.classList.contains(BLOCKED_FEED_CARD_CLASS)).toBe(true)
   })
 
+  it('marks a lazy-loaded card without the outer feed-card wrapper', () => {
+    const feedCard = document.createElement('div')
+    feedCard.className = 'bili-feed-card'
+
+    const videoCard = document.createElement('div')
+    videoCard.className = 'bili-video-card is-rcmd'
+    feedCard.append(videoCard)
+    document.body.append(feedCard)
+
+    setUselessFeedCardBlockerEnabled(true)
+
+    expect(feedCard.classList.contains(BLOCKED_FEED_CARD_CLASS)).toBe(true)
+  })
+
+  it('marks the outer slot instead of its nested bili-feed-card', () => {
+    const outerFeedCard = document.createElement('div')
+    outerFeedCard.className = 'feed-card'
+
+    const innerFeedCard = document.createElement('div')
+    innerFeedCard.className = 'bili-feed-card'
+
+    const videoCard = document.createElement('div')
+    videoCard.className = 'bili-video-card is-rcmd'
+    innerFeedCard.append(videoCard)
+    outerFeedCard.append(innerFeedCard)
+    document.body.append(outerFeedCard)
+
+    setUselessFeedCardBlockerEnabled(true)
+
+    expect(outerFeedCard.classList.contains(BLOCKED_FEED_CARD_CLASS)).toBe(true)
+    expect(innerFeedCard.classList.contains(BLOCKED_FEED_CARD_CLASS)).toBe(false)
+  })
+
   it('removes the outer marker when a card stops matching', async () => {
     const feedCard = document.createElement('div')
     feedCard.className = 'feed-card'


### PR DESCRIPTION
## 修改内容

- 在 BiliBili 主页 iframe 中启用广告卡片外层标记器
- 同时处理首屏 `.feed-card` 和懒加载 `.bili-feed-card` 两种网格包装结构
- 在 iframe 内发生 SPA 导航时重新同步标记器状态
- 补充 iframe、异步类名、懒加载包装器和嵌套包装器的回归测试

## 问题原因

此前的空白卡片修复只在顶层首页启用标记器，而 BewlyCat 的 BiliBili 主页模式会将原版首页放入 iframe，导致 iframe 内广告仅隐藏视频卡片本身，外层网格项仍然占位。

进一步实测发现，Bilibili 首屏卡片使用 `.feed-card` 作为网格项，但后续懒加载卡片会直接使用 `.bili-feed-card`。旧逻辑只标记前一种结构，因此滚动加载后仍会出现空白位置。

## 用户影响

启用广告拦截后，无论是首屏还是滚动加载出的广告卡片，都会隐藏实际网格项，后续视频卡片可以正常补位，不再留下空白卡槽。

## 验证

- Chrome 真实页面加载 102 个网格子项，9 个懒加载广告包装器均被隐藏，可见空白槽为 0
- `pnpm test`：13 个测试文件、42 项测试全部通过
- `pnpm typecheck`
- 相关文件 ESLint 检查
- `pnpm build:js -- --mode development`
