### PR TITLE
feat: 新增可调节的 Liquid Glass 视觉效果

### DIFF
--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -174,6 +174,9 @@ settings:
     Bilibili 默认会专门处理中文标点符号以实现左对齐。 如果你正在使用自定义字体，建议移除缩进。
   enable_frosted_glass: 启用毛玻璃效果
   frosted_glass_blur_intensity: 毛玻璃模糊强度
+  enable_liquid_glass: 启用 Liquid Glass 效果（实验性）
+  enable_liquid_glass_desc: 在毛玻璃上增加液态高光、通透边缘和轻微流动效果。
+  liquid_glass_tint_intensity: Liquid Glass 着色强度
   disable_shadow: 禁用阴影
   link_opening_behavior_opt:
     current_tab: 当前标签页

--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -886,6 +886,12 @@ version_reminder:
   bilibili_dynamic_desc: 查看开发者发布的更新动态
   acknowledge: 已知晓，本版本不再提示
   settings_hint: 可在“设置 → BewlyCat界面 → 首页”中关闭“新版本提醒”。
+
+liquid_glass_upgrade_notice:
+  title: 毛玻璃与 Liquid Glass 现已默认开启
+  description: 如果遇到卡顿、耗电或视频增强异常，可前往“设置 → 外观 → 视觉效果”关闭。
+  acknowledge: 知道了
+
 watch_later:
   title: 稍后再看
   clear_all: 清空稍后再看

--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -176,7 +176,7 @@ settings:
   frosted_glass_blur_intensity: 毛玻璃模糊强度
   enable_liquid_glass: 启用 Liquid Glass 效果（实验性）
   enable_liquid_glass_desc: 在毛玻璃上增加液态高光、通透边缘和轻微流动效果。
-  liquid_glass_tint_intensity: Liquid Glass 着色强度
+  liquid_glass_tint_intensity: Liquid Glass 暗色着色强度
   disable_shadow: 禁用阴影
   link_opening_behavior_opt:
     current_tab: 当前标签页

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -174,7 +174,7 @@ settings:
   frosted_glass_blur_intensity: 毛玻璃模糊強度
   enable_liquid_glass: 啟用 Liquid Glass 效果（實驗性）
   enable_liquid_glass_desc: 在毛玻璃上增加液態高光、通透邊緣和輕微流動效果。
-  liquid_glass_tint_intensity: Liquid Glass 著色強度
+  liquid_glass_tint_intensity: Liquid Glass 深色著色強度
   disable_shadow: 停用陰影
   link_opening_behavior_opt:
     current_tab: 目前索引標籤

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -172,6 +172,9 @@ settings:
     Bilibili 預設會特別處理中文標點符號以達到左對齊。 如果你正在使用自訂字型，建議移除縮排。
   enable_frosted_glass: 啟用毛玻璃效果
   frosted_glass_blur_intensity: 毛玻璃模糊強度
+  enable_liquid_glass: 啟用 Liquid Glass 效果（實驗性）
+  enable_liquid_glass_desc: 在毛玻璃上增加液態高光、通透邊緣和輕微流動效果。
+  liquid_glass_tint_intensity: Liquid Glass 著色強度
   disable_shadow: 停用陰影
   link_opening_behavior_opt:
     current_tab: 目前索引標籤

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -901,6 +901,12 @@ version_reminder:
   bilibili_dynamic_desc: 查看開發者發佈的更新動態
   acknowledge: 已知曉，此版本不再提示
   settings_hint: 可在「設定 → BewlyCat 介面 → 首頁」中關閉「新版本提醒」。
+
+liquid_glass_upgrade_notice:
+  title: 毛玻璃與 Liquid Glass 現已預設開啟
+  description: 如果遇到卡頓、耗電或影片增強異常，可前往「設定 → 外觀 → 視覺效果」關閉。
+  acknowledge: 知道了
+
 watch_later:
   title: 稍後觀看
   clear_all: 清空稍後觀看

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -187,7 +187,7 @@ settings:
   frosted_glass_blur_intensity: Frosted glass blur intensity
   enable_liquid_glass: Enable Liquid Glass effect (experimental)
   enable_liquid_glass_desc: Adds fluid highlights, translucent edges, and subtle motion to frosted glass.
-  liquid_glass_tint_intensity: Liquid Glass tint intensity
+  liquid_glass_tint_intensity: Liquid Glass dark tint intensity
   disable_shadow: Disable shadow
   link_opening_behavior_opt:
     current_tab: Current tab

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -185,6 +185,9 @@ settings:
     the indent.
   enable_frosted_glass: Enable frosted glass effect
   frosted_glass_blur_intensity: Frosted glass blur intensity
+  enable_liquid_glass: Enable Liquid Glass effect (experimental)
+  enable_liquid_glass_desc: Adds fluid highlights, translucent edges, and subtle motion to frosted glass.
+  liquid_glass_tint_intensity: Liquid Glass tint intensity
   disable_shadow: Disable shadow
   link_opening_behavior_opt:
     current_tab: Current tab

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -964,6 +964,12 @@ version_reminder:
   bilibili_dynamic_desc: View update posts from the developer
   acknowledge: Got it, don't show this version again
   settings_hint: You can turn off “New version reminders” under Settings → BewlyCat Interface → Home.
+
+liquid_glass_upgrade_notice:
+  title: Frosted Glass and Liquid Glass are now enabled by default
+  description: If you notice lag, increased power use, or video enhancement issues, turn them off under Settings → Appearance → Visual Effects.
+  acknowledge: Got it
+
 watch_later:
   title: Watch Later
   clear_all: Clear all watch later

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -174,7 +174,7 @@ settings:
   frosted_glass_blur_intensity: 毛玻璃模糊強度
   enable_liquid_glass: 啓用 Liquid Glass 效果（實驗性）
   enable_liquid_glass_desc: 喺毛玻璃上增加液態高光、通透邊緣同輕微流動效果。
-  liquid_glass_tint_intensity: Liquid Glass 着色強度
+  liquid_glass_tint_intensity: Liquid Glass 深色着色強度
   disable_shadow: 閂咗陰影
   link_opening_behavior_opt:
     current_tab: 目前分頁

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -172,6 +172,9 @@ settings:
     Bilibili 預設會專登執吓中文標點符號，令到佢可以左對齊。如果你係用緊自訂字字型，最好係移除縮排。
   enable_frosted_glass: 啓用毛玻璃效果
   frosted_glass_blur_intensity: 毛玻璃模糊強度
+  enable_liquid_glass: 啓用 Liquid Glass 效果（實驗性）
+  enable_liquid_glass_desc: 喺毛玻璃上增加液態高光、通透邊緣同輕微流動效果。
+  liquid_glass_tint_intensity: Liquid Glass 着色強度
   disable_shadow: 閂咗陰影
   link_opening_behavior_opt:
     current_tab: 目前分頁

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -834,6 +834,12 @@ version_reminder:
   bilibili_dynamic_desc: 睇開發者發佈嘅更新動態
   acknowledge: 知道喇，呢個版本唔再提示
   settings_hint: 可以去「設定 → BewlyCat界面 → 主頁」閂咗「新版本提醒」。
+
+liquid_glass_upgrade_notice:
+  title: 毛玻璃同 Liquid Glass 而家預設開啓
+  description: 如果遇到窒、食電或者影片增強異常，可以去「設定 → 外觀 → 視覺效果」閂咗佢哋。
+  acknowledge: 知道喇
+
 watch_later:
   title: 陣間至睇
   clear_all: 剷曬陣間至睇啲片

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -2,13 +2,22 @@ import browser from 'webextension-polyfill'
 
 import { setupAppAuthScheduler } from './appAuthScheduler'
 import { setupContentScriptRecovery } from './contentScriptRecovery'
+import { initializeLiquidGlassUpgrade } from './liquidGlassUpgrade'
 import { setupApiMsgListeners } from './messageListeners/api'
 import { setupTabMsgListeners } from './messageListeners/tabs'
 import { initWbiKeys } from './wbiSign'
 
-// Initialize extension and set up message handlers
-browser.runtime.onInstalled.addListener(async () => {
-  console.log('Extension installed')
+browser.runtime.onInstalled.addListener((details) => {
+  const trigger = details.reason === 'install' ? 'install' : 'update'
+
+  void initializeLiquidGlassUpgrade(browser.storage.local, trigger).catch((error) => {
+    console.error('[BewlyCat] Liquid Glass 升级迁移失败:', error)
+  })
+})
+
+// 兼容已经加载过开发版本、但尚未写入独立提示状态的用户。
+void initializeLiquidGlassUpgrade(browser.storage.local, 'startup').catch((error) => {
+  console.error('[BewlyCat] Liquid Glass 升级提示初始化失败:', error)
 })
 
 // 扩展启动时初始化 WBI 密钥

--- a/src/background/liquidGlassUpgrade.ts
+++ b/src/background/liquidGlassUpgrade.ts
@@ -1,0 +1,69 @@
+import { LIQUID_GLASS_UPGRADE_NOTICE_STORAGE_KEY } from '~/constants/storageKeys'
+
+export type LiquidGlassUpgradeTrigger = 'install' | 'startup' | 'update'
+
+export interface LiquidGlassUpgradeStorage {
+  get: (keys: string[]) => Promise<Record<string, unknown>>
+  set: (items: Record<string, unknown>) => Promise<void>
+}
+
+export type LiquidGlassUpgradeResult = 'initialized' | 'notice-enabled' | 'unchanged'
+
+function enableGlassEffects(rawSettings: unknown): unknown {
+  if (typeof rawSettings === 'string') {
+    try {
+      const parsedSettings = JSON.parse(rawSettings) as unknown
+
+      if (typeof parsedSettings !== 'object' || parsedSettings == null || Array.isArray(parsedSettings))
+        return rawSettings
+
+      return JSON.stringify({
+        ...parsedSettings,
+        enableFrostedGlass: true,
+        enableLiquidGlass: true,
+      })
+    }
+    catch {
+      return rawSettings
+    }
+  }
+
+  if (typeof rawSettings === 'object' && rawSettings != null && !Array.isArray(rawSettings)) {
+    return {
+      ...rawSettings,
+      enableFrostedGlass: true,
+      enableLiquidGlass: true,
+    }
+  }
+
+  return rawSettings
+}
+
+export async function initializeLiquidGlassUpgrade(
+  storage: LiquidGlassUpgradeStorage,
+  trigger: LiquidGlassUpgradeTrigger,
+): Promise<LiquidGlassUpgradeResult> {
+  const storedValues = await storage.get([LIQUID_GLASS_UPGRADE_NOTICE_STORAGE_KEY, 'settings'])
+
+  if (Object.prototype.hasOwnProperty.call(storedValues, LIQUID_GLASS_UPGRADE_NOTICE_STORAGE_KEY))
+    return 'unchanged'
+
+  if (trigger === 'install') {
+    await storage.set({ [LIQUID_GLASS_UPGRADE_NOTICE_STORAGE_KEY]: false })
+    return 'initialized'
+  }
+
+  const hasStoredSettings = storedValues.settings != null
+  if (trigger === 'startup' && !hasStoredSettings)
+    return 'unchanged'
+
+  const updates: Record<string, unknown> = {
+    [LIQUID_GLASS_UPGRADE_NOTICE_STORAGE_KEY]: true,
+  }
+
+  if (hasStoredSettings)
+    updates.settings = enableGlassEffects(storedValues.settings)
+
+  await storage.set(updates)
+  return 'notice-enabled'
+}

--- a/src/components/SearchBar/SearchBar.vue
+++ b/src/components/SearchBar/SearchBar.vue
@@ -837,7 +837,7 @@ function handleClearKeyword() {
     }
 
     &.focus input {
-      --uno: "border-$bew-theme-color rounded-$bew-radius";
+      --uno: "border-$bew-theme-color rounded-60px";
       box-shadow:
         0 0 0 2px var(--bew-theme-color),
         0 6px 16px var(--bew-theme-color-40),

--- a/src/components/Settings/Appearance/Appearance.vue
+++ b/src/components/Settings/Appearance/Appearance.vue
@@ -3,7 +3,7 @@ import { useThrottleFn } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
 
 import Select from '~/components/Select.vue'
-import { FROSTED_GLASS_BLUR_MAX_PX, FROSTED_GLASS_BLUR_MIN_PX, localSettings, settings } from '~/logic'
+import { FROSTED_GLASS_BLUR_MAX_PX, FROSTED_GLASS_BLUR_MIN_PX, LIQUID_GLASS_TINT_MAX_PERCENT, LIQUID_GLASS_TINT_MIN_PERCENT, localSettings, settings } from '~/logic'
 
 import ChangeWallpaper from '../components/ChangeWallpaper.vue'
 import SettingsItem from '../components/SettingsItem.vue'
@@ -231,6 +231,32 @@ function changeWallpaper(url: string) {
             :min="FROSTED_GLASS_BLUR_MIN_PX"
             :max="FROSTED_GLASS_BLUR_MAX_PX"
             :label="`${settings.frostedGlassBlurIntensity}`"
+          />
+        </div>
+      </SettingsItem>
+      <SettingsItem
+        v-if="settings.enableFrostedGlass"
+        :title="$t('settings.enable_liquid_glass')"
+        right-width="auto"
+      >
+        <template #desc>
+          <span>{{ $t('settings.enable_liquid_glass_desc') }}</span>
+          <span color="$bew-warning-color"> {{ $t('common.performance_impact_warn') }}</span>
+        </template>
+
+        <Radio v-model="settings.enableLiquidGlass" />
+      </SettingsItem>
+      <SettingsItem
+        v-if="settings.enableFrostedGlass && settings.enableLiquidGlass"
+        :title="$t('settings.liquid_glass_tint_intensity')"
+        right-width="auto"
+      >
+        <div class="slider-control">
+          <Slider
+            v-model="settings.liquidGlassTintIntensity"
+            :min="LIQUID_GLASS_TINT_MIN_PERCENT"
+            :max="LIQUID_GLASS_TINT_MAX_PERCENT"
+            :label="`${settings.liquidGlassTintIntensity}%`"
           />
         </div>
       </SettingsItem>

--- a/src/components/TopBar/BewlyOrBiliTopBarSwitcher.vue
+++ b/src/components/TopBar/BewlyOrBiliTopBarSwitcher.vue
@@ -47,7 +47,7 @@ const topMargin = computed(() => {
       style="backdrop-filter: var(--bew-filter-glass-1);"
       pos="absolute"
       :class="isButtonVisible ? 'opacity-100' : 'opacity-0'"
-      class="pointer-events-auto"
+      class="pointer-events-auto liquid-glass-surface"
       :style="{
         transform: isButtonVisible ? 'translateY(0)' : 'translateY(-100%)',
       }"

--- a/src/components/TopBar/components/BewlyOrBiliPageSwitcher.vue
+++ b/src/components/TopBar/components/BewlyOrBiliPageSwitcher.vue
@@ -59,7 +59,7 @@ function switchPage(useOriginalBiliPage: boolean) {
 <template>
   <div
     v-if="showBewlyOrBiliPageSwitcher"
-    class="bewly-bili-switcher"
+    class="bewly-bili-switcher liquid-glass-surface"
     :class="{ 'disable-frosted-glass': !settings.enableFrostedGlass }"
     style="backdrop-filter: var(--bew-filter-glass-1);"
     flex="~ gap-1" bg="$bew-elevated" p-1 rounded-full

--- a/src/components/TopBar/components/TopBarPinnedChannels.vue
+++ b/src/components/TopBar/components/TopBarPinnedChannels.vue
@@ -175,7 +175,7 @@ function arraysEqual<T>(a: T[], b: T[]): boolean {
   <div
     v-if="validPinnedKeys.length"
     ref="containerRef"
-    class="pinned-channels"
+    class="pinned-channels liquid-glass-surface"
     :class="{ 'white-theme': props.forceWhiteIcon }"
   >
     <div ref="listRef" class="pinned-channels__list">

--- a/src/components/TopBar/components/TopBarSearch.vue
+++ b/src/components/TopBar/components/TopBarSearch.vue
@@ -15,7 +15,11 @@ const { searchKeyword } = storeToRefs(topBarStore)
 
 // 可以考虑添加一个计算属性来处理样式
 const searchBarStyles = computed(() => ({
-  '--b-search-bar-normal-color': settings.value.enableFrostedGlass ? 'color-mix(in oklab, var(--bew-elevated-solid), transparent 60%)' : 'var(--bew-elevated)',
+  '--b-search-bar-normal-color': settings.value.enableLiquidGlass
+    ? 'var(--bew-elevated)'
+    : settings.value.enableFrostedGlass
+      ? 'color-mix(in oklab, var(--bew-elevated-solid), transparent 60%)'
+      : 'var(--bew-elevated)',
   '--b-search-bar-hover-color': 'var(--bew-elevated-hover)',
   '--b-search-bar-focus-color': 'var(--bew-elevated)',
   '--b-search-bar-normal-icon-color': forceWhiteIcon.value && settings.value.enableFrostedGlass ? 'white' : 'var(--bew-text-1)',

--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -1,0 +1,1 @@
+export const LIQUID_GLASS_UPGRADE_NOTICE_STORAGE_KEY = 'liquidGlassUpgradeNoticePending'

--- a/src/contentScripts/views/Home/Home.vue
+++ b/src/contentScripts/views/Home/Home.vue
@@ -8,6 +8,7 @@ import type { HomeTab } from '~/stores/mainStore'
 import { useMainStore } from '~/stores/mainStore'
 import emitter from '~/utils/mitt'
 
+import LiquidGlassUpgradeNotice from './components/LiquidGlassUpgradeNotice.vue'
 import VersionReminder from './components/VersionReminder.vue'
 import type { GridLayoutIcon } from './types'
 import { HomeSubPage } from './types'
@@ -287,6 +288,7 @@ function toggleTabContentLoading(loading: boolean) {
       </Transition>
     </main>
 
+    <LiquidGlassUpgradeNotice />
     <VersionReminder />
   </div>
 </template>

--- a/src/contentScripts/views/Home/components/LiquidGlassUpgradeNotice.vue
+++ b/src/contentScripts/views/Home/components/LiquidGlassUpgradeNotice.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import { settings } from '~/logic'
+import { liquidGlassUpgradeNoticePending } from '~/logic'
 
-const visible = computed(() => !settings.value.liquidGlassPerformanceNoticeAcknowledged)
+const visible = computed(() => liquidGlassUpgradeNoticePending.value)
 
 function acknowledgeNotice() {
-  settings.value.liquidGlassPerformanceNoticeAcknowledged = true
+  liquidGlassUpgradeNoticePending.value = false
 }
 </script>
 

--- a/src/contentScripts/views/Home/components/LiquidGlassUpgradeNotice.vue
+++ b/src/contentScripts/views/Home/components/LiquidGlassUpgradeNotice.vue
@@ -36,8 +36,8 @@ function acknowledgeNotice() {
 <style scoped lang="scss">
 .liquid-glass-notice {
   position: fixed;
-  left: 24px;
-  bottom: 80px;
+  right: 24px;
+  bottom: max(24px, env(safe-area-inset-bottom, 0px));
   z-index: 51;
   display: grid;
   grid-template-columns: 24px minmax(0, 1fr) auto;
@@ -113,8 +113,8 @@ function acknowledgeNotice() {
 
 @media (max-width: 640px) {
   .liquid-glass-notice {
-    left: 16px;
-    bottom: 72px;
+    right: 16px;
+    bottom: max(16px, env(safe-area-inset-bottom, 0px));
     grid-template-columns: 24px minmax(0, 1fr);
     width: calc(100vw - 32px);
   }

--- a/src/contentScripts/views/Home/components/LiquidGlassUpgradeNotice.vue
+++ b/src/contentScripts/views/Home/components/LiquidGlassUpgradeNotice.vue
@@ -1,0 +1,127 @@
+<script setup lang="ts">
+import { settings } from '~/logic'
+
+const visible = computed(() => !settings.value.liquidGlassPerformanceNoticeAcknowledged)
+
+function acknowledgeNotice() {
+  settings.value.liquidGlassPerformanceNoticeAcknowledged = true
+}
+</script>
+
+<template>
+  <Transition name="liquid-glass-notice">
+    <aside
+      v-if="visible"
+      class="liquid-glass-notice"
+      role="status"
+    >
+      <span class="liquid-glass-notice__icon" i-mingcute:sparkles-2-line />
+
+      <div class="liquid-glass-notice__content">
+        <strong>{{ $t('liquid_glass_upgrade_notice.title') }}</strong>
+        <p>{{ $t('liquid_glass_upgrade_notice.description') }}</p>
+      </div>
+
+      <button
+        class="liquid-glass-notice__acknowledge"
+        type="button"
+        @click="acknowledgeNotice"
+      >
+        {{ $t('liquid_glass_upgrade_notice.acknowledge') }}
+      </button>
+    </aside>
+  </Transition>
+</template>
+
+<style scoped lang="scss">
+.liquid-glass-notice {
+  position: fixed;
+  left: 24px;
+  bottom: 80px;
+  z-index: 51;
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  width: min(560px, calc(100vw - 48px));
+  padding: 14px 16px;
+  color: var(--bew-text-1);
+  background: var(--bew-elevated);
+  border: 1px solid var(--bew-border-color);
+  border-radius: var(--bew-radius);
+  box-shadow: var(--bew-shadow-edge-glow-1), var(--bew-shadow-3);
+  backdrop-filter: var(--bew-filter-glass-1);
+}
+
+.liquid-glass-notice__icon {
+  width: 24px;
+  height: 24px;
+  color: var(--bew-theme-color);
+}
+
+.liquid-glass-notice__content {
+  min-width: 0;
+}
+
+.liquid-glass-notice__content strong {
+  display: block;
+  font-size: 14px;
+}
+
+.liquid-glass-notice__content p {
+  margin: 4px 0 0;
+  color: var(--bew-text-2);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.liquid-glass-notice__acknowledge {
+  padding: 7px 12px;
+  color: white;
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+  background: var(--bew-theme-color);
+  border: 1px solid var(--bew-theme-color);
+  border-radius: var(--bew-radius-half);
+  cursor: pointer;
+  transition:
+    opacity 160ms ease,
+    transform 160ms ease;
+}
+
+.liquid-glass-notice__acknowledge:hover {
+  opacity: 0.84;
+}
+
+.liquid-glass-notice__acknowledge:active {
+  transform: scale(0.96);
+}
+
+.liquid-glass-notice-enter-active,
+.liquid-glass-notice-leave-active {
+  transition:
+    opacity 180ms ease,
+    transform 180ms ease;
+}
+
+.liquid-glass-notice-enter-from,
+.liquid-glass-notice-leave-to {
+  opacity: 0;
+  transform: translateY(12px);
+}
+
+@media (max-width: 640px) {
+  .liquid-glass-notice {
+    left: 16px;
+    bottom: 72px;
+    grid-template-columns: 24px minmax(0, 1fr);
+    width: calc(100vw - 32px);
+  }
+
+  .liquid-glass-notice__acknowledge {
+    grid-column: 1 / -1;
+    width: 100%;
+  }
+}
+</style>

--- a/src/contentScripts/views/WatchLater/WatchLater.vue
+++ b/src/contentScripts/views/WatchLater/WatchLater.vue
@@ -194,7 +194,7 @@ function handleOpenVideoPageAndRemove(index: number, bvid: string, aid: number) 
 </script>
 
 <template>
-  <div v-if="getCSRF()" flex="~ col md:row lg:row" gap-4>
+  <div v-if="getCSRF()" class="watch-later-page" flex="~ col md:row lg:row" gap-4>
     <main w="full md:60% lg:70% xl:75%" order="2 md:1 lg:1" mb-6>
       <h3 text="3xl $bew-text-1" font-bold mb-6>
         {{ t('watch_later.title') }} ({{ watchLaterCount }})
@@ -212,6 +212,7 @@ function handleOpenVideoPageAndRemove(index: number, bvid: string, aid: number) 
             flex cursor-pointer
           >
             <section
+              class="watch-later-card liquid-glass-surface"
               rounded="$bew-radius"
               flex="~ gap-6 col md:col lg:row items-start"
               relative
@@ -400,6 +401,7 @@ function handleOpenVideoPageAndRemove(index: number, bvid: string, aid: number) 
 
         <!-- Content -->
         <main
+          class="watch-later-summary liquid-glass-surface"
           pos="absolute top-0 left-0"
           w-full h-inherit
           overflow-overlay
@@ -461,4 +463,8 @@ function handleOpenVideoPageAndRemove(index: number, bvid: string, aid: number) 
 </template>
 
 <style lang="scss" scoped>
+.watch-later-card,
+.watch-later-summary {
+  background-color: var(--bew-content);
+}
 </style>

--- a/src/contentScripts/views/necessarySettingsWatchers.ts
+++ b/src/contentScripts/views/necessarySettingsWatchers.ts
@@ -3,7 +3,7 @@ import { useI18n } from 'vue-i18n'
 import { IFRAME_TOP_BAR_CHANGE } from '~/constants/globalEvents'
 import { setUselessFeedCardBlockerEnabled } from '~/contentScripts/features/blockUselessFeedCards'
 import { LanguageType } from '~/enums/appEnums'
-import { appAuthTokens, FROSTED_GLASS_BLUR_MAX_PX, FROSTED_GLASS_BLUR_MIN_PX, localSettings, originalSettings, settings } from '~/logic'
+import { appAuthTokens, FROSTED_GLASS_BLUR_MAX_PX, FROSTED_GLASS_BLUR_MIN_PX, LIQUID_GLASS_TINT_MAX_PERCENT, LIQUID_GLASS_TINT_MIN_PERCENT, localSettings, originalSettings, settings } from '~/logic'
 import { resetBilibiliTopBarInlineStyles, setOriginalBilibiliTopBarScrolled } from '~/utils/bilibiliTopBar'
 import { cleanBilibiliShareText, getUserID, injectCSS, isHomePage, isInIframe, isVideoPlaybackPage } from '~/utils/main'
 
@@ -24,6 +24,41 @@ export function setupNecessarySettingsWatchers() {
       return DEFAULT_FROSTED_GLASS_BLUR_PX
 
     return Math.min(FROSTED_GLASS_BLUR_MAX_PX, Math.max(FROSTED_GLASS_BLUR_MIN_PX, value))
+  }
+
+  const clampLiquidGlassTint = (value: number) => {
+    if (!Number.isFinite(value))
+      return originalSettings.liquidGlassTintIntensity
+
+    return Math.min(LIQUID_GLASS_TINT_MAX_PERCENT, Math.max(LIQUID_GLASS_TINT_MIN_PERCENT, value))
+  }
+
+  const applyLiquidGlassTint = (rawValue: number) => {
+    const tintRatio = clampLiquidGlassTint(rawValue) / LIQUID_GLASS_TINT_MAX_PERCENT
+    const bewlyElement = document.querySelector('#bewly') as HTMLElement | null
+    const targets: HTMLElement[] = [document.documentElement]
+    const mixAlpha = (minimum: number, range: number) => (minimum + range * tintRatio).toFixed(3)
+    const variables = {
+      '--bew-liquid-glass-content-alpha': mixAlpha(0.08, 0.36),
+      '--bew-liquid-glass-content-hover-alpha': mixAlpha(0.14, 0.42),
+      '--bew-liquid-glass-content-alt-alpha': mixAlpha(0.08, 0.32),
+      '--bew-liquid-glass-content-alt-hover-alpha': mixAlpha(0.14, 0.38),
+      '--bew-liquid-glass-elevated-alpha': mixAlpha(0.1, 0.38),
+      '--bew-liquid-glass-elevated-hover-alpha': mixAlpha(0.16, 0.42),
+      '--bew-liquid-glass-elevated-alt-alpha': mixAlpha(0.09, 0.36),
+      '--bew-liquid-glass-elevated-alt-hover-alpha': mixAlpha(0.15, 0.4),
+      '--bew-liquid-glass-fill-alt-alpha': mixAlpha(0.06, 0.18),
+      '--bew-liquid-glass-border-alpha': mixAlpha(0.14, 0.14),
+      '--bew-liquid-glass-sheen-strong-alpha': mixAlpha(0.06, 0.12),
+      '--bew-liquid-glass-sheen-weak-alpha': mixAlpha(0.03, 0.08),
+    }
+
+    if (bewlyElement)
+      targets.push(bewlyElement)
+
+    targets.forEach((element) => {
+      Object.entries(variables).forEach(([property, value]) => element.style.setProperty(property, value))
+    })
   }
 
   // Chromium routes videos through a different compositor path when a page uses
@@ -48,12 +83,15 @@ export function setupNecessarySettingsWatchers() {
       return
     }
 
-    const blur1Value = `blur(${clampedValue}px) saturate(180%)`
+    const liquidGlassFilter = settings.value.enableLiquidGlass
+      ? 'saturate(210%) contrast(108%) brightness(104%)'
+      : 'saturate(180%)'
+    const blur1Value = `blur(${clampedValue}px) ${liquidGlassFilter}`
     const dialogBlur = clampedValue === 0 ? 0 : clampedValue + FROSTED_GLASS_DIALOG_OFFSET_PX
-    const blur2Value = `blur(${dialogBlur}px) saturate(180%)`
+    const blur2Value = `blur(${dialogBlur}px) ${liquidGlassFilter}`
 
     targets.forEach((element) => {
-      if (Math.abs(clampedValue - DEFAULT_FROSTED_GLASS_BLUR_PX) < 0.01) {
+      if (!settings.value.enableLiquidGlass && Math.abs(clampedValue - DEFAULT_FROSTED_GLASS_BLUR_PX) < 0.01) {
         element.style.removeProperty('--bew-filter-glass-1')
         element.style.removeProperty('--bew-filter-glass-2')
       }
@@ -67,9 +105,12 @@ export function setupNecessarySettingsWatchers() {
   const applyFrostedGlassState = () => {
     const bewlyElement = document.querySelector('#bewly') as HTMLElement | null
     const shouldDisable = !isFrostedGlassActive()
+    const shouldEnableLiquidGlass = !shouldDisable && settings.value.enableLiquidGlass
 
     bewlyElement?.classList.toggle('disable-frosted-glass', shouldDisable)
+    bewlyElement?.classList.toggle('enable-liquid-glass', shouldEnableLiquidGlass)
     document.documentElement.classList.toggle('disable-frosted-glass', shouldDisable)
+    document.documentElement.classList.toggle('enable-liquid-glass', shouldEnableLiquidGlass)
     applyFrostedGlassBlur(settings.value.frostedGlassBlurIntensity)
   }
 
@@ -188,6 +229,7 @@ export function setupNecessarySettingsWatchers() {
   watch(
     [
       () => settings.value.enableFrostedGlass,
+      () => settings.value.enableLiquidGlass,
       () => settings.value.nvidiaRtxVideoEnhancementCompatibility,
     ],
     applyFrostedGlassState,
@@ -205,6 +247,21 @@ export function setupNecessarySettingsWatchers() {
       }
 
       applyFrostedGlassBlur(clamped)
+    },
+    { immediate: true },
+  )
+
+  watch(
+    () => settings.value.liquidGlassTintIntensity,
+    (value) => {
+      const clamped = clampLiquidGlassTint(value)
+
+      if (clamped !== value) {
+        settings.value.liquidGlassTintIntensity = clamped
+        return
+      }
+
+      applyLiquidGlassTint(clamped)
     },
     { immediate: true },
   )

--- a/src/contentScripts/views/necessarySettingsWatchers.ts
+++ b/src/contentScripts/views/necessarySettingsWatchers.ts
@@ -37,27 +37,28 @@ export function setupNecessarySettingsWatchers() {
     const tintRatio = clampLiquidGlassTint(rawValue) / LIQUID_GLASS_TINT_MAX_PERCENT
     const bewlyElement = document.querySelector('#bewly') as HTMLElement | null
     const targets: HTMLElement[] = [document.documentElement]
-    const mixAlpha = (minimum: number, range: number) => (minimum + range * tintRatio).toFixed(3)
-    const variables = {
-      '--bew-liquid-glass-content-alpha': mixAlpha(0.08, 0.36),
-      '--bew-liquid-glass-content-hover-alpha': mixAlpha(0.14, 0.42),
-      '--bew-liquid-glass-content-alt-alpha': mixAlpha(0.08, 0.32),
-      '--bew-liquid-glass-content-alt-hover-alpha': mixAlpha(0.14, 0.38),
-      '--bew-liquid-glass-elevated-alpha': mixAlpha(0.1, 0.38),
-      '--bew-liquid-glass-elevated-hover-alpha': mixAlpha(0.16, 0.42),
-      '--bew-liquid-glass-elevated-alt-alpha': mixAlpha(0.09, 0.36),
-      '--bew-liquid-glass-elevated-alt-hover-alpha': mixAlpha(0.15, 0.4),
-      '--bew-liquid-glass-fill-alt-alpha': mixAlpha(0.06, 0.18),
-      '--bew-liquid-glass-border-alpha': mixAlpha(0.14, 0.14),
-      '--bew-liquid-glass-sheen-strong-alpha': mixAlpha(0.06, 0.12),
-      '--bew-liquid-glass-sheen-weak-alpha': mixAlpha(0.03, 0.08),
-    }
+    const darkenAlpha = (0.22 * tintRatio).toFixed(3)
+    const legacySurfaceAlphaProperties = [
+      '--bew-liquid-glass-content-alpha',
+      '--bew-liquid-glass-content-hover-alpha',
+      '--bew-liquid-glass-content-alt-alpha',
+      '--bew-liquid-glass-content-alt-hover-alpha',
+      '--bew-liquid-glass-elevated-alpha',
+      '--bew-liquid-glass-elevated-hover-alpha',
+      '--bew-liquid-glass-elevated-alt-alpha',
+      '--bew-liquid-glass-elevated-alt-hover-alpha',
+      '--bew-liquid-glass-fill-alt-alpha',
+      '--bew-liquid-glass-border-alpha',
+      '--bew-liquid-glass-sheen-strong-alpha',
+      '--bew-liquid-glass-sheen-weak-alpha',
+    ]
 
     if (bewlyElement)
       targets.push(bewlyElement)
 
     targets.forEach((element) => {
-      Object.entries(variables).forEach(([property, value]) => element.style.setProperty(property, value))
+      legacySurfaceAlphaProperties.forEach(property => element.style.removeProperty(property))
+      element.style.setProperty('--bew-liquid-glass-darken-alpha', darkenAlpha)
     })
   }
 

--- a/src/contentScripts/views/necessarySettingsWatchers.ts
+++ b/src/contentScripts/views/necessarySettingsWatchers.ts
@@ -3,7 +3,7 @@ import { useI18n } from 'vue-i18n'
 import { IFRAME_TOP_BAR_CHANGE } from '~/constants/globalEvents'
 import { setUselessFeedCardBlockerEnabled } from '~/contentScripts/features/blockUselessFeedCards'
 import { LanguageType } from '~/enums/appEnums'
-import { appAuthTokens, FROSTED_GLASS_BLUR_MAX_PX, FROSTED_GLASS_BLUR_MIN_PX, LIQUID_GLASS_TINT_MAX_PERCENT, LIQUID_GLASS_TINT_MIN_PERCENT, localSettings, originalSettings, settings } from '~/logic'
+import { appAuthTokens, FROSTED_GLASS_BLUR_MAX_PX, FROSTED_GLASS_BLUR_MIN_PX, LIQUID_GLASS_TINT_FULL_PERCENT, LIQUID_GLASS_TINT_MAX_PERCENT, LIQUID_GLASS_TINT_MIN_PERCENT, localSettings, originalSettings, settings } from '~/logic'
 import { resetBilibiliTopBarInlineStyles, setOriginalBilibiliTopBarScrolled } from '~/utils/bilibiliTopBar'
 import { cleanBilibiliShareText, getUserID, injectCSS, isHomePage, isInIframe, isVideoPlaybackPage } from '~/utils/main'
 
@@ -34,10 +34,12 @@ export function setupNecessarySettingsWatchers() {
   }
 
   const applyLiquidGlassTint = (rawValue: number) => {
-    const tintRatio = clampLiquidGlassTint(rawValue) / LIQUID_GLASS_TINT_MAX_PERCENT
+    const clampedTint = clampLiquidGlassTint(rawValue)
+    const tintRatio = clampedTint / LIQUID_GLASS_TINT_FULL_PERCENT
     const bewlyElement = document.querySelector('#bewly') as HTMLElement | null
     const targets: HTMLElement[] = [document.documentElement]
     const darkenAlpha = (0.22 * tintRatio).toFixed(3)
+    const backdropBrightness = Math.max(35, 100 - clampedTint * 0.45).toFixed(1)
     const legacySurfaceAlphaProperties = [
       '--bew-liquid-glass-content-alpha',
       '--bew-liquid-glass-content-hover-alpha',
@@ -59,6 +61,7 @@ export function setupNecessarySettingsWatchers() {
     targets.forEach((element) => {
       legacySurfaceAlphaProperties.forEach(property => element.style.removeProperty(property))
       element.style.setProperty('--bew-liquid-glass-darken-alpha', darkenAlpha)
+      element.style.setProperty('--bew-liquid-glass-backdrop-brightness', `${backdropBrightness}%`)
     })
   }
 
@@ -85,7 +88,7 @@ export function setupNecessarySettingsWatchers() {
     }
 
     const liquidGlassFilter = settings.value.enableLiquidGlass
-      ? 'saturate(210%) contrast(108%) brightness(104%)'
+      ? 'saturate(185%) contrast(108%) brightness(var(--bew-liquid-glass-backdrop-brightness, 55%))'
       : 'saturate(180%)'
     const blur1Value = `blur(${clampedValue}px) ${liquidGlassFilter}`
     const dialogBlur = clampedValue === 0 ? 0 : clampedValue + FROSTED_GLASS_DIALOG_OFFSET_PX

--- a/src/logic/storage.ts
+++ b/src/logic/storage.ts
@@ -69,6 +69,8 @@ export function resetAppAuthTokens() {
 
 export const FROSTED_GLASS_BLUR_MIN_PX = 1
 export const FROSTED_GLASS_BLUR_MAX_PX = 20
+export const LIQUID_GLASS_TINT_MIN_PERCENT = 0
+export const LIQUID_GLASS_TINT_MAX_PERCENT = 100
 
 // 快捷键基础配置接口
 export interface BaseShortcutSetting {
@@ -190,6 +192,8 @@ export interface Settings {
   removeTheIndentFromChinesePunctuation: boolean
 
   enableFrostedGlass: boolean
+  enableLiquidGlass: boolean
+  liquidGlassTintIntensity: number
   frostedGlassBlurIntensity: number
   disableShadow: boolean
 
@@ -416,6 +420,8 @@ export const originalSettings: Settings = {
   removeTheIndentFromChinesePunctuation: false,
 
   enableFrostedGlass: false,
+  enableLiquidGlass: false,
+  liquidGlassTintIntensity: 30,
   frostedGlassBlurIntensity: 20,
   disableShadow: false,
 
@@ -663,6 +669,15 @@ watch(
 
     if (!Number.isFinite(record.frostedGlassBlurIntensity))
       record.frostedGlassBlurIntensity = originalSettings.frostedGlassBlurIntensity
+
+    if (!Number.isFinite(record.liquidGlassTintIntensity))
+      record.liquidGlassTintIntensity = originalSettings.liquidGlassTintIntensity
+
+    if (record.liquidGlassTintIntensity < LIQUID_GLASS_TINT_MIN_PERCENT)
+      record.liquidGlassTintIntensity = LIQUID_GLASS_TINT_MIN_PERCENT
+
+    if (record.liquidGlassTintIntensity > LIQUID_GLASS_TINT_MAX_PERCENT)
+      record.liquidGlassTintIntensity = LIQUID_GLASS_TINT_MAX_PERCENT
 
     if ('reduceFrostedGlassBlur' in record) {
       if (record.reduceFrostedGlassBlur === true && record.frostedGlassBlurIntensity === originalSettings.frostedGlassBlurIntensity)

--- a/src/logic/storage.ts
+++ b/src/logic/storage.ts
@@ -71,7 +71,8 @@ export function resetAppAuthTokens() {
 export const FROSTED_GLASS_BLUR_MIN_PX = 1
 export const FROSTED_GLASS_BLUR_MAX_PX = 20
 export const LIQUID_GLASS_TINT_MIN_PERCENT = 0
-export const LIQUID_GLASS_TINT_MAX_PERCENT = 100
+export const LIQUID_GLASS_TINT_FULL_PERCENT = 100
+export const LIQUID_GLASS_TINT_MAX_PERCENT = 200
 
 // 快捷键基础配置接口
 export interface BaseShortcutSetting {
@@ -422,8 +423,8 @@ export const originalSettings: Settings = {
 
   enableFrostedGlass: true,
   enableLiquidGlass: true,
-  liquidGlassTintIntensity: 30,
-  frostedGlassBlurIntensity: 20,
+  liquidGlassTintIntensity: 53,
+  frostedGlassBlurIntensity: 14,
   disableShadow: false,
 
   // Link Opening Behavior

--- a/src/logic/storage.ts
+++ b/src/logic/storage.ts
@@ -3,6 +3,7 @@ import browser from 'webextension-polyfill'
 
 import { useStorageLocal } from '~/composables/useStorageLocal'
 import type { wallpaperItem } from '~/constants/imgs'
+import { LIQUID_GLASS_UPGRADE_NOTICE_STORAGE_KEY } from '~/constants/storageKeys'
 import type { HomeSubPage } from '~/contentScripts/views/Home/types'
 import type { AppPage } from '~/enums/appEnums'
 import { VideoPageTopBarConfig } from '~/enums/appEnums'
@@ -193,7 +194,6 @@ export interface Settings {
 
   enableFrostedGlass: boolean
   enableLiquidGlass: boolean
-  liquidGlassPerformanceNoticeAcknowledged: boolean
   liquidGlassTintIntensity: number
   frostedGlassBlurIntensity: number
   disableShadow: boolean
@@ -422,7 +422,6 @@ export const originalSettings: Settings = {
 
   enableFrostedGlass: true,
   enableLiquidGlass: true,
-  liquidGlassPerformanceNoticeAcknowledged: true,
   liquidGlassTintIntensity: 30,
   frostedGlassBlurIntensity: 20,
   disableShadow: false,
@@ -661,7 +660,6 @@ export const settingsReady = new Promise<Settings>((resolve) => {
 export function mergeSettingsWithDefaults(storedValue: Settings, defaults: Settings): Settings {
   const storedRecord = storedValue as unknown as Record<string, unknown>
   const hasLiquidGlassSetting = 'enableLiquidGlass' in storedRecord
-  const hasPerformanceNoticeState = typeof storedRecord.liquidGlassPerformanceNoticeAcknowledged === 'boolean'
 
   return {
     ...defaults,
@@ -672,11 +670,14 @@ export function mergeSettingsWithDefaults(storedValue: Settings, defaults: Setti
           enableLiquidGlass: true,
         }
       : {}),
-    liquidGlassPerformanceNoticeAcknowledged: hasPerformanceNoticeState
-      ? storedRecord.liquidGlassPerformanceNoticeAcknowledged as boolean
-      : hasLiquidGlassSetting,
   }
 }
+
+export const liquidGlassUpgradeNoticePending = useStorageLocal(
+  LIQUID_GLASS_UPGRADE_NOTICE_STORAGE_KEY,
+  false,
+  { writeDefaults: false },
+)
 
 export const settings = useStorageLocal('settings', originalSettings, {
   mergeDefaults: mergeSettingsWithDefaults,

--- a/src/logic/storage.ts
+++ b/src/logic/storage.ts
@@ -193,6 +193,7 @@ export interface Settings {
 
   enableFrostedGlass: boolean
   enableLiquidGlass: boolean
+  liquidGlassPerformanceNoticeAcknowledged: boolean
   liquidGlassTintIntensity: number
   frostedGlassBlurIntensity: number
   disableShadow: boolean
@@ -419,8 +420,9 @@ export const originalSettings: Settings = {
   overrideDanmakuFont: true,
   removeTheIndentFromChinesePunctuation: false,
 
-  enableFrostedGlass: false,
-  enableLiquidGlass: false,
+  enableFrostedGlass: true,
+  enableLiquidGlass: true,
+  liquidGlassPerformanceNoticeAcknowledged: true,
   liquidGlassTintIntensity: 30,
   frostedGlassBlurIntensity: 20,
   disableShadow: false,
@@ -656,8 +658,28 @@ export const settingsReady = new Promise<Settings>((resolve) => {
   resolveSettingsReady = resolve
 })
 
+export function mergeSettingsWithDefaults(storedValue: Settings, defaults: Settings): Settings {
+  const storedRecord = storedValue as unknown as Record<string, unknown>
+  const hasLiquidGlassSetting = 'enableLiquidGlass' in storedRecord
+  const hasPerformanceNoticeState = typeof storedRecord.liquidGlassPerformanceNoticeAcknowledged === 'boolean'
+
+  return {
+    ...defaults,
+    ...storedValue,
+    ...(!hasLiquidGlassSetting
+      ? {
+          enableFrostedGlass: true,
+          enableLiquidGlass: true,
+        }
+      : {}),
+    liquidGlassPerformanceNoticeAcknowledged: hasPerformanceNoticeState
+      ? storedRecord.liquidGlassPerformanceNoticeAcknowledged as boolean
+      : hasLiquidGlassSetting,
+  }
+}
+
 export const settings = useStorageLocal('settings', originalSettings, {
-  mergeDefaults: true,
+  mergeDefaults: mergeSettingsWithDefaults,
   writeDefaults: false,
   onReady: value => resolveSettingsReady(value),
 })

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,4 +1,5 @@
 import './variables.scss'
+import './liquidGlass.scss'
 import './main.scss'
 import './adaptedStyles'
 import './transitionAndTransitionGroup.scss'

--- a/src/styles/liquidGlass.scss
+++ b/src/styles/liquidGlass.scss
@@ -107,6 +107,7 @@
     .settings-content,
     .dock-content-inner,
     .bew-popover,
+    .liquid-glass-notice,
     .liquid-glass-surface,
     #search-wrap .search-bar input
   ) {
@@ -153,6 +154,7 @@
       .settings-content,
       .dock-content-inner,
       .bew-popover,
+      .liquid-glass-notice,
       .liquid-glass-surface,
       #search-wrap .search-bar input
     ) {

--- a/src/styles/liquidGlass.scss
+++ b/src/styles/liquidGlass.scss
@@ -1,18 +1,18 @@
 :host(.enable-liquid-glass:not(.disable-frosted-glass)),
 :root.enable-liquid-glass:not(.disable-frosted-glass) {
-  --bew-liquid-glass-content-alpha: 0.188;
-  --bew-liquid-glass-content-hover-alpha: 0.266;
-  --bew-liquid-glass-content-alt-alpha: 0.176;
-  --bew-liquid-glass-content-alt-hover-alpha: 0.254;
-  --bew-liquid-glass-elevated-alpha: 0.214;
-  --bew-liquid-glass-elevated-hover-alpha: 0.286;
-  --bew-liquid-glass-elevated-alt-alpha: 0.198;
-  --bew-liquid-glass-elevated-alt-hover-alpha: 0.27;
-  --bew-liquid-glass-fill-alt-alpha: 0.114;
-  --bew-liquid-glass-border-alpha: 0.182;
-  --bew-liquid-glass-sheen-strong-alpha: 0.096;
-  --bew-liquid-glass-sheen-weak-alpha: 0.054;
-  --bew-liquid-glass-darken-alpha: 0.065;
+  --bew-liquid-glass-content-alpha: 0.08;
+  --bew-liquid-glass-content-hover-alpha: 0.14;
+  --bew-liquid-glass-content-alt-alpha: 0.08;
+  --bew-liquid-glass-content-alt-hover-alpha: 0.14;
+  --bew-liquid-glass-elevated-alpha: 0.1;
+  --bew-liquid-glass-elevated-hover-alpha: 0.16;
+  --bew-liquid-glass-elevated-alt-alpha: 0.09;
+  --bew-liquid-glass-elevated-alt-hover-alpha: 0.15;
+  --bew-liquid-glass-fill-alt-alpha: 0.06;
+  --bew-liquid-glass-border-alpha: 0.14;
+  --bew-liquid-glass-sheen-strong-alpha: 0.06;
+  --bew-liquid-glass-sheen-weak-alpha: 0.03;
+  --bew-liquid-glass-darken-alpha: 0.066;
   --bew-content-opacity: var(--bew-liquid-glass-content-alpha);
   --bew-content: rgb(255 255 255 / var(--bew-liquid-glass-content-alpha));
   --bew-content-hover: rgb(255 255 255 / var(--bew-liquid-glass-content-hover-alpha));
@@ -49,7 +49,7 @@
 
 :host(.enable-liquid-glass.dark:not(.disable-frosted-glass)),
 :root.enable-liquid-glass.dark:not(.disable-frosted-glass) {
-  --bew-liquid-glass-darken-alpha: 0.1;
+  --bew-liquid-glass-darken-alpha: 0.066;
   --bew-content: rgb(
     from color-mix(in oklab, var(--bew-dark-base-color), white 8%) r g b / var(--bew-liquid-glass-content-alpha)
   );

--- a/src/styles/liquidGlass.scss
+++ b/src/styles/liquidGlass.scss
@@ -1,0 +1,178 @@
+:host(.enable-liquid-glass:not(.disable-frosted-glass)),
+:root.enable-liquid-glass:not(.disable-frosted-glass) {
+  --bew-liquid-glass-content-alpha: 0.188;
+  --bew-liquid-glass-content-hover-alpha: 0.266;
+  --bew-liquid-glass-content-alt-alpha: 0.176;
+  --bew-liquid-glass-content-alt-hover-alpha: 0.254;
+  --bew-liquid-glass-elevated-alpha: 0.214;
+  --bew-liquid-glass-elevated-hover-alpha: 0.286;
+  --bew-liquid-glass-elevated-alt-alpha: 0.198;
+  --bew-liquid-glass-elevated-alt-hover-alpha: 0.27;
+  --bew-liquid-glass-fill-alt-alpha: 0.114;
+  --bew-liquid-glass-border-alpha: 0.182;
+  --bew-liquid-glass-sheen-strong-alpha: 0.096;
+  --bew-liquid-glass-sheen-weak-alpha: 0.054;
+  --bew-liquid-glass-darken-alpha: 0.065;
+  --bew-content-opacity: var(--bew-liquid-glass-content-alpha);
+  --bew-content: rgb(255 255 255 / var(--bew-liquid-glass-content-alpha));
+  --bew-content-hover: rgb(255 255 255 / var(--bew-liquid-glass-content-hover-alpha));
+  --bew-content-alt: rgb(244 247 255 / var(--bew-liquid-glass-content-alt-alpha));
+  --bew-content-alt-hover: rgb(238 243 255 / var(--bew-liquid-glass-content-alt-hover-alpha));
+  --bew-elevated: rgb(255 255 255 / var(--bew-liquid-glass-elevated-alpha));
+  --bew-elevated-hover: rgb(255 255 255 / var(--bew-liquid-glass-elevated-hover-alpha));
+  --bew-elevated-alt: rgb(248 250 255 / var(--bew-liquid-glass-elevated-alt-alpha));
+  --bew-elevated-alt-hover: rgb(244 248 255 / var(--bew-liquid-glass-elevated-alt-hover-alpha));
+  --bew-fill-alt: rgb(255 255 255 / var(--bew-liquid-glass-fill-alt-alpha));
+  --bew-border-color: rgb(255 255 255 / var(--bew-liquid-glass-border-alpha));
+  --bew-shadow-edge-glow-1:
+    inset 0 0.5px 0.35px rgb(255 255 255 / 48%), inset 0.5px 0 0.35px rgb(255 255 255 / 26%),
+    inset 0 -0.5px 0.45px color-mix(in oklab, var(--bew-theme-color), transparent 88%),
+    inset -0.5px 0 0.45px rgb(96 165 250 / 10%), inset 0 0 8px rgb(255 255 255 / 7%);
+  --bew-shadow-edge-glow-2:
+    inset 0 0.75px 0.5px rgb(255 255 255 / 54%), inset 0.75px 0 0.5px rgb(255 255 255 / 30%),
+    inset 0 -0.75px 0.6px color-mix(in oklab, var(--bew-theme-color), transparent 85%),
+    inset -0.75px 0 0.6px rgb(96 165 250 / 12%), inset 0 0 12px rgb(255 255 255 / 9%);
+  --bew-liquid-glass-sheen:
+    linear-gradient(
+      rgb(10 14 22 / var(--bew-liquid-glass-darken-alpha)),
+      rgb(10 14 22 / var(--bew-liquid-glass-darken-alpha))
+    ),
+    radial-gradient(circle at 16% 0%, rgb(255 255 255 / var(--bew-liquid-glass-sheen-strong-alpha)), transparent 38%),
+    linear-gradient(
+      135deg,
+      rgb(255 255 255 / var(--bew-liquid-glass-sheen-weak-alpha)) 0%,
+      transparent 38%,
+      color-mix(in oklab, var(--bew-theme-color), transparent 95%) 72%,
+      rgb(255 255 255 / var(--bew-liquid-glass-sheen-weak-alpha)) 100%
+    );
+}
+
+:host(.enable-liquid-glass.dark:not(.disable-frosted-glass)),
+:root.enable-liquid-glass.dark:not(.disable-frosted-glass) {
+  --bew-liquid-glass-darken-alpha: 0.1;
+  --bew-content: rgb(
+    from color-mix(in oklab, var(--bew-dark-base-color), white 8%) r g b / var(--bew-liquid-glass-content-alpha)
+  );
+  --bew-content-hover: rgb(
+    from color-mix(in oklab, var(--bew-dark-base-color), white 14%) r g b / var(--bew-liquid-glass-content-hover-alpha)
+  );
+  --bew-content-alt: rgb(
+    from color-mix(in oklab, var(--bew-dark-base-color), white 10%) r g b / var(--bew-liquid-glass-content-alt-alpha)
+  );
+  --bew-content-alt-hover: rgb(
+    from color-mix(in oklab, var(--bew-dark-base-color), white 16%) r g b /
+      var(--bew-liquid-glass-content-alt-hover-alpha)
+  );
+  --bew-elevated: rgb(
+    from color-mix(in oklab, var(--bew-dark-base-color), white 14%) r g b / var(--bew-liquid-glass-elevated-alpha)
+  );
+  --bew-elevated-hover: rgb(
+    from color-mix(in oklab, var(--bew-dark-base-color), white 20%) r g b / var(--bew-liquid-glass-elevated-hover-alpha)
+  );
+  --bew-elevated-alt: rgb(
+    from color-mix(in oklab, var(--bew-dark-base-color), white 16%) r g b / var(--bew-liquid-glass-elevated-alt-alpha)
+  );
+  --bew-elevated-alt-hover: rgb(
+    from color-mix(in oklab, var(--bew-dark-base-color), white 22%) r g b /
+      var(--bew-liquid-glass-elevated-alt-hover-alpha)
+  );
+  --bew-fill-alt: rgb(255 255 255 / var(--bew-liquid-glass-fill-alt-alpha));
+  --bew-border-color: rgb(255 255 255 / var(--bew-liquid-glass-border-alpha));
+  --bew-shadow-edge-glow-1:
+    inset 0 0.5px 0.35px rgb(255 255 255 / 20%), inset 0.5px 0 0.35px rgb(255 255 255 / 10%),
+    inset 0 -0.5px 0.45px color-mix(in oklab, var(--bew-theme-color), transparent 88%),
+    inset -0.5px 0 0.45px rgb(96 165 250 / 8%), inset 0 0 8px rgb(255 255 255 / 3%);
+  --bew-shadow-edge-glow-2:
+    inset 0 0.75px 0.5px rgb(255 255 255 / 24%), inset 0.75px 0 0.5px rgb(255 255 255 / 12%),
+    inset 0 -0.75px 0.6px color-mix(in oklab, var(--bew-theme-color), transparent 85%),
+    inset -0.75px 0 0.6px rgb(96 165 250 / 10%), inset 0 0 12px rgb(255 255 255 / 4%);
+  --bew-liquid-glass-sheen:
+    linear-gradient(
+      rgb(0 0 0 / var(--bew-liquid-glass-darken-alpha)),
+      rgb(0 0 0 / var(--bew-liquid-glass-darken-alpha))
+    ),
+    radial-gradient(circle at 16% 0%, rgb(255 255 255 / var(--bew-liquid-glass-sheen-strong-alpha)), transparent 38%),
+    linear-gradient(
+      135deg,
+      rgb(255 255 255 / var(--bew-liquid-glass-sheen-weak-alpha)) 0%,
+      transparent 38%,
+      color-mix(in oklab, var(--bew-theme-color), transparent 94%) 72%,
+      rgb(255 255 255 / var(--bew-liquid-glass-sheen-weak-alpha)) 100%
+    );
+}
+
+:host(.enable-liquid-glass:not(.disable-frosted-glass)) {
+  :is(
+    .glass-panel,
+    .settings-content,
+    .dock-content-inner,
+    .bew-popover,
+    .liquid-glass-surface,
+    #search-wrap .search-bar input
+  ) {
+    background-image: var(--bew-liquid-glass-sheen);
+    background-position: 0% 0%;
+    background-size: 160% 160%;
+  }
+
+  .liquid-glass-surface {
+    border: 0.5px solid var(--bew-border-color);
+    backdrop-filter: var(--bew-filter-glass-1);
+    box-shadow: var(--bew-shadow-edge-glow-1), var(--bew-shadow-1);
+  }
+
+  :is(
+    .bewly-bili-switcher-button.active,
+    .pinned-channels__item:hover,
+    .pinned-channels__more:hover,
+    .top-bar .right-side-item.active > a,
+    .top-bar .right-side-item > a:hover,
+    .top-bar .right-side-item > .notifications:hover,
+    .top-bar .logo:hover,
+    .top-bar .logo.activated,
+    .top-bar .home-button:hover
+  ) {
+    background-image: var(--bew-liquid-glass-sheen);
+    background-position: 50% 50%;
+    box-shadow: var(--bew-shadow-edge-glow-1);
+  }
+}
+
+:root.enable-liquid-glass:not(.disable-frosted-glass) {
+  :is(.bewly-design .bili-header .slide-down, .bewly-design .bili-header .mini-header) {
+    background-image: var(--bew-liquid-glass-sheen) !important;
+    background-position: 0% 0%;
+    background-size: 160% 160%;
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  :host(.enable-liquid-glass:not(.disable-frosted-glass)) {
+    :is(
+      .glass-panel,
+      .settings-content,
+      .dock-content-inner,
+      .bew-popover,
+      .liquid-glass-surface,
+      #search-wrap .search-bar input
+    ) {
+      animation: bew-liquid-glass-flow 12s ease-in-out infinite alternate;
+    }
+  }
+
+  :root.enable-liquid-glass:not(.disable-frosted-glass) {
+    :is(.bewly-design .bili-header .slide-down, .bewly-design .bili-header .mini-header) {
+      animation: bew-liquid-glass-flow 12s ease-in-out infinite alternate;
+    }
+  }
+}
+
+@keyframes bew-liquid-glass-flow {
+  from {
+    background-position: 0% 0%;
+  }
+
+  to {
+    background-position: 100% 100%;
+  }
+}

--- a/src/styles/liquidGlass.scss
+++ b/src/styles/liquidGlass.scss
@@ -12,7 +12,8 @@
   --bew-liquid-glass-border-alpha: 0.14;
   --bew-liquid-glass-sheen-strong-alpha: 0.06;
   --bew-liquid-glass-sheen-weak-alpha: 0.03;
-  --bew-liquid-glass-darken-alpha: 0.066;
+  --bew-liquid-glass-darken-alpha: 0.22;
+  --bew-liquid-glass-backdrop-brightness: 55%;
   --bew-content-opacity: var(--bew-liquid-glass-content-alpha);
   --bew-content: rgb(255 255 255 / var(--bew-liquid-glass-content-alpha));
   --bew-content-hover: rgb(255 255 255 / var(--bew-liquid-glass-content-hover-alpha));
@@ -49,7 +50,7 @@
 
 :host(.enable-liquid-glass.dark:not(.disable-frosted-glass)),
 :root.enable-liquid-glass.dark:not(.disable-frosted-glass) {
-  --bew-liquid-glass-darken-alpha: 0.066;
+  --bew-liquid-glass-darken-alpha: 0.22;
   --bew-content: rgb(
     from color-mix(in oklab, var(--bew-dark-base-color), white 8%) r g b / var(--bew-liquid-glass-content-alpha)
   );
@@ -140,7 +141,12 @@
 }
 
 :root.enable-liquid-glass:not(.disable-frosted-glass) {
-  :is(.bewly-design .bili-header .slide-down, .bewly-design .bili-header .mini-header) {
+  :is(
+    .bewly-design .bili-header .slide-down,
+    .bewly-design .bili-header .mini-header,
+    .bewly-design.watchLaterPage .watchlater-list-nav.fixed,
+    .bewly-design.watchLaterPage .watch-later-list
+  ) {
     background-image: var(--bew-liquid-glass-sheen) !important;
     background-position: 0% 0%;
     background-size: 160% 160%;
@@ -163,7 +169,12 @@
   }
 
   :root.enable-liquid-glass:not(.disable-frosted-glass) {
-    :is(.bewly-design .bili-header .slide-down, .bewly-design .bili-header .mini-header) {
+    :is(
+      .bewly-design .bili-header .slide-down,
+      .bewly-design .bili-header .mini-header,
+      .bewly-design.watchLaterPage .watchlater-list-nav.fixed,
+      .bewly-design.watchLaterPage .watch-later-list
+    ) {
       animation: bew-liquid-glass-flow 12s ease-in-out infinite alternate;
     }
   }

--- a/src/tests/liquidGlassUpgrade.spec.ts
+++ b/src/tests/liquidGlassUpgrade.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { initializeLiquidGlassUpgrade } from '~/background/liquidGlassUpgrade'
+import { LIQUID_GLASS_UPGRADE_NOTICE_STORAGE_KEY } from '~/constants/storageKeys'
+
+function createStorage(initialValues: Record<string, unknown>) {
+  const values = { ...initialValues }
+  const storage = {
+    get: vi.fn(async (keys: string[]) => Object.fromEntries(
+      keys
+        .filter(key => Object.prototype.hasOwnProperty.call(values, key))
+        .map(key => [key, values[key]]),
+    )),
+    set: vi.fn(async (items: Record<string, unknown>) => {
+      Object.assign(values, items)
+    }),
+  }
+
+  return { storage, values }
+}
+
+describe('liquid glass 升级提示迁移', () => {
+  it('全新安装只记录状态，不显示升级提示', async () => {
+    const { storage, values } = createStorage({})
+
+    await expect(initializeLiquidGlassUpgrade(storage, 'install')).resolves.toBe('initialized')
+    expect(values[LIQUID_GLASS_UPGRADE_NOTICE_STORAGE_KEY]).toBe(false)
+  })
+
+  it('升级时开启两种玻璃效果并挂出一次性提示', async () => {
+    const { storage, values } = createStorage({
+      settings: JSON.stringify({
+        enableFrostedGlass: false,
+        language: 'en',
+      }),
+    })
+
+    await expect(initializeLiquidGlassUpgrade(storage, 'update')).resolves.toBe('notice-enabled')
+
+    expect(values[LIQUID_GLASS_UPGRADE_NOTICE_STORAGE_KEY]).toBe(true)
+    expect(JSON.parse(values.settings as string)).toMatchObject({
+      enableFrostedGlass: true,
+      enableLiquidGlass: true,
+      language: 'en',
+    })
+  })
+
+  it('兼容已经试用过旧实现但尚无独立提示状态的用户', async () => {
+    const { storage, values } = createStorage({
+      settings: JSON.stringify({
+        enableFrostedGlass: true,
+        enableLiquidGlass: true,
+        liquidGlassPerformanceNoticeAcknowledged: true,
+      }),
+    })
+
+    await expect(initializeLiquidGlassUpgrade(storage, 'startup')).resolves.toBe('notice-enabled')
+    expect(values[LIQUID_GLASS_UPGRADE_NOTICE_STORAGE_KEY]).toBe(true)
+  })
+
+  it('已有独立状态时不会在后续升级中重复提示或覆盖开关', async () => {
+    const originalSettings = JSON.stringify({
+      enableFrostedGlass: false,
+      enableLiquidGlass: false,
+    })
+    const { storage, values } = createStorage({
+      [LIQUID_GLASS_UPGRADE_NOTICE_STORAGE_KEY]: false,
+      settings: originalSettings,
+    })
+
+    await expect(initializeLiquidGlassUpgrade(storage, 'update')).resolves.toBe('unchanged')
+    expect(values.settings).toBe(originalSettings)
+    expect(storage.set).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## 改动内容

- 在外观设置中新增独立的 Liquid Glass 开关，并将毛玻璃与 Liquid Glass 调整为默认开启
- 新增 0–200% 暗色着色强度滑杆：`0%` 不添加黑色遮罩，数值越高玻璃越暗，默认 `53%`
- 保留毛玻璃模糊强度调节，并将默认值设为 `14px`
- 降低基础玻璃白色层和高光的不透明度，使整体更清透、边缘更轻
- 着色强度同时联动背景亮度，让高强度着色仍能保持文字和控件的可读性
- 为旧版本设置加入一次性迁移：首次升级时开启两种玻璃效果，并显示性能提示
- 使用独立持久化状态和扩展升级事件触发提示，兼容已经试用过旧 demo 的用户；确认后不再重复提示
- 提示用户遇到卡顿、耗电或视频增强异常时，可在“设置 → 外观 → 视觉效果”关闭
- 补齐设置窗口、首页标签、Dock、搜索框、顶栏弹层、Bewly/Bili 切换器、固定分区、稍后再看页面和顶栏按钮状态的效果
- 修复搜索框聚焦后圆角从胶囊形变为方形的问题
- 遵循系统“减少动态效果”偏好，自动停止流动动画
- 补充简体中文、繁体中文、粤语和英文文案

## 背景与原因

现有毛玻璃只提供模糊和饱和效果，缺少更通透的层次、边缘高光和可调节的着色程度。本改动在复用现有毛玻璃合成链路的基础上增加 Liquid Glass 增强层，并提供独立开关和强度滑杆。

初版强度滑杆主要提高白色玻璃底层的不透明度，导致数值越高越泛白，与“Tinted”用于压暗背景、提升可读性的预期相反。现在滑杆控制黑色遮罩与背景亮度，同时将基础白色玻璃层固定在较低透明度。默认 `53%` 对应约 11.7% 黑色遮罩和约 76.2% 背景亮度；`100%` 对应约 22% 黑色遮罩和 55% 背景亮度；继续提高到 `200%` 时可获得更深的着色效果。

初版升级提示通过 Liquid Glass 设置字段是否存在来推断升级状态，已经加载过 demo 的用户会被误判为无需提示。现在改由后台监听真实安装/升级事件，并使用独立的一次性状态；同时保留启动迁移，兼容已经试用过旧实现但尚未记录提示状态的用户。

## 用户影响

- 新安装默认启用毛玻璃与 Liquid Glass，但不会显示“升级提示”
- 首次升级会启用两种效果并显示一次性能提示
- 用户确认后，后续升级不会再次提示或覆盖其玻璃开关选择
- 着色强度现在明确表示暗色遮罩强度，降低数值会更清透，提高数值会更暗
- 该效果会增加一定 GPU 合成开销，升级提示和设置项均提供性能说明
- NVIDIA RTX 视频增强兼容模式仍会在播放页停用相关 backdrop filter

## 验证

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`（14 个测试文件、43 项测试全部通过）
- `pnpm build:js`
- `pnpm build:bg`
- `git diff --check`
