### PR TITLE
feat: 搜索结果视频标签支持点击跳转搜索

### DIFF
--- a/src/components/SearchBar/SearchBar.vue
+++ b/src/components/SearchBar/SearchBar.vue
@@ -10,6 +10,7 @@ import { settings } from '~/logic'
 import api from '~/utils/api'
 import { findLeafActiveElement } from '~/utils/element'
 import { isHomePage } from '~/utils/main'
+import { buildKeywordSearchUrl } from '~/utils/searchNavigation'
 import { openLinkInBackground } from '~/utils/tabs'
 
 import type { HistoryItem, SuggestionItem, SuggestionResponse } from './searchHistoryProvider'
@@ -354,13 +355,7 @@ function handleNativeInput(event: Event) {
 }
 
 function buildKeywordHref(keyword: string) {
-  const encoded = encodeURIComponent(keyword)
-
-  if (settings.value.usePluginSearchResultsPage) {
-    return `https://www.bilibili.com/?page=SearchResults&keyword=${encoded}`
-  }
-
-  return `https://search.bilibili.com/all?keyword=${encoded}`
+  return buildKeywordSearchUrl(keyword)
 }
 
 // 从URL中提取搜索关键词

--- a/src/components/VideoCard/components/VideoCardInfo.vue
+++ b/src/components/VideoCard/components/VideoCardInfo.vue
@@ -4,6 +4,7 @@ import { computed, ref } from 'vue'
 import { calcTimeSince, numFormatter } from '~/utils/dataFormatter'
 
 import type { Video } from '../types'
+import { getTagSearchUrl } from '../utils'
 import VideoCardAuthorAvatar from '../VideoCardAuthor/components/VideoCardAuthorAvatar.vue'
 import VideoCardAuthorName from '../VideoCardAuthor/components/VideoCardAuthorName.vue'
 
@@ -261,7 +262,7 @@ const isModernLikeLayout = computed(() => props.layout === 'modern' || props.lay
           flex="~ items-center gap-2 wrap"
           :class="metaFontSizeClass"
         >
-          <span
+          <a
             v-for="primaryTag in visiblePrimaryTags"
             :key="`primary-${primaryTag}`"
             class="video-card-meta__chip"
@@ -269,10 +270,13 @@ const isModernLikeLayout = computed(() => props.layout === 'modern' || props.lay
             p="x-2"
             lh-6
             rounded="$bew-radius"
-            bg="$bew-theme-color-20"
+            bg="$bew-theme-color-20 hover:$bew-theme-color-30"
+            :href="getTagSearchUrl(primaryTag)"
+            target="_blank"
+            @click.stop=""
           >
             {{ primaryTag }}
-          </span>
+          </a>
 
           <span
             v-for="extraTag in visibleHighlightTags"
@@ -339,7 +343,7 @@ const isModernLikeLayout = computed(() => props.layout === 'modern' || props.lay
               flex="~ items-center gap-2 wrap"
               :class="metaFontSizeClass"
             >
-              <span
+              <a
                 v-for="primaryTag in visiblePrimaryTags"
                 :key="`primary-${primaryTag}`"
                 class="video-card-meta__chip"
@@ -347,10 +351,13 @@ const isModernLikeLayout = computed(() => props.layout === 'modern' || props.lay
                 p="x-2"
                 lh-6
                 rounded="$bew-radius"
-                bg="$bew-theme-color-20"
+                bg="$bew-theme-color-20 hover:$bew-theme-color-30"
+                :href="getTagSearchUrl(primaryTag)"
+                target="_blank"
+                @click.stop=""
               >
                 {{ primaryTag }}
-              </span>
+              </a>
 
               <span
                 v-for="extraTag in visibleHighlightTags"
@@ -400,13 +407,16 @@ const isModernLikeLayout = computed(() => props.layout === 'modern' || props.lay
             :class="metaFontSizeClass"
           >
             <!-- Tag -->
-            <span
+            <a
               v-for="primaryTag in visiblePrimaryTags"
               :key="`legacy-primary-${primaryTag}`"
-              text="$bew-theme-color" lh-6 p="x-2" rounded="$bew-radius" bg="$bew-theme-color-20"
+              text="$bew-theme-color" lh-6 p="x-2" rounded="$bew-radius" bg="$bew-theme-color-20 hover:$bew-theme-color-30"
+              :href="getTagSearchUrl(primaryTag)"
+              target="_blank"
+              @click.stop=""
             >
               {{ primaryTag }}
-            </span>
+            </a>
             <span
               v-for="extraTag in visibleHighlightTags"
               :key="`highlight-${extraTag}`"
@@ -485,13 +495,16 @@ const isModernLikeLayout = computed(() => props.layout === 'modern' || props.lay
               :class="metaFontSizeClass"
             >
               <!-- Tag -->
-              <span
+              <a
                 v-for="primaryTag in visiblePrimaryTags"
                 :key="`legacy-primary-${primaryTag}`"
-                text="$bew-theme-color" lh-6 p="x-2" rounded="$bew-radius" bg="$bew-theme-color-20"
+                text="$bew-theme-color" lh-6 p="x-2" rounded="$bew-radius" bg="$bew-theme-color-20 hover:$bew-theme-color-30"
+                :href="getTagSearchUrl(primaryTag)"
+                target="_blank"
+                @click.stop=""
               >
                 {{ primaryTag }}
-              </span>
+              </a>
               <span
                 v-for="extraTag in visibleHighlightTags"
                 :key="`highlight-${extraTag}`"

--- a/src/components/VideoCard/components/VideoCardInfo.vue
+++ b/src/components/VideoCard/components/VideoCardInfo.vue
@@ -266,7 +266,7 @@ const isModernLikeLayout = computed(() => props.layout === 'modern' || props.lay
             v-for="primaryTag in visiblePrimaryTags"
             :key="`primary-${primaryTag}`"
             class="video-card-meta__chip"
-            text="$bew-theme-color"
+            un-text="$bew-theme-color"
             p="x-2"
             lh-6
             rounded="$bew-radius"
@@ -347,7 +347,7 @@ const isModernLikeLayout = computed(() => props.layout === 'modern' || props.lay
                 v-for="primaryTag in visiblePrimaryTags"
                 :key="`primary-${primaryTag}`"
                 class="video-card-meta__chip"
-                text="$bew-theme-color"
+                un-text="$bew-theme-color"
                 p="x-2"
                 lh-6
                 rounded="$bew-radius"
@@ -410,7 +410,7 @@ const isModernLikeLayout = computed(() => props.layout === 'modern' || props.lay
             <a
               v-for="primaryTag in visiblePrimaryTags"
               :key="`legacy-primary-${primaryTag}`"
-              text="$bew-theme-color" lh-6 p="x-2" rounded="$bew-radius" bg="$bew-theme-color-20 hover:$bew-theme-color-30"
+              un-text="$bew-theme-color" lh-6 p="x-2" rounded="$bew-radius" bg="$bew-theme-color-20 hover:$bew-theme-color-30"
               :href="getTagSearchUrl(primaryTag)"
               target="_blank"
               @click.stop=""
@@ -498,7 +498,7 @@ const isModernLikeLayout = computed(() => props.layout === 'modern' || props.lay
               <a
                 v-for="primaryTag in visiblePrimaryTags"
                 :key="`legacy-primary-${primaryTag}`"
-                text="$bew-theme-color" lh-6 p="x-2" rounded="$bew-radius" bg="$bew-theme-color-20 hover:$bew-theme-color-30"
+                un-text="$bew-theme-color" lh-6 p="x-2" rounded="$bew-radius" bg="$bew-theme-color-20 hover:$bew-theme-color-30"
                 :href="getTagSearchUrl(primaryTag)"
                 target="_blank"
                 @click.stop=""

--- a/src/components/VideoCard/utils.ts
+++ b/src/components/VideoCard/utils.ts
@@ -1,3 +1,5 @@
+import { buildKeywordSearchUrl } from '~/utils/searchNavigation'
+
 import type { Author, Video } from './types'
 
 export function getAuthorJumpUrl(author?: Author) {
@@ -5,6 +7,11 @@ export function getAuthorJumpUrl(author?: Author) {
     return ''
 
   return author.authorUrl || (author.mid ? `//space.bilibili.com/${author.mid}` : '')
+}
+
+/** 标签点击跳转搜索页（复用统一的搜索链接构建入口） */
+export function getTagSearchUrl(tag: string) {
+  return buildKeywordSearchUrl(tag)
 }
 
 export function getCurrentTime(videoElement: Ref<HTMLVideoElement | null>) {

--- a/src/utils/searchNavigation.ts
+++ b/src/utils/searchNavigation.ts
@@ -1,3 +1,5 @@
+import { settings } from '~/logic'
+
 const NATIVE_SEARCH_CATEGORY_BY_PATH: Record<string, string> = {
   article: 'article',
   bangumi: 'bangumi',
@@ -8,6 +10,19 @@ const NATIVE_SEARCH_CATEGORY_BY_PATH: Record<string, string> = {
   upuser: 'user',
   user: 'user',
   video: 'video',
+}
+
+/**
+ * 构建关键词搜索链接的唯一入口：
+ * 开启插件搜索页时跳扩展内搜索页，否则跳 B 站原生搜索页
+ */
+export function buildKeywordSearchUrl(keyword: string): string {
+  const encoded = encodeURIComponent(keyword)
+
+  if (settings.value.usePluginSearchResultsPage)
+    return `https://www.bilibili.com/?page=SearchResults&keyword=${encoded}`
+
+  return `https://search.bilibili.com/all?keyword=${encoded}`
 }
 
 /**


### PR DESCRIPTION
close #374

## Summary
- 搜索结果页视频卡片的标签改为可点击链接，新标签页跳转到对应关键词的搜索页
- 新增统一的搜索链接构建入口 `buildKeywordSearchUrl`，跟随"使用插件搜索页"设置分流扩展搜索页 / 原生搜索页
- SearchBar 与 VideoCard 标签链接复用该入口