### PR TITLE
fix: 移除 NVIDIA RTX 视频增强兼容模式

### DIFF
--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -561,8 +561,6 @@ settings:
   adapt_to_other_page_styles_desc: 适应一些常见页面，以与 BewlyCat 主题相匹配。
   prevent_mobile_redirect: 防止跳转移动端
   prevent_mobile_redirect_desc: 开启后，仅在访问 www.bilibili.com 时使用桌面端 UA，避免被跳转到 m.bilibili.com；直接访问移动端不受影响。
-  nvidia_rtx_video_enhancement_compatibility: NVIDIA RTX 视频增强功能兼容
-  nvidia_rtx_video_enhancement_compatibility_desc: 开启后，将在视频播放页自动禁用毛玻璃效果，避免 NVIDIA RTX 视频增强功能异常。
   follow_bilibili_evolved_color: 使用 Bilibili Evolved 主题色
   follow_bilibili_evolved_color_desc: 每次选完 Bilibili Evolved 主题色时，记得重新选中这一选项以更新配置。
   links: 链接

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -515,8 +515,6 @@ settings:
   adapt_to_other_page_styles_desc: 適應一些常見頁面，以配合 BewlyBewly 主題。
   prevent_mobile_redirect: 防止跳轉至行動版
   prevent_mobile_redirect_desc: 啟用後，僅在造訪 www.bilibili.com 時使用桌面版 UA，避免被跳轉至 m.bilibili.com；直接造訪行動版不受影響。
-  nvidia_rtx_video_enhancement_compatibility: NVIDIA RTX 影片增強功能相容
-  nvidia_rtx_video_enhancement_compatibility_desc: 啟用後，將在影片播放頁自動停用毛玻璃效果，避免 NVIDIA RTX 影片增強功能異常。
   follow_bilibili_evolved_color: 使用 Bilibili Evolved 主題色
   follow_bilibili_evolved_color_desc: 每次變更 Bilibili Evolved 主題色後，記得重新選取此選項以更新配置。
   links: 連結

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -570,8 +570,6 @@ settings:
   adapt_to_other_page_styles_desc: Adapt to some common pages to match with the BewlyBewly theme.
   prevent_mobile_redirect: Prevent mobile redirect
   prevent_mobile_redirect_desc: When enabled, a desktop UA is used only for www.bilibili.com to prevent redirects to m.bilibili.com. Direct visits to the mobile site are unaffected.
-  nvidia_rtx_video_enhancement_compatibility: NVIDIA RTX Video Enhancement compatibility
-  nvidia_rtx_video_enhancement_compatibility_desc: When enabled, frosted glass is automatically disabled on video playback pages to prevent NVIDIA RTX Video Enhancement issues.
   follow_bilibili_evolved_color: Follow the Bilibili Evolved theme color
   follow_bilibili_evolved_color_desc: >-
     After changing the theme color in Bilibili Evolved, you will need to

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -489,8 +489,6 @@ settings:
   adapt_to_other_page_styles_desc: 執執啲常用嘅版面，襯返 BewlyBewly 主題風格。
   prevent_mobile_redirect: 防止跳轉去流動版
   prevent_mobile_redirect_desc: 開啟之後，只會喺進入 www.bilibili.com 時使用桌面版 UA，避免跳轉去 m.bilibili.com；直接進入流動版唔受影響。
-  nvidia_rtx_video_enhancement_compatibility: NVIDIA RTX 影片增強功能相容
-  nvidia_rtx_video_enhancement_compatibility_desc: 啓用之後，會喺影片播放頁自動停用毛玻璃效果，避免 NVIDIA RTX 影片增強功能異常。
   follow_bilibili_evolved_color: 跟返 Bilibili Evolved 主題色
   follow_bilibili_evolved_color_desc: 每次換完 Bilibili Evolved 主題色嗰陣，記得揀多一次呢個選項愛嚟更新佈置。
   links: 拎

--- a/src/components/Settings/Compatibility/Compatibility.vue
+++ b/src/components/Settings/Compatibility/Compatibility.vue
@@ -45,13 +45,6 @@ function changeThemeColor(color: string) {
       >
         <Radio v-model="settings.preventMobileRedirect" />
       </SettingsItem>
-      <SettingsItem
-        :title="$t('settings.nvidia_rtx_video_enhancement_compatibility')"
-        :desc="$t('settings.nvidia_rtx_video_enhancement_compatibility_desc')"
-        right-width="auto"
-      >
-        <Radio v-model="settings.nvidiaRtxVideoEnhancementCompatibility" />
-      </SettingsItem>
     </SettingsItemGroup>
 
     <SettingsItemGroup title="Bilibili Evolved">

--- a/src/components/Settings/searchCatalog.ts
+++ b/src/components/Settings/searchCatalog.ts
@@ -412,7 +412,6 @@ export const settingsSearchEntries: SettingsSearchEntry[] = [
     'settings.use_original_bilibili_homepage',
     'settings.adapt_to_other_page_styles',
     'settings.prevent_mobile_redirect',
-    'settings.nvidia_rtx_video_enhancement_compatibility',
     'settings.follow_bilibili_evolved_color',
     'settings.maintenance.title',
     'settings.maintenance.backup_title',

--- a/src/contentScripts/views/necessarySettingsWatchers.ts
+++ b/src/contentScripts/views/necessarySettingsWatchers.ts
@@ -26,12 +26,6 @@ export function setupNecessarySettingsWatchers() {
     return Math.min(FROSTED_GLASS_BLUR_MAX_PX, Math.max(FROSTED_GLASS_BLUR_MIN_PX, value))
   }
 
-  // Chromium routes videos through a different compositor path when a page uses
-  // backdrop filters. In compatibility mode, avoid that path on playback pages
-  // so NVIDIA RTX Video Enhancement can process the video.
-  const isFrostedGlassActive = () => settings.value.enableFrostedGlass
-    && !(settings.value.nvidiaRtxVideoEnhancementCompatibility && isVideoPlaybackPage())
-
   const applyFrostedGlassBlur = (rawValue: number) => {
     const clampedValue = clampFrostedGlassBlur(rawValue)
     const bewlyElement = document.querySelector('#bewly') as HTMLElement | null
@@ -40,7 +34,7 @@ export function setupNecessarySettingsWatchers() {
     if (bewlyElement)
       targets.push(bewlyElement)
 
-    if (!isFrostedGlassActive()) {
+    if (!settings.value.enableFrostedGlass) {
       targets.forEach((element) => {
         element.style.removeProperty('--bew-filter-glass-1')
         element.style.removeProperty('--bew-filter-glass-2')
@@ -66,7 +60,7 @@ export function setupNecessarySettingsWatchers() {
 
   const applyFrostedGlassState = () => {
     const bewlyElement = document.querySelector('#bewly') as HTMLElement | null
-    const shouldDisable = !isFrostedGlassActive()
+    const shouldDisable = !settings.value.enableFrostedGlass
 
     bewlyElement?.classList.toggle('disable-frosted-glass', shouldDisable)
     document.documentElement.classList.toggle('disable-frosted-glass', shouldDisable)
@@ -186,10 +180,7 @@ export function setupNecessarySettingsWatchers() {
   )
 
   watch(
-    [
-      () => settings.value.enableFrostedGlass,
-      () => settings.value.nvidiaRtxVideoEnhancementCompatibility,
-    ],
+    () => settings.value.enableFrostedGlass,
     applyFrostedGlassState,
     { immediate: true },
   )
@@ -431,7 +422,6 @@ export function setupNecessarySettingsWatchers() {
 
     lastBewlyDesignHref = location.href
     applyBewlyDesignClasses()
-    applyFrostedGlassState()
   }
 
   window.addEventListener('popstate', refreshBewlyDesignOnRouteChange)

--- a/src/logic/storage.ts
+++ b/src/logic/storage.ts
@@ -356,7 +356,6 @@ export interface Settings {
   showTopBar: boolean
   useOriginalBilibiliTopBar: boolean
   useOriginalBilibiliHomepage: boolean
-  nvidiaRtxVideoEnhancementCompatibility: boolean
   preventMobileRedirect: boolean
 
   // Video Player
@@ -596,7 +595,6 @@ export const originalSettings: Settings = {
   showTopBar: true,
   useOriginalBilibiliTopBar: false,
   useOriginalBilibiliHomepage: false,
-  nvidiaRtxVideoEnhancementCompatibility: false,
   preventMobileRedirect: false,
 
   // Video Player
@@ -723,6 +721,9 @@ watch(
 
     if (record.shortcuts?.webFullscreen?.key === 'W')
       record.shortcuts.webFullscreen.key = originalSettings.shortcuts.webFullscreen?.key
+
+    // 清理已移除的 NVIDIA RTX 视频增强兼容设置
+    Reflect.deleteProperty(record, 'nvidiaRtxVideoEnhancementCompatibility')
 
     // 迁移旧的 disableFrostedGlass 到 enableFrostedGlass
     if ('disableFrostedGlass' in record) {


### PR DESCRIPTION
## 变更内容

- 移除“兼容性”设置中的 NVIDIA RTX 视频增强兼容模式入口
- 删除设置搜索项、四套语言文案、设置类型与默认值
- 恢复毛玻璃效果仅由全局开关控制，不再在视频播放页自动禁用
- 升级时自动清理本地存储中遗留的废弃设置字段

## 变更原因

issue #777 的后续排查已确认异常来自浏览器环境，更换 Chrome 后恢复正常，并非 BewlyCat 的毛玻璃效果或插件逻辑导致。因此原有 NVIDIA RTX 视频增强兼容模式不再有保留必要，继续存在还会增加无效设置和维护成本。

关联 #777

## 用户影响

- 设置页不再显示该兼容模式
- 已保存的旧开关会在升级后自动清理
- 视频播放页的毛玻璃效果与其他页面保持一致，由“启用毛玻璃效果”统一控制

## 验证

- `pnpm lint`
- `pnpm typecheck`
- `git diff --check`
