### PR TITLE
feat: 重构 伪Liquid Glass V2 视觉与性能

### DIFF
--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -235,6 +235,10 @@ settings:
     Bilibili 默认会专门处理中文标点符号以实现左对齐。 如果你正在使用自定义字体，建议移除缩进。
   enable_frosted_glass: 启用毛玻璃效果
   frosted_glass_blur_intensity: 毛玻璃模糊强度
+  enable_liquid_glass: 启用伪 Liquid Glass 效果
+  enable_liquid_glass_desc: 出于性能考虑，大面积区域仅使用仿 Liquid Glass 风格的加强版毛玻璃，Dock 与主页选中控件保留局部折射；与普通毛玻璃效果互斥，仍可能影响性能。
+  liquid_glass_blur_intensity: Liquid Glass 模糊强度
+  liquid_glass_tint_intensity: Liquid Glass 玻璃着色
   disable_shadow: 禁用阴影
   link_opening_behavior_opt:
     current_tab: 当前标签页

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -233,6 +233,10 @@ settings:
     Bilibili 預設會特別處理中文標點符號以達到左對齊。 如果你正在使用自訂字型，建議移除縮排。
   enable_frosted_glass: 啟用毛玻璃效果
   frosted_glass_blur_intensity: 毛玻璃模糊強度
+  enable_liquid_glass: 啟用偽 Liquid Glass 效果
+  enable_liquid_glass_desc: 基於效能考量，大面積區域僅使用仿 Liquid Glass 風格的加強版毛玻璃，Dock 與首頁選取控制項保留局部折射；與一般毛玻璃效果互斥，仍可能影響效能。
+  liquid_glass_blur_intensity: Liquid Glass 模糊強度
+  liquid_glass_tint_intensity: Liquid Glass 玻璃著色
   disable_shadow: 停用陰影
   link_opening_behavior_opt:
     current_tab: 目前索引標籤

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -246,6 +246,10 @@ settings:
     the indent.
   enable_frosted_glass: Enable frosted glass effect
   frosted_glass_blur_intensity: Frosted glass blur intensity
+  enable_liquid_glass: Enable pseudo Liquid Glass effect
+  enable_liquid_glass_desc: For performance, large surfaces use enhanced frosted glass styled after Liquid Glass, while the Dock and selected Home controls retain local refraction. It is mutually exclusive with regular frosted glass and may still affect performance.
+  liquid_glass_blur_intensity: Liquid Glass blur intensity
+  liquid_glass_tint_intensity: Liquid Glass tint
   disable_shadow: Disable shadow
   link_opening_behavior_opt:
     current_tab: Current tab

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -233,6 +233,10 @@ settings:
     Bilibili 預設會專登執吓中文標點符號，令到佢可以左對齊。如果你係用緊自訂字字型，最好係移除縮排。
   enable_frosted_glass: 啓用毛玻璃效果
   frosted_glass_blur_intensity: 毛玻璃模糊強度
+  enable_liquid_glass: 啓用偽 Liquid Glass 效果
+  enable_liquid_glass_desc: 基於效能考慮，大面積區域只使用模仿 Liquid Glass 風格嘅加強版毛玻璃，Dock 同主頁已選控制項保留局部折射；同普通毛玻璃效果互斥，仍然可能影響效能。
+  liquid_glass_blur_intensity: Liquid Glass 模糊強度
+  liquid_glass_tint_intensity: Liquid Glass 玻璃着色
   disable_shadow: 閂咗陰影
   link_opening_behavior_opt:
     current_tab: 目前分頁

--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -28,7 +28,7 @@ const { mainAppRef } = useBewlyApp()
     <div
       class="context-menu-container"
       :style="menuStyles"
-      style="backdrop-filter: var(--bew-filter-glass-1); box-shadow: var(--bew-shadow-edge-glow-1), var(--bew-shadow-1); z-index: 9999;"
+      style="background-image: var(--bew-liquid-glass-surface-image); backdrop-filter: var(--bew-filter-glass-1); box-shadow: var(--bew-shadow-edge-glow-1), var(--bew-shadow-1); z-index: 9999;"
       p-1 bg="$bew-elevated" rounded="$bew-radius"
       min-w-140px m="t-1 l-[calc(-140px+0.5rem)]"
       border="1 $bew-border-color"

--- a/src/components/Dialog.vue
+++ b/src/components/Dialog.vue
@@ -104,6 +104,7 @@ const dialogPanelStyle = computed(() => {
     border: props.showBorder ? undefined : '0',
     backdropFilter: props.frostedGlass ? 'var(--bew-filter-glass-2)' : 'none',
     backgroundColor: props.frostedGlass ? 'var(--bew-elevated)' : 'var(--bew-elevated-solid)',
+    backgroundImage: props.frostedGlass ? 'var(--bew-liquid-glass-surface-image)' : 'none',
     boxShadow: props.showBorder ? 'var(--bew-shadow-4), var(--bew-shadow-edge-glow-2)' : 'var(--bew-shadow-4)',
   }
 })
@@ -205,6 +206,7 @@ function handleConfirm() {
 
             <div
               style="
+                background-image: var(--bew-liquid-glass-surface-image);
                 backdrop-filter: var(--bew-filter-glass-1);
                 box-shadow: var(--bew-shadow-edge-glow-1), var(--bew-shadow-1);
               "

--- a/src/components/Dock/Dock.vue
+++ b/src/components/Dock/Dock.vue
@@ -549,7 +549,6 @@ onUnmounted(() => {
               class="dock-item group"
               :class="{
                 'active': isDockItemActivated(dockItem),
-                'inactive': hoveringDockItem.themeMode && isDark,
                 'disable-glowing-effect': settings.disableDockGlowingEffect,
               }"
               @click="handleDockItemClick($event, dockItem)"
@@ -575,27 +574,13 @@ onUnmounted(() => {
         <Tooltip
           v-if="!settings.disableLightDarkModeSwitcherOnDock"
           :content="isDark ? $t('dock.dark_mode') : $t('dock.light_mode')" :placement="tooltipPlacement"
-          class="group"
           pointer-events-none
         >
-          <!-- moon -->
-          <div
-            v-if="isDark"
-            pos="absolute top-0 left-0 group-hover:top-2px group-hover:left--4px"
-            w-full h-full bg-white rounded="1/2"
-            z--2 pointer-events-none
-            :shadow="
-              settings.disableDockGlowingEffect
-                ? 'none'
-                : 'group-hover:[-8px_4px_160px_20px_hsla(226deg,85%,77%,1),-8px_4px_100px_12px_hsla(226deg,85%,77%,0.8),-8px_4px_60px_10px_hsla(226deg,85%,77%,0.6),-8px_4px_20px_4px_hsla(226deg,85%,77%,0.4),-4px_2px_8px_0_hsla(226deg,85%,77%,0.8)]'"
-            opacity-0 group-hover:opacity-100
-            duration-600
-          />
-
           <button
             class="dock-item"
-            bg="!dark-hover:$bew-bg" transform="!dark-hover:scale-100"
-            :shadow="settings.disableDockGlowingEffect ? 'none' : '!dark-hover:[inset_4px_-2px_8px_hsla(226deg,85%,77%,1)]'"
+            :class="{
+              'disable-glowing-effect': settings.disableDockGlowingEffect,
+            }"
             pointer-events-auto
             @click="toggleDark"
             @mouseenter="hoveringDockItem.themeMode = true"
@@ -620,7 +605,7 @@ onUnmounted(() => {
           <button
             class="dock-item group"
             :class="{
-              inactive: hoveringDockItem.themeMode && isDark,
+              'disable-glowing-effect': settings.disableDockGlowingEffect,
             }"
             @click="emit('settingsVisibilityChange')"
           >
@@ -644,9 +629,6 @@ onUnmounted(() => {
               <button
                 v-if="(key === 1 && canRefreshCurrentPage) || (key === 2 && !reachTop)"
                 class="back-to-top-or-refresh-btn"
-                :class="{
-                  inactive: hoveringDockItem.themeMode && isDark,
-                }"
                 @click="handleBackToTopOrRefresh(key === 1 ? 'refresh' : 'backToTop')"
               >
                 <Icon
@@ -666,9 +648,6 @@ onUnmounted(() => {
         <template v-else>
           <button
             class="back-to-top-or-refresh-btn"
-            :class="{
-              inactive: hoveringDockItem.themeMode && isDark,
-            }"
             @click="handleBackToTopOrRefresh('auto')"
           >
             <Transition name="fade">
@@ -690,9 +669,6 @@ onUnmounted(() => {
           <button
             v-if="showUndoForwardActions"
             class="back-to-top-or-refresh-btn"
-            :class="{
-              inactive: hoveringDockItem.themeMode && isDark,
-            }"
             @click="handleHistoryNavigation"
           >
             <Icon
@@ -798,11 +774,11 @@ onUnmounted(() => {
     --uno: "transform active:important-scale-90 hover:scale-110";
     --uno: "lg:w-45px w-35px lg:h-45px h-35px";
     --uno: "grid place-items-center";
-    --uno: "filter-$bew-filter-glass-1";
     --uno: "bg-$bew-elevated hover:bg-$bew-content-hover";
     --uno: "rounded-full shadow-$bew-shadow-2 border-1 border-$bew-border-color";
 
-    backdrop-filter: var(--bew-filter-glass-1);
+    background-image: var(--bew-liquid-glass-surface-image);
+    backdrop-filter: var(--bew-filter-glass-dock, var(--bew-filter-glass-1));
     transition:
       transform 300ms cubic-bezier(0.34, 2, 0.6, 1),
       background 300ms ease,
@@ -860,7 +836,8 @@ onUnmounted(() => {
     --uno: "flex flex-col gap-2 shrink-0";
     --uno: "rounded-full border-1 border-$bew-border-color";
     box-shadow: var(--bew-shadow-edge-glow-1), var(--bew-shadow-2);
-    backdrop-filter: var(--bew-filter-glass-1);
+    background-image: var(--bew-liquid-glass-surface-image);
+    backdrop-filter: var(--bew-filter-glass-dock, var(--bew-filter-glass-1));
   }
 
   &.bottom .dock-content-inner {
@@ -871,11 +848,11 @@ onUnmounted(() => {
     --uno: "transform active:important-scale-90 hover:scale-110";
     --uno: "lg:w-45px w-35px lg:h-45px h-35px";
     --uno: "grid place-items-center";
-    --uno: "filter-$bew-filter-glass-1";
     --uno: "bg-$bew-elevated hover:bg-$bew-content-hover";
     --uno: "rounded-full shadow-$bew-shadow-2 border-1 border-$bew-border-color";
 
-    backdrop-filter: var(--bew-filter-glass-1);
+    background-image: var(--bew-liquid-glass-surface-image);
+    backdrop-filter: var(--bew-filter-glass-dock, var(--bew-filter-glass-1));
     transition:
       transform 300ms cubic-bezier(0.34, 2, 0.6, 1),
       background 300ms ease,
@@ -888,10 +865,6 @@ onUnmounted(() => {
       --uno: "important-bg-$bew-theme-color-auto text-$bew-text-auto";
       --uno: "shadow-$shadow-active dark:shadow-$shadow-dark";
       --uno: "active:shadow-$shadow-active-active dark-active:shadow-$shadow-dark-active";
-    }
-
-    &.inactive {
-      --uno: "opacity-80 !shadow-none";
     }
   }
 
@@ -941,12 +914,94 @@ onUnmounted(() => {
     --uno: "active:shadow-$shadow-active-active dark-active:shadow-$shadow-dark-active";
   }
 
-  &.inactive {
-    --uno: "opacity-80 !shadow-none";
-  }
-
   svg {
     --uno: "lg:w-22px w-18px lg:h-22px h-18px block align-middle";
+  }
+}
+</style>
+
+<style lang="scss">
+:host(.enable-liquid-glass) {
+  .dock-content-inner,
+  .back-to-top-or-refresh-btn {
+    position: relative;
+    overflow: hidden;
+    isolation: isolate;
+    border-color: color-mix(in oklab, var(--bew-border-color), white 24%);
+    background-color: color-mix(in oklab, var(--bew-elevated), transparent 10%);
+    background-image:
+      linear-gradient(150deg, rgb(255 255 255 / 0.2), transparent 38%), var(--bew-liquid-glass-surface-image);
+    box-shadow:
+      inset 0 1px 0 rgb(255 255 255 / 0.36),
+      inset 0 -1px 0 rgb(0 0 0 / 0.09),
+      inset 1px 0 0 rgb(255 255 255 / 0.12),
+      var(--bew-liquid-shadow-dock-panel);
+  }
+
+  .dock-content-inner::before,
+  .back-to-top-or-refresh-btn::before {
+    position: absolute;
+    z-index: 0;
+    inset: 1px;
+    border-radius: inherit;
+    pointer-events: none;
+    content: "";
+    background: linear-gradient(
+      135deg,
+      transparent 12%,
+      rgb(255 255 255 / 0.06) 34%,
+      rgb(255 255 255 / 0.3) 48%,
+      color-mix(in oklab, var(--bew-theme-color), transparent 82%) 58%,
+      transparent 76%
+    );
+    background-position: 100% 100%;
+    background-size: 220% 220%;
+    opacity: 0.72;
+    transition:
+      background-position 650ms cubic-bezier(0.16, 1, 0.3, 1),
+      opacity 300ms ease;
+  }
+
+  .dock-content-inner > *,
+  .back-to-top-or-refresh-btn > * {
+    position: relative;
+    z-index: 1;
+  }
+
+  .dock-content:hover .dock-content-inner::before,
+  .back-to-top-or-refresh-btn:hover::before {
+    background-position: 0 0;
+    opacity: 1;
+  }
+
+  .dock-content.right .dock-content-inner::before {
+    background-size: 180% 180%;
+    opacity: 0.2;
+  }
+
+  .dock-content.right:hover .dock-content-inner::before {
+    background-position: 58% 58%;
+    opacity: 0.4;
+  }
+
+  .dock-item:not(.active):hover {
+    background-color: color-mix(in oklab, var(--bew-fill-2), white 10%);
+    box-shadow:
+      inset 0 1px 0 rgb(255 255 255 / 0.32),
+      inset 0 0 0 1px rgb(255 255 255 / 0.12),
+      var(--bew-liquid-shadow-floating);
+  }
+}
+
+:host(.enable-liquid-glass.dark) {
+  .dock-content-inner,
+  .back-to-top-or-refresh-btn {
+    border-color: color-mix(in oklab, var(--bew-border-color), white 12%);
+    box-shadow:
+      inset 0 1px 0 rgb(255 255 255 / 0.2),
+      inset 0 -1px 0 rgb(0 0 0 / 0.22),
+      inset 1px 0 0 rgb(255 255 255 / 0.07),
+      var(--bew-liquid-shadow-dock-panel);
   }
 }
 </style>

--- a/src/components/MediaEpisodeSelect/MediaEpisodeSelect.vue
+++ b/src/components/MediaEpisodeSelect/MediaEpisodeSelect.vue
@@ -134,6 +134,7 @@ watchEffect(() => {
             top: `${dropdownPosition.top}px`,
             left: `${dropdownPosition.left}px`,
             width: `${dropdownPosition.width}px`,
+            backgroundImage: 'var(--bew-liquid-glass-surface-image)',
             backdropFilter: 'var(--bew-filter-glass-1)',
           }"
           pos="absolute"

--- a/src/components/SearchBar/SearchBar.vue
+++ b/src/components/SearchBar/SearchBar.vue
@@ -826,6 +826,7 @@ function handleClearKeyword() {
   @mixin card-content {
     --uno: "text-base outline-none w-full bg-$b-search-bar-normal-color border-1 border-$bew-border-color";
     --uno: "shadow-[var(--bew-shadow-2),var(--bew-shadow-edge-glow-1)]";
+    background-image: var(--bew-liquid-glass-surface-image);
     backdrop-filter: var(--bew-filter-glass-1);
   }
 
@@ -856,7 +857,7 @@ function handleClearKeyword() {
     }
 
     &.focus input {
-      --uno: "border-$bew-theme-color rounded-$bew-radius";
+      --uno: "border-$bew-theme-color";
       box-shadow:
         0 0 0 2px var(--bew-theme-color),
         0 6px 16px var(--bew-theme-color-40),
@@ -966,12 +967,13 @@ function handleClearKeyword() {
   }
 
   &.search-wrap--top-bar {
-    @media (max-width: 767px) {
-      #search-dropdown,
-      #search-suggestion {
-        max-height: calc(100dvh - var(--bew-top-bar-height) - 12px);
-      }
+    #search-dropdown,
+    #search-suggestion {
+      // 内容较少时保持自然高度，仅在超过视口剩余空间后滚动。
+      max-height: calc(100dvh - var(--bew-top-bar-height) - 12px);
+    }
 
+    @media (max-width: 767px) {
       #search-dropdown .hot-search-container {
         grid-template-columns: minmax(0, 1fr);
       }

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -158,6 +158,7 @@ function onMouseEnter() {
             // 向上弹出时锚点移到触发器顶部，用 transform 上移自身高度，无需先测量实际高度
             transform: dropdownPosition.openUp ? `translateY(calc(-100% - ${DROPDOWN_MARGIN}px))` : undefined,
             marginTop: dropdownPosition.openUp ? undefined : `${DROPDOWN_MARGIN}px`,
+            backgroundImage: 'var(--bew-liquid-glass-surface-image)',
             backdropFilter: 'var(--bew-filter-glass-1)',
           }"
           pos="absolute" bg="$bew-elevated" shadow="$bew-shadow-2" p="2"

--- a/src/components/Settings/Appearance/Appearance.vue
+++ b/src/components/Settings/Appearance/Appearance.vue
@@ -3,7 +3,7 @@ import { useThrottleFn } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
 
 import Select from '~/components/Select.vue'
-import { FROSTED_GLASS_BLUR_MAX_PX, FROSTED_GLASS_BLUR_MIN_PX, localSettings, settings } from '~/logic'
+import { FROSTED_GLASS_BLUR_MAX_PX, FROSTED_GLASS_BLUR_MIN_PX, LIQUID_GLASS_BLUR_MAX_PX, LIQUID_GLASS_BLUR_MIN_PX, LIQUID_GLASS_TINT_MAX_PERCENT, LIQUID_GLASS_TINT_MIN_PERCENT, localSettings, settings } from '~/logic'
 
 import ChangeWallpaper from '../components/ChangeWallpaper.vue'
 import SettingsItem from '../components/SettingsItem.vue'
@@ -90,6 +90,24 @@ const themeOptions = computed<Array<{ value: string, label: string }>>(() => {
   ]
 })
 
+const frostedGlassEnabled = computed({
+  get: () => settings.value.enableFrostedGlass,
+  set: (enabled: boolean) => {
+    settings.value.enableFrostedGlass = enabled
+    if (enabled)
+      settings.value.enableLiquidGlass = false
+  },
+})
+
+const liquidGlassEnabled = computed({
+  get: () => settings.value.enableLiquidGlass,
+  set: (enabled: boolean) => {
+    settings.value.enableLiquidGlass = enabled
+    if (enabled)
+      settings.value.enableFrostedGlass = false
+  },
+})
+
 watch(() => settings.value.wallpaper, (newValue) => {
   changeWallpaper(newValue)
 })
@@ -124,6 +142,9 @@ function changeWallpaper(url: string) {
     />
 
     <SettingsItemGroup :title="$t('settings.group_visual_effects')">
+      <SettingsItem :title="$t('settings.disable_shadow')" right-width="auto">
+        <Radio v-model="settings.disableShadow" />
+      </SettingsItem>
       <SettingsItem
         :title="$t('settings.enable_frosted_glass')"
         :badge="$t('settings.badge_performance_impact')"
@@ -133,7 +154,7 @@ function changeWallpaper(url: string) {
           <span color="$bew-warning-color">{{ $t('common.performance_impact_warn') }}</span>
         </template>
 
-        <Radio v-model="settings.enableFrostedGlass" />
+        <Radio v-model="frostedGlassEnabled" />
       </SettingsItem>
       <SettingsItem
         v-if="settings.enableFrostedGlass"
@@ -149,9 +170,45 @@ function changeWallpaper(url: string) {
           />
         </div>
       </SettingsItem>
-      <SettingsItem :title="$t('settings.disable_shadow')" right-width="auto">
-        <Radio v-model="settings.disableShadow" />
+      <SettingsItem
+        :title="$t('settings.enable_liquid_glass')"
+        :badge="$t('settings.badge_performance_impact')"
+        right-width="auto"
+      >
+        <template #desc>
+          <span color="$bew-warning-color">{{ $t('settings.enable_liquid_glass_desc') }}</span>
+        </template>
+
+        <Radio v-model="liquidGlassEnabled" />
       </SettingsItem>
+      <template v-if="settings.enableLiquidGlass">
+        <SettingsItem
+          :title="$t('settings.liquid_glass_blur_intensity')"
+          right-width="auto"
+        >
+          <div class="slider-control">
+            <Slider
+              v-model="settings.liquidGlassBlurIntensity"
+              :min="LIQUID_GLASS_BLUR_MIN_PX"
+              :max="LIQUID_GLASS_BLUR_MAX_PX"
+              :label="`${settings.liquidGlassBlurIntensity}px`"
+            />
+          </div>
+        </SettingsItem>
+        <SettingsItem
+          :title="$t('settings.liquid_glass_tint_intensity')"
+          right-width="auto"
+        >
+          <div class="slider-control">
+            <Slider
+              v-model="settings.liquidGlassTintIntensity"
+              :min="LIQUID_GLASS_TINT_MIN_PERCENT"
+              :max="LIQUID_GLASS_TINT_MAX_PERCENT"
+              :label="`${settings.liquidGlassTintIntensity}%`"
+            />
+          </div>
+        </SettingsItem>
+      </template>
     </SettingsItemGroup>
 
     <SettingsItemGroup :title="$t('settings.group_color')">

--- a/src/components/Settings/Settings.vue
+++ b/src/components/Settings/Settings.vue
@@ -344,6 +344,7 @@ function changeMenuItem(menuItem: MenuType) {
           <!-- https://github.com/BewlyBewly/BewlyBewly/issues/1162 -->
           <div
             style="
+              background-image: var(--bew-liquid-glass-surface-image);
               box-shadow: var(--bew-shadow-edge-glow-2);
               backdrop-filter: var(--bew-filter-glass-2);
             "
@@ -397,6 +398,7 @@ function changeMenuItem(menuItem: MenuType) {
       <div
         class="settings-content"
         style="
+          background-image: var(--bew-liquid-glass-surface-image);
           --un-shadow: var(--bew-shadow-4), var(--bew-shadow-edge-glow-2);
           backdrop-filter: var(--bew-filter-glass-2);
         "
@@ -416,8 +418,8 @@ function changeMenuItem(menuItem: MenuType) {
           <div
             pos="absolute top-0 left-0" w-inherit h-inherit pointer-events-none
             :style="{
-              maskImage: settings.enableFrostedGlass ? 'linear-gradient(to bottom, black 0, transparent 100%)' : 'none',
-              WebkitMaskImage: settings.enableFrostedGlass ? 'linear-gradient(to bottom, black 0, transparent 100%)' : 'none',
+              maskImage: settings.enableFrostedGlass || settings.enableLiquidGlass ? 'linear-gradient(to bottom, black 0, transparent 100%)' : 'none',
+              WebkitMaskImage: settings.enableFrostedGlass || settings.enableLiquidGlass ? 'linear-gradient(to bottom, black 0, transparent 100%)' : 'none',
               backdropFilter: 'blur(6px)',
             }"
             z--1 rounded-inherit
@@ -475,6 +477,7 @@ function changeMenuItem(menuItem: MenuType) {
           </div>
           <div
             style="
+              background-image: var(--bew-liquid-glass-surface-image);
               backdrop-filter: var(--bew-filter-glass-1);
               box-shadow: var(--bew-shadow-edge-glow-1), var(--bew-shadow-2);
             "
@@ -491,8 +494,8 @@ function changeMenuItem(menuItem: MenuType) {
         <div
           ref="scrollViewportRef"
           :style="{
-            maskImage: settings.enableFrostedGlass ? 'linear-gradient(to bottom, transparent 0%, black 80px 30%)' : 'none',
-            WebkitMaskImage: settings.enableFrostedGlass ? 'linear-gradient(to bottom, transparent 0%, black 80px 30%)' : 'none',
+            maskImage: settings.enableFrostedGlass || settings.enableLiquidGlass ? 'linear-gradient(to bottom, transparent 0%, black 80px 30%)' : 'none',
+            WebkitMaskImage: settings.enableFrostedGlass || settings.enableLiquidGlass ? 'linear-gradient(to bottom, transparent 0%, black 80px 30%)' : 'none',
             scrollbarGutter: 'stable',
           }"
           h-inherit of-y-auto of-x-hidden

--- a/src/components/Settings/components/ChangeWallpaper.vue
+++ b/src/components/Settings/components/ChangeWallpaper.vue
@@ -265,7 +265,7 @@ onMounted(() => {
                   pos="absolute top-4px right-4px" z-1 text="14px" flex="~ gap-1"
                 >
                   <button
-                    style="backdrop-filter: var(--bew-filter-glass-1);"
+                    style="background-image: var(--bew-liquid-glass-surface-image); backdrop-filter: var(--bew-filter-glass-1);"
                     bg="$bew-content" rounded-full w-28px h-28px
                     grid place-items-center
                     @click="handleUploadWallpaper"
@@ -273,7 +273,7 @@ onMounted(() => {
                     <i i-mingcute:edit-2-line />
                   </button>
                   <button
-                    style="backdrop-filter: var(--bew-filter-glass-1);"
+                    style="background-image: var(--bew-liquid-glass-surface-image); backdrop-filter: var(--bew-filter-glass-1);"
                     bg="$bew-content" rounded-full w-28px h-28px
                     grid place-items-center
                     @click="handleRemoveCustomWallpaper"

--- a/src/components/Settings/searchCatalog.ts
+++ b/src/components/Settings/searchCatalog.ts
@@ -336,9 +336,12 @@ export const settingsSearchEntries: SettingsSearchEntry[] = [
   ...createEntries(appearanceRoute, [
     'settings.menu_appearance',
     'settings.group_visual_effects',
+    'settings.disable_shadow',
     'settings.enable_frosted_glass',
     'settings.frosted_glass_blur_intensity',
-    'settings.disable_shadow',
+    'settings.enable_liquid_glass',
+    'settings.liquid_glass_blur_intensity',
+    'settings.liquid_glass_tint_intensity',
     'settings.group_color',
     'settings.theme',
     'settings.video_page_dark_mode',

--- a/src/components/SideBar/SideBar.vue
+++ b/src/components/SideBar/SideBar.vue
@@ -81,7 +81,7 @@ function toggleHideSidebar(hide: boolean) {
       <Tooltip :content="isDark ? $t('dock.dark_mode') : $t('dock.light_mode')" placement="left">
         <Button
           class="ctrl-btn"
-          style="backdrop-filter: var(--bew-filter-glass-1);"
+          style="background-image: var(--bew-liquid-glass-surface-image); backdrop-filter: var(--bew-filter-glass-1);"
           center size="small" round
           @click="toggleDark"
           @mouseenter="hoveringDockItem.themeMode = true"
@@ -104,7 +104,7 @@ function toggleHideSidebar(hide: boolean) {
       <Tooltip :content="$t('dock.settings')" placement="left">
         <Button
           class="ctrl-btn group"
-          style="backdrop-filter: var(--bew-filter-glass-1);"
+          style="background-image: var(--bew-liquid-glass-surface-image); backdrop-filter: var(--bew-filter-glass-1);"
           center size="small" round
           @click="emit('settingsVisibilityChange')"
         >

--- a/src/components/TopBar/BewlyOrBiliTopBarSwitcher.vue
+++ b/src/components/TopBar/BewlyOrBiliTopBarSwitcher.vue
@@ -44,7 +44,7 @@ const topMargin = computed(() => {
     @mouseleave="isButtonVisible = false"
   >
     <button
-      style="backdrop-filter: var(--bew-filter-glass-1);"
+      style="background-image: var(--bew-liquid-glass-surface-image); backdrop-filter: var(--bew-filter-glass-1);"
       pos="absolute"
       :class="isButtonVisible ? 'opacity-100' : 'opacity-0'"
       class="pointer-events-auto"

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -472,3 +472,165 @@ const VideoPageTopBarConfigEnum = VideoPageTopBarConfig
   height: 20px;
 }
 </style>
+
+<style lang="scss">
+// 顶栏只复用已有模糊层，按钮本身使用静态高光与阴影模拟玻璃厚度。
+:host(.enable-liquid-glass) .top-bar {
+  --bew-top-bar-liquid-border: color-mix(in oklab, var(--bew-border-color), transparent 52%);
+  --bew-top-bar-liquid-surface: color-mix(in oklab, var(--bew-elevated), transparent 38%);
+  --bew-top-bar-liquid-surface-image:
+    linear-gradient(155deg, rgb(255 255 255 / 0.14) 0%, rgb(255 255 255 / 0.025) 32%, transparent 55%),
+    linear-gradient(330deg, var(--bew-liquid-glass-surface-tint, transparent) 0%, transparent 58%);
+  --bew-top-bar-liquid-button-hover: color-mix(in oklab, var(--bew-content-hover), transparent 72%);
+
+  .top-bar-action-group,
+  .pinned-channels,
+  .bewly-bili-switcher {
+    border-width: 0.5px;
+    border-color: var(--bew-top-bar-liquid-border);
+    background-color: var(--bew-top-bar-liquid-surface);
+    background-image: var(--bew-top-bar-liquid-surface-image);
+    box-shadow:
+      inset 0 1px 0 rgb(255 255 255 / 0.18),
+      inset 0 -1px 0 rgb(0 0 0 / 0.055),
+      var(--bew-liquid-shadow-control);
+  }
+
+  .top-bar-action-group::before {
+    background-color: transparent;
+    background-image: var(--bew-top-bar-liquid-surface-image);
+    box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.1);
+  }
+
+  .right-side .right-side-item:not(.avatar) > a:not(.login),
+  .right-side .right-side-item > .notifications,
+  .pinned-channels__item,
+  .pinned-channels__more,
+  .bewly-bili-switcher-button,
+  .home-button,
+  .search-wrap--top-bar .search-bar > button:last-of-type {
+    box-sizing: border-box;
+    border: 0.5px solid transparent;
+    background-color: transparent;
+    background-image: none !important;
+    box-shadow: none;
+    transform: translateY(0) scale(1);
+    transition:
+      transform 220ms cubic-bezier(0.34, 1.56, 0.64, 1),
+      border-color 220ms ease,
+      background-color 220ms ease,
+      box-shadow 220ms ease;
+  }
+
+  .right-side .right-side-item.active:not(.avatar) > a:not(.login),
+  .right-side .right-side-item.active > .notifications,
+  .bewly-bili-switcher-button.active {
+    border-color: color-mix(in oklab, var(--bew-theme-color), transparent 68%);
+    background-color: color-mix(in oklab, var(--bew-theme-color), transparent 88%);
+    background-image: none !important;
+    box-shadow: none;
+  }
+
+  .right-side .right-side-item:not(.avatar):not(.active) > a:not(.login):hover,
+  .right-side .right-side-item:not(.active) > .notifications:hover,
+  .pinned-channels__item:hover,
+  .pinned-channels__more:hover,
+  .bewly-bili-switcher-button:not(.active):hover,
+  .home-button:hover,
+  .search-wrap--top-bar .search-bar > button:last-of-type:hover {
+    border-color: transparent;
+    background-color: var(--bew-top-bar-liquid-button-hover);
+    background-image: none !important;
+    box-shadow: none;
+    transform: none;
+  }
+
+  .right-side .right-side-item:not(.avatar) > a:not(.login):active,
+  .right-side .right-side-item > .notifications:active,
+  .pinned-channels__item:active,
+  .bewly-bili-switcher-button:active,
+  .home-button:active,
+  .search-wrap--top-bar .search-bar > button:last-of-type:active {
+    box-shadow: none;
+    transform: translateY(0) scale(0.94);
+  }
+
+  .top-bar-brand-button {
+    border: 0.5px solid transparent;
+    background-color: transparent;
+    background-image: none;
+    box-shadow: none;
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+    transition:
+      transform 220ms cubic-bezier(0.34, 1.56, 0.64, 1),
+      border-color 220ms ease,
+      background-color 220ms ease,
+      box-shadow 220ms ease,
+      color 220ms ease;
+
+    &:is(:hover, .activated) {
+      border-color: var(--bew-top-bar-liquid-border);
+      background-color: var(--bew-top-bar-liquid-surface);
+      background-image: var(--bew-top-bar-liquid-surface-image) !important;
+      box-shadow:
+        inset 0 1px 0 rgb(255 255 255 / 0.18),
+        inset 0 -1px 0 rgb(0 0 0 / 0.055),
+        var(--bew-liquid-shadow-control);
+      -webkit-backdrop-filter: var(--bew-filter-glass-1);
+      backdrop-filter: var(--bew-filter-glass-1);
+      color: var(--bew-theme-color);
+      transform: none;
+    }
+
+    &.top-bar-brand-button--white:is(.activated, :hover) {
+      color: white;
+    }
+
+    &:active {
+      transform: translateY(0) scale(0.97);
+    }
+  }
+
+  .search-wrap--top-bar .search-bar input {
+    border-color: var(--bew-top-bar-liquid-border);
+    background-color: var(--bew-top-bar-liquid-surface);
+    background-image:
+      linear-gradient(155deg, rgb(255 255 255 / 0.24), rgb(255 255 255 / 0.035) 42%, transparent 62%),
+      linear-gradient(330deg, var(--bew-liquid-glass-surface-tint, transparent), transparent 64%);
+    box-shadow:
+      inset 0 1px 0 rgb(255 255 255 / 0.38),
+      inset 0 -1px 0 rgb(0 0 0 / 0.09),
+      var(--bew-liquid-shadow-floating);
+  }
+}
+
+:host(.enable-liquid-glass.dark) .top-bar {
+  --bew-top-bar-liquid-border: color-mix(in oklab, var(--bew-border-color), transparent 46%);
+  --bew-top-bar-liquid-surface: color-mix(in oklab, var(--bew-elevated), transparent 30%);
+
+  .top-bar-action-group,
+  .pinned-channels,
+  .bewly-bili-switcher {
+    box-shadow:
+      inset 0 1px 0 rgb(255 255 255 / 0.14),
+      inset 0 -1px 0 rgb(0 0 0 / 0.16),
+      var(--bew-liquid-shadow-control);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :host(.enable-liquid-glass) .top-bar {
+    .right-side .right-side-item:not(.avatar) > a:not(.login),
+    .right-side .right-side-item > .notifications,
+    .pinned-channels__item,
+    .pinned-channels__more,
+    .bewly-bili-switcher-button,
+    .home-button,
+    .top-bar-brand-button,
+    .search-wrap--top-bar .search-bar > button:last-of-type {
+      transition: none;
+    }
+  }
+}
+</style>

--- a/src/components/TopBar/components/BewlyOrBiliPageSwitcher.vue
+++ b/src/components/TopBar/components/BewlyOrBiliPageSwitcher.vue
@@ -73,7 +73,7 @@ function switchPage(nextUseOriginalBiliPage: boolean) {
     class="bewly-bili-switcher"
     :class="{
       'bewly-bili-switcher--white': props.forceWhiteIcon,
-      'bewly-bili-switcher--solid': !settings.enableFrostedGlass,
+      'bewly-bili-switcher--solid': !settings.enableFrostedGlass && !settings.enableLiquidGlass,
     }"
     role="group"
     aria-label="Homepage mode"
@@ -110,9 +110,11 @@ function switchPage(nextUseOriginalBiliPage: boolean) {
   border: 0;
   border-radius: var(--bew-top-bar-control-radius);
   background: var(--bew-elevated);
+  background-image: var(--bew-liquid-glass-surface-image);
   backdrop-filter: var(--bew-filter-glass-1);
 
   &--solid {
+    background-image: none;
     backdrop-filter: none;
   }
 

--- a/src/components/TopBar/components/TopBarHeader.vue
+++ b/src/components/TopBar/components/TopBarHeader.vue
@@ -127,7 +127,7 @@ function refreshSearchContent() {
     <!-- Top bar mask -->
     <Transition name="fade">
       <div
-        v-if="!reachTop && settings.enableFrostedGlass"
+        v-if="!reachTop && (settings.enableFrostedGlass || settings.enableLiquidGlass)"
         style="
           mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 1), rgba(0, 0, 0, 1) 24px, rgba(0, 0, 0, 0.9) 44px, transparent);
           -webkit-mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 1), rgba(0, 0, 0, 1) 24px, rgba(0, 0, 0, 0.9) 44px, transparent);
@@ -135,9 +135,10 @@ function refreshSearchContent() {
         pos="absolute top-0 left-0" w-full h="$bew-top-bar-height"
         pointer-events-none
         :style="{
-          backgroundColor: settings.enableFrostedGlass ? 'transparent' : 'var(--bew-bg)',
-          opacity: settings.enableFrostedGlass ? 1 : 0.9,
-          backdropFilter: settings.enableFrostedGlass ? 'var(--bew-filter-glass-1)' : 'none',
+          backgroundColor: settings.enableFrostedGlass || settings.enableLiquidGlass ? 'transparent' : 'var(--bew-bg)',
+          backgroundImage: settings.enableFrostedGlass || settings.enableLiquidGlass ? 'var(--bew-liquid-glass-surface-image)' : 'none',
+          opacity: settings.enableFrostedGlass || settings.enableLiquidGlass ? 1 : 0.9,
+          backdropFilter: settings.enableFrostedGlass || settings.enableLiquidGlass ? 'var(--bew-filter-glass-1)' : 'none',
         }"
       />
     </Transition>

--- a/src/components/TopBar/components/TopBarRight.vue
+++ b/src/components/TopBar/components/TopBarRight.vue
@@ -399,7 +399,7 @@ const showUtilityActionGroup = computed(() => {
             <a
               class="upload"
               :class="{ 'white-icon': forceWhiteIcon }"
-              style="backdrop-filter: var(--bew-filter-glass-1);"
+              style="background-image: var(--bew-liquid-glass-surface-image); backdrop-filter: var(--bew-filter-glass-1);"
               href="https://member.bilibili.com/platform/upload/video/frame"
               target="_blank"
               :title="$t('topbar.upload')"
@@ -544,6 +544,7 @@ const showUtilityActionGroup = computed(() => {
     position: absolute;
     border-radius: inherit;
     background: var(--bew-top-bar-control-background);
+    background-image: var(--bew-liquid-glass-surface-image);
     backdrop-filter: var(--bew-filter-glass-1);
     content: "";
     inset: 0;

--- a/src/components/TopBar/components/TopBarSearch.vue
+++ b/src/components/TopBar/components/TopBarSearch.vue
@@ -16,11 +16,11 @@ const { searchKeyword } = storeToRefs(topBarStore)
 // 可以考虑添加一个计算属性来处理样式
 const searchBarStyles = computed(() => ({
   '--b-search-bar-max-width': '100%',
-  '--b-search-bar-normal-color': settings.value.enableFrostedGlass ? 'color-mix(in oklab, var(--bew-elevated-solid), transparent 60%)' : 'var(--bew-elevated)',
+  '--b-search-bar-normal-color': settings.value.enableFrostedGlass || settings.value.enableLiquidGlass ? 'color-mix(in oklab, var(--bew-elevated-solid), transparent 60%)' : 'var(--bew-elevated)',
   '--b-search-bar-hover-color': 'var(--bew-elevated-hover)',
   '--b-search-bar-focus-color': 'var(--bew-elevated)',
-  '--b-search-bar-normal-icon-color': forceWhiteIcon.value && settings.value.enableFrostedGlass ? 'white' : 'var(--bew-text-1)',
-  '--b-search-bar-normal-text-color': forceWhiteIcon.value && settings.value.enableFrostedGlass ? 'white' : 'var(--bew-text-1)',
+  '--b-search-bar-normal-icon-color': forceWhiteIcon.value && (settings.value.enableFrostedGlass || settings.value.enableLiquidGlass) ? 'white' : 'var(--bew-text-1)',
+  '--b-search-bar-normal-text-color': forceWhiteIcon.value && (settings.value.enableFrostedGlass || settings.value.enableLiquidGlass) ? 'white' : 'var(--bew-text-1)',
 }))
 
 const currentLocation = ref(window.location.href)

--- a/src/components/TopBar/components/pops/ChannelsPop.vue
+++ b/src/components/TopBar/components/pops/ChannelsPop.vue
@@ -26,7 +26,7 @@ const otherLinks = computed(() => {
 
 <template>
   <div
-    style="backdrop-filter: var(--bew-filter-glass-1);"
+    style="background-image: var(--bew-liquid-glass-surface-image); backdrop-filter: var(--bew-filter-glass-1);"
     h="[calc(100vh-100px)]" max-h="445px"
     w="fit"
     of-y-auto of-x-hidden

--- a/src/components/TopBar/components/pops/FavoritesPop.vue
+++ b/src/components/TopBar/components/pops/FavoritesPop.vue
@@ -366,7 +366,7 @@ defineExpose({
 
 <template>
   <div
-    style="backdrop-filter: var(--bew-filter-glass-1);"
+    style="background-image: var(--bew-liquid-glass-surface-image); backdrop-filter: var(--bew-filter-glass-1);"
     h="[calc(100vh-100px)]" max-h-500px important-overflow-y-overlay
     bg="$bew-elevated"
     w="450px"

--- a/src/components/TopBar/components/pops/HistoryPop.vue
+++ b/src/components/TopBar/components/pops/HistoryPop.vue
@@ -206,7 +206,7 @@ defineExpose({
 
 <template>
   <div
-    style="backdrop-filter: var(--bew-filter-glass-1);"
+    style="background-image: var(--bew-liquid-glass-surface-image); backdrop-filter: var(--bew-filter-glass-1);"
     h="[calc(100vh-100px)]" max-h-500px important-overflow-y-overlay
     bg="$bew-elevated"
     w="380px"

--- a/src/components/TopBar/components/pops/MomentsPop.vue
+++ b/src/components/TopBar/components/pops/MomentsPop.vue
@@ -114,7 +114,7 @@ defineExpose({
 
 <template>
   <div
-    style="backdrop-filter: var(--bew-filter-glass-1);" h="[calc(100vh-100px)]" max-h-500px
+    style="background-image: var(--bew-liquid-glass-surface-image); backdrop-filter: var(--bew-filter-glass-1);" h="[calc(100vh-100px)]" max-h-500px
     important-overflow-y-overlay
     bg="$bew-elevated"
     w="380px"

--- a/src/components/TopBar/components/pops/MorePop.vue
+++ b/src/components/TopBar/components/pops/MorePop.vue
@@ -17,7 +17,7 @@ const list = computed((): { name: string, url: string, icon: string }[] => [
 
 <template>
   <div
-    style="backdrop-filter: var(--bew-filter-glass-1);"
+    style="background-image: var(--bew-liquid-glass-surface-image); backdrop-filter: var(--bew-filter-glass-1);"
     h="[calc(100vh-100px)]" max-h-264px important-overflow-y-auto
     w="180px"
     bg="$bew-elevated"

--- a/src/components/TopBar/components/pops/NotificationsPop.vue
+++ b/src/components/TopBar/components/pops/NotificationsPop.vue
@@ -76,7 +76,7 @@ function handleClick(event: MouseEvent, item: { name: string, url: string, unrea
 
 <template>
   <div
-    style="backdrop-filter: var(--bew-filter-glass-1);"
+    style="background-image: var(--bew-liquid-glass-surface-image); backdrop-filter: var(--bew-filter-glass-1);"
     bg="$bew-elevated"
     p="4"
     rounded="$bew-radius"

--- a/src/components/TopBar/components/pops/UploadPop.vue
+++ b/src/components/TopBar/components/pops/UploadPop.vue
@@ -36,7 +36,7 @@ const list = computed(() => {
 
 <template>
   <div
-    style="backdrop-filter: var(--bew-filter-glass-1);"
+    style="background-image: var(--bew-liquid-glass-surface-image); backdrop-filter: var(--bew-filter-glass-1);"
     bg="$bew-elevated"
     rounded="$bew-radius"
     p="4"

--- a/src/components/TopBar/components/pops/UserPanelPop.vue
+++ b/src/components/TopBar/components/pops/UserPanelPop.vue
@@ -168,7 +168,7 @@ function handleClickChannel() {
 
 <template>
   <div
-    style="backdrop-filter: var(--bew-filter-glass-1); overflow-y: auto;"
+    style="background-image: var(--bew-liquid-glass-surface-image); backdrop-filter: var(--bew-filter-glass-1); overflow-y: auto;"
     w-300px max-h="[calc(100vh-120px)]" min-h-0
     p-4 rounded="$bew-radius" z--1 bg="$bew-elevated-alt"
     border="1 $bew-border-color"

--- a/src/components/TopBar/components/pops/WatchLaterPop.vue
+++ b/src/components/TopBar/components/pops/WatchLaterPop.vue
@@ -92,7 +92,7 @@ function handleOpenVideoPageAndRemove(index: number, aid: number, bvid: string) 
 
 <template>
   <div
-    style="backdrop-filter: var(--bew-filter-glass-1);"
+    style="background-image: var(--bew-liquid-glass-surface-image); backdrop-filter: var(--bew-filter-glass-1);"
     h="[calc(100vh-100px)]" max-h-500px important-overflow-y-overlay
     bg="$bew-elevated"
     w="380px"

--- a/src/components/VideoCard/VideoCardContextMenu/VideoCardContextMenu.vue
+++ b/src/components/VideoCard/VideoCardContextMenu/VideoCardContextMenu.vue
@@ -452,7 +452,7 @@ async function unfollowUser() {
     <!-- more popup -->
     <div v-if="showContextMenu">
       <div
-        style="backdrop-filter: var(--bew-filter-glass-1); box-shadow: var(--bew-shadow-edge-glow-1), var(--bew-shadow-1);"
+        style="background-image: var(--bew-liquid-glass-surface-image); backdrop-filter: var(--bew-filter-glass-1); box-shadow: var(--bew-shadow-edge-glow-1), var(--bew-shadow-1);"
         :style="contextMenuStyles"
         p-1 bg="$bew-elevated" rounded="$bew-radius"
         min-w-200px m="t-4 l-[calc(-200px+1rem)]"

--- a/src/contentScripts/views/Home/Home.vue
+++ b/src/contentScripts/views/Home/Home.vue
@@ -3,9 +3,10 @@ import { useThrottleFn } from '@vueuse/core'
 
 import { useBewlyApp } from '~/composables/useAppProvider'
 import { OVERLAY_SCROLL_BAR_SCROLL, TOP_BAR_VISIBILITY_CHANGE } from '~/constants/globalEvents'
-import { gridLayout, settings } from '~/logic'
+import { gridLayout, LIQUID_GLASS_TINT_DEFAULT_PERCENT, LIQUID_GLASS_TINT_MAX_PERCENT, LIQUID_GLASS_TINT_MIN_PERCENT, settings } from '~/logic'
 import type { HomeTab } from '~/stores/mainStore'
 import { useMainStore } from '~/stores/mainStore'
+import { createPillDisplacementMap } from '~/utils/liquidGlass'
 import emitter from '~/utils/mitt'
 
 import VersionReminder from './components/VersionReminder.vue'
@@ -43,6 +44,145 @@ const shouldShowHomeHeader = computed(() => shouldShowHomeTabs.value || settings
 const shouldShowFixedTabsBackground = computed(() => {
   return settings.value.fixedHomeTabsOnHomePage && cachedScrollTop.value > 8
 })
+const supportsHomeLiquidGlassRefraction = typeof CSS !== 'undefined'
+  && (
+    CSS.supports('backdrop-filter', 'url("#bew-home-tab-liquid-glass-filter")')
+    || CSS.supports('-webkit-backdrop-filter', 'url("#bew-home-tab-liquid-glass-filter")')
+  )
+
+interface HomeLiquidGlassMap {
+  height: number
+  href: string
+  width: number
+}
+
+const homeHeaderRef = ref<HTMLElement>()
+const homeTabLiquidGlassMap = shallowRef<HomeLiquidGlassMap>()
+const homeGridLiquidGlassMap = shallowRef<HomeLiquidGlassMap>()
+const homeLiquidGlassMapCache = new Map<string, string>()
+const HOME_LIQUID_GLASS_MAP_CACHE_LIMIT = 24
+let homeLiquidGlassResizeObserver: ResizeObserver | undefined
+let homeLiquidGlassUpdateFrame: number | undefined
+
+function clampLiquidGlassTint(value: number) {
+  return Math.min(
+    LIQUID_GLASS_TINT_MAX_PERCENT,
+    Math.max(LIQUID_GLASS_TINT_MIN_PERCENT, Number.isFinite(value) ? value : LIQUID_GLASS_TINT_DEFAULT_PERCENT),
+  )
+}
+
+const homeLiquidGlassRefractionScale = 3.5
+const homeLiquidGlassStyle = computed(() => {
+  const tint = clampLiquidGlassTint(settings.value.liquidGlassTintIntensity) / 100
+  const surfaceAlpha = 0.06 + tint * 0.05
+  const themeAlpha = 0.005 + tint * 0.025
+
+  return {
+    '--bew-home-liquid-glass-surface': `color-mix(in oklab, var(--bew-elevated), transparent ${(100 - surfaceAlpha * 100).toFixed(2)}%)`,
+    '--bew-home-liquid-glass-theme-tint': `color-mix(in oklab, var(--bew-theme-color), transparent ${(100 - themeAlpha * 100).toFixed(2)}%)`,
+    '--bew-home-liquid-glass-rim-opacity': '0.190',
+    '--bew-home-liquid-glass-focus-alpha': (0.075 + tint * 0.055).toFixed(3),
+  }
+})
+const shouldUseHomeLiquidGlassRefraction = computed(() => {
+  return settings.value.enableLiquidGlass
+    && supportsHomeLiquidGlassRefraction
+    && Boolean(homeTabLiquidGlassMap.value || homeGridLiquidGlassMap.value)
+})
+
+function createElementLiquidGlassMap(
+  element: HTMLElement | null,
+  currentMap: HomeLiquidGlassMap | undefined,
+): HomeLiquidGlassMap | undefined {
+  if (!element)
+    return undefined
+
+  const rect = element.getBoundingClientRect()
+  const width = Math.max(1, Math.round(rect.width))
+  const height = Math.max(1, Math.round(rect.height))
+
+  if (currentMap?.width === width && currentMap.height === height)
+    return currentMap
+
+  const cacheKey = `${width}x${height}`
+  const cachedHref = homeLiquidGlassMapCache.get(cacheKey)
+  if (cachedHref) {
+    homeLiquidGlassMapCache.delete(cacheKey)
+    homeLiquidGlassMapCache.set(cacheKey, cachedHref)
+    return { height, href: cachedHref, width }
+  }
+
+  const href = createPillDisplacementMap(width, height)
+  if (href) {
+    const oldestKey = homeLiquidGlassMapCache.keys().next().value
+    if (homeLiquidGlassMapCache.size >= HOME_LIQUID_GLASS_MAP_CACHE_LIMIT && oldestKey !== undefined)
+      homeLiquidGlassMapCache.delete(oldestKey)
+    homeLiquidGlassMapCache.set(cacheKey, href)
+  }
+
+  return href ? { height, href, width } : undefined
+}
+
+function updateHomeLiquidGlassMaps() {
+  homeLiquidGlassUpdateFrame = undefined
+  const header = homeHeaderRef.value
+  homeTabLiquidGlassMap.value = createElementLiquidGlassMap(
+    header?.querySelector<HTMLElement>('.tab-activated') ?? null,
+    homeTabLiquidGlassMap.value,
+  )
+  homeGridLiquidGlassMap.value = createElementLiquidGlassMap(
+    header?.querySelector<HTMLElement>('.grid-layout-item-activated') ?? null,
+    homeGridLiquidGlassMap.value,
+  )
+}
+
+function scheduleHomeLiquidGlassMapUpdate() {
+  if (homeLiquidGlassUpdateFrame !== undefined)
+    return
+
+  if (typeof requestAnimationFrame === 'undefined') {
+    updateHomeLiquidGlassMaps()
+    return
+  }
+
+  homeLiquidGlassUpdateFrame = requestAnimationFrame(updateHomeLiquidGlassMaps)
+}
+
+function cancelHomeLiquidGlassMapUpdate() {
+  if (homeLiquidGlassUpdateFrame === undefined)
+    return
+
+  if (typeof cancelAnimationFrame !== 'undefined')
+    cancelAnimationFrame(homeLiquidGlassUpdateFrame)
+  homeLiquidGlassUpdateFrame = undefined
+}
+
+function refreshHomeLiquidGlassTargets() {
+  void nextTick(() => {
+    homeLiquidGlassResizeObserver?.disconnect()
+
+    if (!settings.value.enableLiquidGlass || !supportsHomeLiquidGlassRefraction) {
+      cancelHomeLiquidGlassMapUpdate()
+      homeTabLiquidGlassMap.value = undefined
+      homeGridLiquidGlassMap.value = undefined
+      return
+    }
+
+    const header = homeHeaderRef.value
+    const activeTab = header?.querySelector<HTMLElement>('.tab-activated') ?? null
+    const activeGridItem = header?.querySelector<HTMLElement>('.grid-layout-item-activated') ?? null
+
+    if (typeof ResizeObserver !== 'undefined') {
+      homeLiquidGlassResizeObserver ??= new ResizeObserver(scheduleHomeLiquidGlassMapUpdate)
+      if (activeTab)
+        homeLiquidGlassResizeObserver.observe(activeTab)
+      if (activeGridItem)
+        homeLiquidGlassResizeObserver.observe(activeGridItem)
+    }
+
+    scheduleHomeLiquidGlassMapUpdate()
+  })
+}
 const gridLayoutIcons = computed((): GridLayoutIcon[] => {
   return [
     { icon: 'i-mingcute:table-3-line', iconActivated: 'i-mingcute:table-3-fill', value: 'adaptive' },
@@ -55,6 +195,18 @@ const gridLayoutIcons = computed((): GridLayoutIcon[] => {
 watch(() => settings.value.homePageTabVisibilityList, () => {
   syncCurrentTabs()
 }, { deep: true })
+
+watch(
+  [
+    () => settings.value.enableLiquidGlass,
+    () => settings.value.enableGridLayoutSwitcher,
+    () => activatedPage.value,
+    () => gridLayout.value.home,
+    () => currentTabs.value.map(tab => tab.page).join('|'),
+  ],
+  refreshHomeLiquidGlassTargets,
+  { flush: 'post' },
+)
 
 function handleOverlayScroll(scrollTop: number) {
   cachedScrollTop.value = scrollTop
@@ -102,9 +254,13 @@ onMounted(() => {
   emitter.on(TOP_BAR_VISIBILITY_CHANGE, handleTopBarVisibilityChange)
 
   syncCurrentTabs()
+  refreshHomeLiquidGlassTargets()
 })
 
 onUnmounted(() => {
+  homeLiquidGlassResizeObserver?.disconnect()
+  cancelHomeLiquidGlassMapUpdate()
+  homeLiquidGlassMapCache.clear()
   emitter.off(TOP_BAR_VISIBILITY_CHANGE, handleTopBarVisibilityChange)
   emitter.off(OVERLAY_SCROLL_BAR_SCROLL, handleOverlayScroll)
 })
@@ -146,6 +302,71 @@ function toggleTabContentLoading(loading: boolean) {
 
 <template>
   <div pos="relative">
+    <svg
+      v-if="shouldUseHomeLiquidGlassRefraction"
+      class="home-liquid-glass-definitions"
+      width="0"
+      height="0"
+      aria-hidden="true"
+    >
+      <defs>
+        <filter
+          v-if="homeTabLiquidGlassMap"
+          id="bew-home-tab-liquid-glass-filter"
+          x="-8"
+          y="-8"
+          :width="homeTabLiquidGlassMap.width + 16"
+          :height="homeTabLiquidGlassMap.height + 16"
+          filterUnits="userSpaceOnUse"
+          color-interpolation-filters="sRGB"
+        >
+          <feImage
+            :href="homeTabLiquidGlassMap.href"
+            x="0"
+            y="0"
+            :width="homeTabLiquidGlassMap.width"
+            :height="homeTabLiquidGlassMap.height"
+            preserveAspectRatio="none"
+            result="displacement-map"
+          />
+          <feDisplacementMap
+            in="SourceGraphic"
+            in2="displacement-map"
+            :scale="homeLiquidGlassRefractionScale"
+            xChannelSelector="R"
+            yChannelSelector="G"
+          />
+        </filter>
+        <filter
+          v-if="homeGridLiquidGlassMap"
+          id="bew-home-grid-liquid-glass-filter"
+          x="-8"
+          y="-8"
+          :width="homeGridLiquidGlassMap.width + 16"
+          :height="homeGridLiquidGlassMap.height + 16"
+          filterUnits="userSpaceOnUse"
+          color-interpolation-filters="sRGB"
+        >
+          <feImage
+            :href="homeGridLiquidGlassMap.href"
+            x="0"
+            y="0"
+            :width="homeGridLiquidGlassMap.width"
+            :height="homeGridLiquidGlassMap.height"
+            preserveAspectRatio="none"
+            result="displacement-map"
+          />
+          <feDisplacementMap
+            in="SourceGraphic"
+            in2="displacement-map"
+            :scale="homeLiquidGlassRefractionScale"
+            xChannelSelector="R"
+            yChannelSelector="G"
+          />
+        </filter>
+      </defs>
+    </svg>
+
     <!-- Home search page mode background -->
     <Transition name="bg">
       <div
@@ -214,11 +435,15 @@ function toggleTabContentLoading(loading: boolean) {
 
       <header
         v-if="shouldShowHomeHeader"
+        ref="homeHeaderRef"
         class="home-header"
         :class="{
           'home-header--tabs-left': settings.homeTabsPosition === 'left',
           'home-header-fixed': settings.fixedHomeTabsOnHomePage,
+          'home-header--liquid-glass': settings.enableLiquidGlass,
+          'home-header--liquid-glass-refraction': shouldUseHomeLiquidGlassRefraction,
         }"
+        :style="homeLiquidGlassStyle"
         w-full z-9 duration-300 ease-in-out
       >
         <section
@@ -243,15 +468,6 @@ function toggleTabContentLoading(loading: boolean) {
                 @click="handleChangeTab(tab)"
               >
                 <span class="text-center">{{ $t(tab.i18nKey) }}</span>
-
-                <Transition name="fade">
-                  <div
-                    v-show="activatedPage === tab.page && tabContentLoading"
-                    i-svg-spinners:ring-resize
-                    pos="absolute right-4px top-4px" duration-300
-                    text="8px $bew-theme-color"
-                  />
-                </Transition>
               </button>
             </div>
           </div>
@@ -322,11 +538,18 @@ function toggleTabContentLoading(loading: boolean) {
 }
 
 .glass-panel {
+  background-image: var(--bew-liquid-glass-surface-image);
   backdrop-filter: var(--bew-filter-glass-1);
   /* 关键优化：绘制隔离，防止重绘传播 */
   contain: paint layout;
   /* 创建独立堆叠上下文，减少合成压力 */
   isolation: isolate;
+}
+
+.home-liquid-glass-definitions {
+  position: absolute;
+  overflow: hidden;
+  pointer-events: none;
 }
 
 .home-header {
@@ -371,9 +594,11 @@ function toggleTabContentLoading(loading: boolean) {
 .home-tabs-panel--scrolled {
   border-color: color-mix(in oklab, var(--bew-border-color), transparent 24%);
   background: color-mix(in oklab, var(--bew-elevated), transparent 18%);
+  background-image: var(--bew-liquid-glass-surface-image);
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.06),
-    0 4px 16px rgb(0 0 0 / 0.08);
+    var(--bew-liquid-shadow-control);
+  -webkit-backdrop-filter: var(--bew-filter-glass-1);
   backdrop-filter: var(--bew-filter-glass-1);
 }
 
@@ -384,7 +609,85 @@ function toggleTabContentLoading(loading: boolean) {
   background: color-mix(in oklab, var(--bew-elevated), transparent 28%);
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.06),
-    0 1px 3px rgb(0 0 0 / 0.05);
+    var(--bew-liquid-shadow-subtle);
+}
+
+.home-header--liquid-glass {
+  .glass-panel {
+    --bew-home-liquid-glass-background:
+      linear-gradient(145deg, rgb(255 255 255 / 0.1), transparent 46%),
+      linear-gradient(
+        105deg,
+        var(--bew-home-liquid-glass-surface),
+        transparent 72%,
+        var(--bew-home-liquid-glass-theme-tint)
+      );
+
+    position: relative;
+    overflow: hidden;
+    border-color: color-mix(in oklab, var(--bew-border-color), transparent 48%);
+    background: transparent;
+    box-shadow:
+      inset 0 1px 0 rgb(255 255 255 / 0.2),
+      inset 0 -1px 0 rgb(0 0 0 / 0.055),
+      var(--bew-liquid-shadow-floating);
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+  }
+
+  .home-tabs-panel--scrolled {
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+  }
+
+  .glass-panel::before {
+    position: absolute;
+    z-index: 0;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    content: "";
+    background: var(--bew-home-liquid-glass-background);
+    -webkit-backdrop-filter: var(--bew-filter-glass-1);
+    backdrop-filter: var(--bew-filter-glass-1);
+  }
+
+  .glass-panel > * {
+    position: relative;
+    z-index: 2;
+  }
+
+  .home-tab-button:not(.tab-activated):hover,
+  .home-grid-layout-switcher > div:not(.grid-layout-item-activated):hover {
+    background: rgb(255 255 255 / 0.075);
+  }
+
+  .tab-activated,
+  .grid-layout-item-activated {
+    border: 0;
+    background: linear-gradient(
+      145deg,
+      rgb(255 255 255 / var(--bew-home-liquid-glass-focus-alpha)),
+      rgb(255 255 255 / 0.018) 58%,
+      var(--bew-home-liquid-glass-theme-tint)
+    );
+    box-shadow:
+      inset 0 0 0 1px rgb(255 255 255 / var(--bew-home-liquid-glass-rim-opacity)),
+      inset 0 1px 0 rgb(255 255 255 / 0.22),
+      inset 0 -1px 0 rgb(0 0 0 / 0.06);
+  }
+}
+
+.home-header--liquid-glass-refraction {
+  .tab-activated {
+    -webkit-backdrop-filter: url("#bew-home-tab-liquid-glass-filter") blur(0.75px) saturate(125%);
+    backdrop-filter: url("#bew-home-tab-liquid-glass-filter") blur(0.75px) saturate(125%);
+  }
+
+  .grid-layout-item-activated {
+    -webkit-backdrop-filter: url("#bew-home-grid-liquid-glass-filter") blur(0.75px) saturate(125%);
+    backdrop-filter: url("#bew-home-grid-liquid-glass-filter") blur(0.75px) saturate(125%);
+  }
 }
 
 .home-tabs-scroll {
@@ -411,7 +714,7 @@ function toggleTabContentLoading(loading: boolean) {
   background: var(--bew-theme-color-20);
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.08),
-    0 2px 6px var(--bew-theme-color-10);
+    var(--bew-liquid-shadow-focus);
   transform: translateY(-0.5px);
 }
 
@@ -420,7 +723,7 @@ function toggleTabContentLoading(loading: boolean) {
   background: color-mix(in oklab, var(--bew-theme-color), var(--bew-elevated) 82%);
   box-shadow:
     inset 0 0 0 1px var(--bew-theme-color-20),
-    0 1px 3px var(--bew-theme-color-10);
+    var(--bew-liquid-shadow-focus);
   transform: translateY(-0.5px);
 }
 

--- a/src/contentScripts/views/Home/components/Weekly.vue
+++ b/src/contentScripts/views/Home/components/Weekly.vue
@@ -230,6 +230,7 @@ defineExpose({ initData })
               top: `${dropdownPosition.top}px`,
               left: `${dropdownPosition.left}px`,
               width: `${dropdownPosition.width}px`,
+              backgroundImage: 'var(--bew-liquid-glass-surface-image)',
               backdropFilter: 'var(--bew-filter-glass-1)',
             }"
             pos="absolute" bg="$bew-elevated" shadow="$bew-shadow-2"

--- a/src/contentScripts/views/SearchResults/components/DatePicker.vue
+++ b/src/contentScripts/views/SearchResults/components/DatePicker.vue
@@ -472,6 +472,7 @@ const weekDays = ['日', '一', '二', '三', '四', '五', '六']
   width: 280px;
   padding: 12px;
   background: var(--bew-elevated);
+  background-image: var(--bew-liquid-glass-surface-image);
   border-radius: var(--bew-radius);
   box-shadow: var(--bew-shadow-3);
   backdrop-filter: var(--bew-filter-glass-1);

--- a/src/contentScripts/views/necessarySettingsWatchers.ts
+++ b/src/contentScripts/views/necessarySettingsWatchers.ts
@@ -3,8 +3,9 @@ import { useI18n } from 'vue-i18n'
 import { IFRAME_TOP_BAR_CHANGE } from '~/constants/globalEvents'
 import { setUselessFeedCardBlockerEnabled, shouldEnableUselessFeedCardBlocker } from '~/contentScripts/features/blockUselessFeedCards'
 import { LanguageType } from '~/enums/appEnums'
-import { appAuthTokens, FROSTED_GLASS_BLUR_MAX_PX, FROSTED_GLASS_BLUR_MIN_PX, localSettings, originalSettings, settings } from '~/logic'
+import { appAuthTokens, FROSTED_GLASS_BLUR_MAX_PX, FROSTED_GLASS_BLUR_MIN_PX, LIQUID_GLASS_BLUR_MAX_PX, LIQUID_GLASS_BLUR_MIN_PX, LIQUID_GLASS_TINT_DEFAULT_PERCENT, LIQUID_GLASS_TINT_MAX_PERCENT, LIQUID_GLASS_TINT_MIN_PERCENT, localSettings, originalSettings, settings } from '~/logic'
 import { resetBilibiliTopBarInlineStyles, setOriginalBilibiliTopBarScrolled } from '~/utils/bilibiliTopBar'
+import { DOCK_LIQUID_GLASS_FILTER_URL, syncDockLiquidGlassFilter } from '~/utils/liquidGlass'
 import { cleanBilibiliShareText, getUserID, injectCSS, isHomePage, isInIframe, isVideoPlaybackPage } from '~/utils/main'
 
 function isFestivalPage(): boolean {
@@ -18,6 +19,8 @@ export function setupNecessarySettingsWatchers() {
 
   const DEFAULT_FROSTED_GLASS_BLUR_PX = originalSettings.frostedGlassBlurIntensity
   const FROSTED_GLASS_DIALOG_OFFSET_PX = 10
+  const DEFAULT_LIQUID_GLASS_BLUR_PX = originalSettings.liquidGlassBlurIntensity
+  const LIQUID_GLASS_DIALOG_OFFSET_PX = 4
 
   const clampFrostedGlassBlur = (value: number) => {
     if (!Number.isFinite(value))
@@ -26,11 +29,20 @@ export function setupNecessarySettingsWatchers() {
     return Math.min(FROSTED_GLASS_BLUR_MAX_PX, Math.max(FROSTED_GLASS_BLUR_MIN_PX, value))
   }
 
+  const clampLiquidGlassBlur = (value: number) => {
+    if (!Number.isFinite(value))
+      return DEFAULT_LIQUID_GLASS_BLUR_PX
+
+    return Math.min(LIQUID_GLASS_BLUR_MAX_PX, Math.max(LIQUID_GLASS_BLUR_MIN_PX, value))
+  }
+
   // Chromium routes videos through a different compositor path when a page uses
   // backdrop filters. In compatibility mode, avoid that path on playback pages
   // so NVIDIA RTX Video Enhancement can process the video.
-  const isFrostedGlassActive = () => settings.value.enableFrostedGlass
-    && !(settings.value.nvidiaRtxVideoEnhancementCompatibility && isVideoPlaybackPage())
+  const isGlassCompositingAllowed = () => !(settings.value.nvidiaRtxVideoEnhancementCompatibility && isVideoPlaybackPage())
+  const isFrostedGlassActive = () => isGlassCompositingAllowed() && settings.value.enableFrostedGlass
+  const isLiquidGlassActive = () => isGlassCompositingAllowed() && settings.value.enableLiquidGlass
+  const isAnyGlassActive = () => isFrostedGlassActive() || isLiquidGlassActive()
 
   const applyFrostedGlassBlur = (rawValue: number) => {
     const clampedValue = clampFrostedGlassBlur(rawValue)
@@ -40,20 +52,37 @@ export function setupNecessarySettingsWatchers() {
     if (bewlyElement)
       targets.push(bewlyElement)
 
-    if (!isFrostedGlassActive()) {
+    if (!isAnyGlassActive()) {
+      syncDockLiquidGlassFilter(false)
       targets.forEach((element) => {
         element.style.removeProperty('--bew-filter-glass-1')
         element.style.removeProperty('--bew-filter-glass-2')
+        element.style.removeProperty('--bew-filter-glass-dock')
       })
       return
     }
 
-    const blur1Value = `blur(${clampedValue}px) saturate(180%)`
-    const dialogBlur = clampedValue === 0 ? 0 : clampedValue + FROSTED_GLASS_DIALOG_OFFSET_PX
-    const blur2Value = `blur(${dialogBlur}px) saturate(180%)`
+    const liquidGlassActive = isLiquidGlassActive()
+    const dockRefractionActive = syncDockLiquidGlassFilter(liquidGlassActive)
+    const saturation = liquidGlassActive ? 128 : 180
+    const liquidBlur = clampLiquidGlassBlur(settings.value.liquidGlassBlurIntensity)
+    const blur1 = liquidGlassActive ? liquidBlur : clampedValue
+    const dialogBlur = liquidGlassActive
+      ? (liquidBlur === 0 ? 0 : liquidBlur + LIQUID_GLASS_DIALOG_OFFSET_PX)
+      : (clampedValue === 0 ? 0 : clampedValue + FROSTED_GLASS_DIALOG_OFFSET_PX)
+    const materialAdjustments = liquidGlassActive ? ' contrast(108%) brightness(102%)' : ''
+    const blur1Value = `blur(${blur1}px) saturate(${saturation}%)${materialAdjustments}`
+    const blur2Value = `blur(${dialogBlur}px) saturate(${saturation}%)${materialAdjustments}`
+    const dockBlur = liquidBlur * 0.72
+    const dockFilterValue = `${DOCK_LIQUID_GLASS_FILTER_URL} blur(${dockBlur}px) saturate(138%) contrast(114%) brightness(104%)`
 
     targets.forEach((element) => {
-      if (Math.abs(clampedValue - DEFAULT_FROSTED_GLASS_BLUR_PX) < 0.01) {
+      if (liquidGlassActive && dockRefractionActive)
+        element.style.setProperty('--bew-filter-glass-dock', dockFilterValue)
+      else
+        element.style.removeProperty('--bew-filter-glass-dock')
+
+      if (!liquidGlassActive && Math.abs(clampedValue - DEFAULT_FROSTED_GLASS_BLUR_PX) < 0.01) {
         element.style.removeProperty('--bew-filter-glass-1')
         element.style.removeProperty('--bew-filter-glass-2')
       }
@@ -66,10 +95,43 @@ export function setupNecessarySettingsWatchers() {
 
   const applyFrostedGlassState = () => {
     const bewlyElement = document.querySelector('#bewly') as HTMLElement | null
-    const shouldDisable = !isFrostedGlassActive()
+    const targets: HTMLElement[] = [document.documentElement]
+    const shouldDisable = !isAnyGlassActive()
+    const liquidGlassActive = isLiquidGlassActive()
 
-    bewlyElement?.classList.toggle('disable-frosted-glass', shouldDisable)
-    document.documentElement.classList.toggle('disable-frosted-glass', shouldDisable)
+    if (bewlyElement)
+      targets.push(bewlyElement)
+
+    const tint = Math.min(
+      LIQUID_GLASS_TINT_MAX_PERCENT,
+      Math.max(
+        LIQUID_GLASS_TINT_MIN_PERCENT,
+        Number.isFinite(settings.value.liquidGlassTintIntensity)
+          ? settings.value.liquidGlassTintIntensity
+          : LIQUID_GLASS_TINT_DEFAULT_PERCENT,
+      ),
+    ) / 100
+    const contentOpacity = (0.54 + tint * 0.16).toFixed(3)
+    const themeMix = `${(0.4 + tint * 3.5).toFixed(2)}%`
+    const surfaceTintAlpha = 0.005 + tint * 0.055
+    const surfaceTint = `color-mix(in oklab, var(--bew-theme-color), transparent ${(100 - surfaceTintAlpha * 100).toFixed(2)}%)`
+
+    targets.forEach((element) => {
+      element.classList.toggle('disable-frosted-glass', shouldDisable)
+      element.classList.toggle('enable-liquid-glass', liquidGlassActive)
+
+      if (liquidGlassActive) {
+        element.style.setProperty('--bew-liquid-glass-content-opacity', contentOpacity)
+        element.style.setProperty('--bew-liquid-glass-theme-mix', themeMix)
+        element.style.setProperty('--bew-liquid-glass-surface-tint', surfaceTint)
+      }
+      else {
+        element.style.removeProperty('--bew-liquid-glass-content-opacity')
+        element.style.removeProperty('--bew-liquid-glass-theme-mix')
+        element.style.removeProperty('--bew-liquid-glass-surface-tint')
+      }
+    })
+
     applyFrostedGlassBlur(settings.value.frostedGlassBlurIntensity)
   }
 
@@ -188,6 +250,8 @@ export function setupNecessarySettingsWatchers() {
   watch(
     [
       () => settings.value.enableFrostedGlass,
+      () => settings.value.enableLiquidGlass,
+      () => settings.value.liquidGlassTintIntensity,
       () => settings.value.nvidiaRtxVideoEnhancementCompatibility,
     ],
     applyFrostedGlassState,
@@ -205,6 +269,21 @@ export function setupNecessarySettingsWatchers() {
       }
 
       applyFrostedGlassBlur(clamped)
+    },
+    { immediate: true },
+  )
+
+  watch(
+    () => settings.value.liquidGlassBlurIntensity,
+    (value) => {
+      const clamped = clampLiquidGlassBlur(value)
+
+      if (clamped !== value) {
+        settings.value.liquidGlassBlurIntensity = clamped
+        return
+      }
+
+      applyFrostedGlassBlur(settings.value.frostedGlassBlurIntensity)
     },
     { immediate: true },
   )

--- a/src/logic/storage.ts
+++ b/src/logic/storage.ts
@@ -69,6 +69,11 @@ export function resetAppAuthTokens() {
 
 export const FROSTED_GLASS_BLUR_MIN_PX = 1
 export const FROSTED_GLASS_BLUR_MAX_PX = 20
+export const LIQUID_GLASS_BLUR_MIN_PX = 0
+export const LIQUID_GLASS_BLUR_MAX_PX = 20
+export const LIQUID_GLASS_TINT_MIN_PERCENT = 0
+export const LIQUID_GLASS_TINT_MAX_PERCENT = 200
+export const LIQUID_GLASS_TINT_DEFAULT_PERCENT = 40
 
 // 快捷键基础配置接口
 export interface BaseShortcutSetting {
@@ -195,6 +200,9 @@ export interface Settings {
 
   enableFrostedGlass: boolean
   frostedGlassBlurIntensity: number
+  enableLiquidGlass: boolean
+  liquidGlassBlurIntensity: number
+  liquidGlassTintIntensity: number
   disableShadow: boolean
 
   enableVideoPreview: boolean
@@ -431,6 +439,9 @@ export const originalSettings: Settings = {
 
   enableFrostedGlass: false,
   frostedGlassBlurIntensity: 20,
+  enableLiquidGlass: false,
+  liquidGlassBlurIntensity: 8,
+  liquidGlassTintIntensity: LIQUID_GLASS_TINT_DEFAULT_PERCENT,
   disableShadow: false,
 
   // Link Opening Behavior
@@ -700,6 +711,39 @@ watch(
     if (record.frostedGlassBlurIntensity > FROSTED_GLASS_BLUR_MAX_PX)
       record.frostedGlassBlurIntensity = FROSTED_GLASS_BLUR_MAX_PX
 
+    if (!Number.isFinite(record.liquidGlassBlurIntensity))
+      record.liquidGlassBlurIntensity = originalSettings.liquidGlassBlurIntensity
+
+    record.liquidGlassBlurIntensity = Math.min(
+      LIQUID_GLASS_BLUR_MAX_PX,
+      Math.max(LIQUID_GLASS_BLUR_MIN_PX, record.liquidGlassBlurIntensity),
+    )
+
+    if ('enableHomeLiquidGlass' in record) {
+      record.enableLiquidGlass = record.enableHomeLiquidGlass === true
+      Reflect.deleteProperty(record, 'enableHomeLiquidGlass')
+    }
+
+    if ('homeLiquidGlassRefractionIntensity' in record) {
+      Reflect.deleteProperty(record, 'homeLiquidGlassRefractionIntensity')
+    }
+
+    if ('liquidGlassRefractionIntensity' in record)
+      Reflect.deleteProperty(record, 'liquidGlassRefractionIntensity')
+
+    if ('homeLiquidGlassTintIntensity' in record) {
+      record.liquidGlassTintIntensity = record.homeLiquidGlassTintIntensity
+      Reflect.deleteProperty(record, 'homeLiquidGlassTintIntensity')
+    }
+
+    if (!Number.isFinite(record.liquidGlassTintIntensity))
+      record.liquidGlassTintIntensity = originalSettings.liquidGlassTintIntensity
+
+    record.liquidGlassTintIntensity = Math.min(
+      LIQUID_GLASS_TINT_MAX_PERCENT,
+      Math.max(LIQUID_GLASS_TINT_MIN_PERCENT, record.liquidGlassTintIntensity),
+    )
+
     // 迁移旧的布尔类型自动播放设置到新的 AutoPlayMode 类型
     const autoPlayFields = ['autoPlayMultipart', 'autoPlayCollection', 'autoPlayRecommend', 'autoPlayPlaylist'] as const
 
@@ -731,6 +775,10 @@ watch(
       // 清理旧的字段
       Reflect.deleteProperty(record, 'disableFrostedGlass')
     }
+
+    // 两种玻璃效果互斥；旧配置同时开启时优先保留 Liquid Glass。
+    if (record.enableLiquidGlass === true && record.enableFrostedGlass === true)
+      record.enableFrostedGlass = false
 
     // 迁移旧的 locallyUploadedWallpaper/customizeCSS/customizeCSSContent 到 localSettings
     if ('locallyUploadedWallpaper' in record || 'customizeCSS' in record || 'customizeCSSContent' in record) {

--- a/src/styles/adaptedStyles/common/topBar.scss
+++ b/src/styles/adaptedStyles/common/topBar.scss
@@ -7,6 +7,7 @@
   .bili-header .slide-down,
   .bili-header .mini-header {
     background-color: var(--bew-elevated) !important;
+    background-image: var(--bew-liquid-glass-surface-image) !important;
     backdrop-filter: var(--bew-filter-glass-1);
   }
 

--- a/src/styles/adaptedStyles/pages/animePlayback&MoviePage.scss
+++ b/src/styles/adaptedStyles/pages/animePlayback&MoviePage.scss
@@ -3,6 +3,110 @@
     box-sizing: unset;
   }
 
+  &.enable-liquid-glass {
+    // 番剧选集沿用播放页的单层玻璃合成，列表项本身不启用模糊。
+    :is(
+      #eplist_module,
+      [class*="eplist_ep_list_wrapper"],
+      [class*="numberList_wrapper"],
+      [class*="imageList_wrap"],
+      .ep-list-wrapper,
+      .ep-section-module
+    ):not(
+      :is(
+          #eplist_module,
+          [class*="eplist_ep_list_wrapper"],
+          [class*="numberList_wrapper"],
+          [class*="imageList_wrap"],
+          .ep-list-wrapper,
+          .ep-section-module
+        )
+        *
+    ) {
+      background-color: var(--bew-elevated) !important;
+      background-image: var(--bew-liquid-glass-surface-image) !important;
+      background-clip: padding-box;
+      border-color: color-mix(in oklab, var(--bew-border-color), white 18%) !important;
+      border-radius: 8px;
+      outline: 1px solid color-mix(in oklab, var(--bew-border-color), white 12%);
+      outline-offset: -1px;
+      box-shadow: var(--bew-shadow-edge-glow-1), var(--bew-liquid-shadow-panel);
+      -webkit-backdrop-filter: var(--bew-filter-glass-1);
+      backdrop-filter: var(--bew-filter-glass-1);
+    }
+
+    :is(
+        #eplist_module,
+        [class*="eplist_ep_list_wrapper"],
+        [class*="numberList_wrapper"],
+        [class*="imageList_wrap"],
+        .ep-list-wrapper,
+        .ep-section-module
+      )
+      :is(
+        #eplist_module,
+        [class*="eplist_ep_list_wrapper"],
+        [class*="numberList_wrapper"],
+        [class*="imageList_wrap"],
+        .ep-list-wrapper,
+        .ep-section-module
+      ) {
+      border-color: transparent !important;
+      outline: none;
+      background-color: transparent !important;
+      background-image: none !important;
+      box-shadow: none;
+      -webkit-backdrop-filter: none;
+      backdrop-filter: none;
+    }
+
+    :is(
+        #eplist_module,
+        [class*="eplist_ep_list_wrapper"],
+        [class*="numberList_wrapper"],
+        [class*="imageList_wrap"],
+        .ep-list-wrapper,
+        .ep-section-module
+      )
+      :is(
+        [class*="eplist_ep_list_header"],
+        [class*="eplist_ep_list_content"],
+        .list-title,
+        .list-wrapper,
+        .section-title,
+        .section-ep-wrapper
+      ) {
+      background-color: transparent !important;
+      background-image: none !important;
+    }
+
+    :is(
+        #eplist_module,
+        [class*="eplist_ep_list_wrapper"],
+        [class*="numberList_wrapper"],
+        [class*="imageList_wrap"],
+        .ep-list-wrapper,
+        .ep-section-module
+      )
+      :is([class*="numberListItem_number_list_item"], [class*="imageListItem_wrap"], .ep-item) {
+      background-color: transparent !important;
+      border-radius: 6px;
+      box-shadow: inset 0 0 0 1px transparent;
+      transition:
+        background-color 160ms ease,
+        box-shadow 160ms ease;
+
+      &:hover {
+        background-color: var(--bew-fill-2) !important;
+      }
+
+      &:is(.cursor, [class*="numberListItem_select"], [class*="imageListItem_select"]) {
+        background-color: var(--bew-theme-color-10) !important;
+        box-shadow: inset 0 0 0 1px var(--bew-theme-color-20);
+      }
+    }
+  }
+
   body .special-cover::after {
     content: "";
     position: absolute;

--- a/src/styles/adaptedStyles/pages/articlesPage.scss
+++ b/src/styles/adaptedStyles/pages/articlesPage.scss
@@ -13,6 +13,7 @@
 
   .fixed-top-header {
     background-color: var(--bew-elevated);
+    background-image: var(--bew-liquid-glass-surface-image);
     backdrop-filter: var(--bew-filter-glass-1);
   }
 

--- a/src/styles/adaptedStyles/pages/historyPage.scss
+++ b/src/styles/adaptedStyles/pages/historyPage.scss
@@ -8,6 +8,7 @@
   // #region new history page
   .history-record.fixed .main-breadcrums {
     background-color: var(--bew-elevated);
+    background-image: var(--bew-liquid-glass-surface-image);
     backdrop-filter: var(--bew-filter-glass-1);
   }
   // #endregion

--- a/src/styles/adaptedStyles/pages/homePage.scss
+++ b/src/styles/adaptedStyles/pages/homePage.scss
@@ -14,6 +14,7 @@
     background-color: transparent;
     backdrop-filter: var(--bew-filter-glass-1);
     background: var(--bew-elevated);
+    background-image: var(--bew-liquid-glass-surface-image);
     // border-radius: var(--bew-radius);
     // margin: 10px 20px;
     // width: calc(100% - 40px);

--- a/src/styles/adaptedStyles/pages/momentsPage.scss
+++ b/src/styles/adaptedStyles/pages/momentsPage.scss
@@ -67,6 +67,7 @@
 
   .fixed-author-header {
     background-color: var(--bew-elevated);
+    background-image: var(--bew-liquid-glass-surface-image);
     backdrop-filter: var(--bew-filter-glass-1);
   }
 

--- a/src/styles/adaptedStyles/pages/notificationsPage.scss
+++ b/src/styles/adaptedStyles/pages/notificationsPage.scss
@@ -76,11 +76,13 @@ html.bewly-design.notificationsPage {
 
   .space-left {
     background-color: color-mix(in oklab, var(--bew-content-solid), transparent 40%);
+    background-image: var(--bew-liquid-glass-surface-image);
     backdrop-filter: var(--bew-filter-glass-1);
   }
 
   .space-right {
     background-color: color-mix(in oklab, var(--bew-content-solid), transparent 60%);
+    background-image: var(--bew-liquid-glass-surface-image);
     backdrop-filter: var(--bew-filter-glass-1);
   }
 

--- a/src/styles/adaptedStyles/pages/searchPage.scss
+++ b/src/styles/adaptedStyles/pages/searchPage.scss
@@ -5,6 +5,7 @@
 
   .search-input-container .search-fixed-header {
     background-color: var(--bew-elevated);
+    background-image: var(--bew-liquid-glass-surface-image);
     backdrop-filter: var(--bew-filter-glass-1);
   }
 

--- a/src/styles/adaptedStyles/pages/userSpacePage.scss
+++ b/src/styles/adaptedStyles/pages/userSpacePage.scss
@@ -31,6 +31,7 @@
 
   .nav-bar {
     background-color: var(--bew-elevated);
+    background-image: var(--bew-liquid-glass-surface-image);
     backdrop-filter: var(--bew-filter-glass-1);
   }
   // #endregion

--- a/src/styles/adaptedStyles/pages/videoPage.scss
+++ b/src/styles/adaptedStyles/pages/videoPage.scss
@@ -20,6 +20,216 @@
     --app_graph_bg: var(--bew-fill-1);
   }
 
+  &.enable-liquid-glass {
+    @mixin liquid-glass-panel {
+      background-color: var(--bew-elevated) !important;
+      background-image: var(--bew-liquid-glass-surface-image) !important;
+      background-clip: padding-box;
+      border-color: color-mix(in oklab, var(--bew-border-color), white 18%) !important;
+      border-radius: 8px;
+      outline: 1px solid color-mix(in oklab, var(--bew-border-color), white 12%);
+      outline-offset: -1px;
+      box-shadow: var(--bew-shadow-edge-glow-1), var(--bew-liquid-shadow-panel);
+      -webkit-backdrop-filter: var(--bew-filter-glass-1);
+      backdrop-filter: var(--bew-filter-glass-1);
+    }
+
+    // 选集与合集只在面板外壳合成玻璃，避免为长列表中的每一项重复启用模糊。
+    :is(
+      #eplist_module,
+      [class*="eplist_ep_list_wrapper"],
+      [class*="numberList_wrapper"],
+      [class*="imageList_wrap"],
+      .video-pod,
+      .multi-page,
+      .multi-page-v1,
+      .base-video-sections-v1,
+      .video-sections-v1,
+      .playlist-container
+    ):not(
+      :is(
+          #eplist_module,
+          [class*="eplist_ep_list_wrapper"],
+          [class*="numberList_wrapper"],
+          [class*="imageList_wrap"],
+          .video-pod,
+          .multi-page,
+          .multi-page-v1,
+          .base-video-sections-v1,
+          .video-sections-v1,
+          .playlist-container
+        )
+        *
+    ) {
+      @include liquid-glass-panel;
+    }
+
+    // 多个候选容器嵌套时，仅让最外层参与模糊合成。
+    :is(
+        #eplist_module,
+        [class*="eplist_ep_list_wrapper"],
+        [class*="numberList_wrapper"],
+        [class*="imageList_wrap"],
+        .video-pod,
+        .multi-page,
+        .multi-page-v1,
+        .base-video-sections-v1,
+        .video-sections-v1,
+        .playlist-container
+      )
+      :is(
+        #eplist_module,
+        [class*="eplist_ep_list_wrapper"],
+        [class*="numberList_wrapper"],
+        [class*="imageList_wrap"],
+        .video-pod,
+        .multi-page,
+        .multi-page-v1,
+        .base-video-sections-v1,
+        .video-sections-v1,
+        .playlist-container
+      ) {
+      border-color: transparent !important;
+      outline: none;
+      background-color: transparent !important;
+      background-image: none !important;
+      box-shadow: none;
+      -webkit-backdrop-filter: none;
+      backdrop-filter: none;
+    }
+
+    // 折叠组件本身覆盖标题和列表，是弹幕区域唯一的玻璃合成层。
+    :is(#danmukuBox, [class*="DanmukuBox_wrap"], .danmaku-box, .danmaku-wrap, .bpx-player-dm-wrap)
+      :is(.bui-collapse, .bui-collapse-wrap):not(:is(.bui-collapse, .bui-collapse-wrap) *),
+    :is(#danmukuBox, [class*="DanmukuBox_wrap"], .danmaku-box, .danmaku-wrap, .bpx-player-dm-wrap):not(
+        :is(#danmukuBox, [class*="DanmukuBox_wrap"], .danmaku-box, .danmaku-wrap, .bpx-player-dm-wrap) *
+      ):not(:has(:is(.bui-collapse, .bui-collapse-wrap))) {
+      @include liquid-glass-panel;
+      box-sizing: border-box;
+      overflow: hidden;
+      border: 1px solid color-mix(in oklab, var(--bew-border-color), white 18%) !important;
+      outline: none;
+    }
+
+    :is(#danmukuBox, [class*="DanmukuBox_wrap"], .danmaku-box, .danmaku-wrap, .bpx-player-dm-wrap)
+      :is(#danmukuBox, [class*="DanmukuBox_wrap"], .danmaku-box, .danmaku-wrap, .bpx-player-dm-wrap) {
+      outline: none;
+      background-color: transparent !important;
+      background-image: none !important;
+      box-shadow: none;
+      -webkit-backdrop-filter: none;
+      backdrop-filter: none;
+    }
+
+    // 清除弹幕标题栏的不透明底色，让外壳材质保持连续。
+    :is(#danmukuBox, [class*="DanmukuBox_wrap"], .danmaku-box, .danmaku-wrap, .bpx-player-dm-wrap)
+      :is(
+        .bui-collapse-header,
+        .bpx-player-dm-title,
+        .bpx-player-dm-function,
+        .bpx-player-dm-list,
+        .danmaku-list,
+        [class*="DanmukuBox_header"]
+      ) {
+      background-color: transparent !important;
+      background-image: none !important;
+    }
+
+    // 展开区透出同一块玻璃材质，不再绘制独立矩形边界或创建第二个模糊层。
+    :is(#danmukuBox, [class*="DanmukuBox_wrap"], .danmaku-box, .danmaku-wrap, .bpx-player-dm-wrap)
+      :is(
+        .bui-collapse-body,
+        .bpx-player-dm-container,
+        .bpx-player-dm-list,
+        .danmaku-list,
+        [class*="DanmukuBox_list"]
+      ) {
+      border-radius: 0;
+      background-color: transparent !important;
+      background-image: none !important;
+      box-shadow: none;
+      -webkit-backdrop-filter: none;
+      backdrop-filter: none;
+    }
+
+    // 清除选集与合集内部标题、滚动区域的不透明底色。
+    :is(
+        #eplist_module,
+        [class*="eplist_ep_list_wrapper"],
+        [class*="numberList_wrapper"],
+        [class*="imageList_wrap"],
+        .video-pod,
+        .multi-page,
+        .multi-page-v1,
+        .base-video-sections-v1,
+        .video-sections-v1,
+        .playlist-container
+      )
+      :is(
+        .video-pod__header,
+        .video-pod__body,
+        .head-con,
+        .cur-list,
+        .list-box,
+        .video-sections-head,
+        .video-sections-content-list,
+        [class*="eplist_ep_list_header"],
+        [class*="eplist_ep_list_content"]
+      ) {
+      background-color: transparent !important;
+      background-image: none !important;
+    }
+
+    :is(#danmukuBox, [class*="DanmukuBox_wrap"], .danmaku-box, .danmaku-wrap, .bpx-player-dm-wrap)
+      :is(.bpx-player-dm-list-row, .danmaku-info-row) {
+      border-radius: 6px;
+      transition: background-color 160ms ease;
+
+      &:hover {
+        background-color: var(--bew-fill-2) !important;
+      }
+    }
+
+    :is(
+        #eplist_module,
+        [class*="eplist_ep_list_wrapper"],
+        [class*="numberList_wrapper"],
+        [class*="imageList_wrap"],
+        .video-pod,
+        .multi-page,
+        .multi-page-v1,
+        .base-video-sections-v1,
+        .video-sections-v1,
+        .playlist-container
+      )
+      :is(
+        .video-pod__item,
+        .multi-page__item,
+        .page-item,
+        .simple-base-item,
+        .normal-base-item,
+        .video-section-list,
+        [class*="numberListItem_number_list_item"],
+        [class*="imageListItem_wrap"]
+      ) {
+      background-color: transparent !important;
+      border-radius: 6px;
+      box-shadow: inset 0 0 0 1px transparent;
+      transition:
+        background-color 160ms ease,
+        box-shadow 160ms ease;
+
+      &:hover {
+        background-color: var(--bew-fill-2) !important;
+      }
+
+      &:is(.active, .on, [class*="numberListItem_select"], [class*="imageListItem_select"]) {
+        background-color: var(--bew-theme-color-10) !important;
+        box-shadow: inset 0 0 0 1px var(--bew-theme-color-20);
+      }
+    }
+  }
+
   // #region theme color adaption part
   // Increase the priority of the style inside by writing a non-existent selector in `:not()`
   :not(foobar) {

--- a/src/styles/adaptedStyles/pages/watchLaterPage.scss
+++ b/src/styles/adaptedStyles/pages/watchLaterPage.scss
@@ -3,6 +3,7 @@
 
   .watchlater-list-nav.fixed {
     background-color: var(--bew-elevated);
+    background-image: var(--bew-liquid-glass-surface-image);
     backdrop-filter: var(--bew-filter-glass-1);
   }
 

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -20,6 +20,8 @@
   // Use this in dialogs if you want to add a frosted glass effect
   --bew-filter-glass-2: blur(30px) saturate(180%);
 
+  --bew-liquid-glass-surface-image: none;
+
   // Apply this to the Bilibili icon if it is an image with the brand's original blue or pink color
   // Change it to glow effect to matches the user's theme color
   --bew-filter-icon-glow: saturate(0) brightness(2) drop-shadow(0 0 0.2px white)
@@ -40,6 +42,14 @@
   // Only used in the dialog
   --bew-shadow-4:
     0 34px 50px -20px rgb(0 0 0 / 0.14), 0 32px 45px -12px rgb(0 0 0 / 0.1), 0 30px 40px -8px rgb(0 0 0 / 0.12);
+
+  // Liquid Glass 的外投影单独管理，确保“禁用阴影”能完整关闭。
+  --bew-liquid-shadow-panel: 0 10px 28px rgb(0 0 0 / 0.1);
+  --bew-liquid-shadow-dock-panel: 0 10px 28px rgb(0 0 0 / 0.12);
+  --bew-liquid-shadow-floating: 0 6px 18px rgb(0 0 0 / 0.06);
+  --bew-liquid-shadow-control: 0 4px 12px rgb(0 0 0 / 0.06);
+  --bew-liquid-shadow-subtle: 0 1px 3px rgb(0 0 0 / 0.05);
+  --bew-liquid-shadow-focus: 0 2px 6px var(--bew-theme-color-10);
 
   // Use this to imitate the frosted glass edge effect in components with a frosted glass design (except dialogs)
   --bew-shadow-edge-glow-1:
@@ -221,6 +231,9 @@
   --bew-shadow-4:
     0 34px 50px -20px rgb(0 0 0 / 0.14), 0 32px 45px -12px rgb(0 0 0 / 0.12), 0 30px 40px -8px rgb(0 0 0 / 0.14);
 
+  --bew-liquid-shadow-dock-panel: 0 12px 30px rgb(0 0 0 / 0.28);
+  --bew-liquid-shadow-control: 0 5px 14px rgb(0 0 0 / 0.14);
+
   --bew-shadow-edge-glow-1:
     inset 1px 1px 1px -0.5px rgba(255, 255, 255, 0.06), inset -1px -1px 1px -0.5px rgba(255, 255, 255, 0.03),
     inset 0 0 10px rgba(255, 255, 255, 0.02);
@@ -295,6 +308,99 @@
   --bew-filter-force-dark: invert(0.98) hue-rotate(180deg) brightness(1.1);
 }
 
+// 伪 Liquid Glass 复用现有毛玻璃合成层，只调整材质透明度、着色与边缘高光。
+:host(.enable-liquid-glass),
+:root.enable-liquid-glass {
+  --bew-content-opacity: var(--bew-liquid-glass-content-opacity, 0.57);
+  --bew-liquid-glass-surface-image:
+    linear-gradient(145deg, rgb(255 255 255 / 0.16) 0%, rgb(255 255 255 / 0.035) 34%, transparent 56%),
+    linear-gradient(315deg, var(--bew-liquid-glass-surface-tint, transparent) 0%, transparent 48%);
+  --bew-content: color-mix(
+    in oklab,
+    hsl(0 0% 100% / var(--bew-content-opacity)),
+    var(--bew-theme-color) var(--bew-liquid-glass-theme-mix, 1%)
+  );
+  --bew-content-hover: color-mix(
+    in oklab,
+    hsl(0 0% 88% / var(--bew-content-opacity)),
+    var(--bew-theme-color) var(--bew-liquid-glass-theme-mix, 1%)
+  );
+  --bew-content-alt: color-mix(
+    in oklab,
+    hsl(240 31% 95% / var(--bew-content-opacity)),
+    var(--bew-theme-color) var(--bew-liquid-glass-theme-mix, 1%)
+  );
+  --bew-content-alt-hover: color-mix(
+    in oklab,
+    hsl(240 20% 82% / var(--bew-content-opacity)),
+    var(--bew-theme-color) var(--bew-liquid-glass-theme-mix, 1%)
+  );
+  --bew-elevated: color-mix(
+    in oklab,
+    hsl(0 0% 100% / var(--bew-content-opacity)),
+    var(--bew-theme-color) var(--bew-liquid-glass-theme-mix, 1%)
+  );
+  --bew-elevated-hover: color-mix(
+    in oklab,
+    hsl(0 0% 88% / var(--bew-content-opacity)),
+    var(--bew-theme-color) var(--bew-liquid-glass-theme-mix, 1%)
+  );
+  --bew-elevated-alt: var(--bew-content-alt);
+  --bew-elevated-alt-hover: var(--bew-content-alt-hover);
+  --bew-fill-alt: color-mix(in oklab, var(--bew-content), transparent 25%);
+  --bew-shadow-edge-glow-1:
+    inset 0 1px 0 rgb(255 255 255 / 0.22), inset 0 -1px 0 rgb(0 0 0 / 0.055), inset 1px 0 0 rgb(255 255 255 / 0.06),
+    inset -1px 0 0 rgb(0 0 0 / 0.025);
+  --bew-shadow-edge-glow-2:
+    inset 0 1px 0 rgb(255 255 255 / 0.26), inset 0 -1px 0 rgb(0 0 0 / 0.065), inset 1px 0 0 rgb(255 255 255 / 0.075),
+    inset -1px 0 0 rgb(0 0 0 / 0.03);
+}
+
+:host(.enable-liquid-glass.dark),
+:root.enable-liquid-glass.dark {
+  --bew-liquid-glass-surface-image:
+    linear-gradient(145deg, rgb(255 255 255 / 0.1) 0%, rgb(255 255 255 / 0.018) 36%, transparent 58%),
+    linear-gradient(315deg, var(--bew-liquid-glass-surface-tint, transparent) 0%, transparent 50%);
+  --bew-content: color-mix(
+    in oklab,
+    rgb(from color-mix(in oklab, var(--bew-dark-base-color), white 3%) r g b / var(--bew-content-opacity)),
+    var(--bew-theme-color) var(--bew-liquid-glass-theme-mix, 1%)
+  );
+  --bew-content-hover: color-mix(
+    in oklab,
+    rgb(from color-mix(in oklab, var(--bew-dark-base-color), white 8%) r g b / var(--bew-content-opacity)),
+    var(--bew-theme-color) var(--bew-liquid-glass-theme-mix, 1%)
+  );
+  --bew-content-alt: color-mix(
+    in oklab,
+    rgb(from color-mix(in oklab, var(--bew-dark-base-color), white 5%) r g b / var(--bew-content-opacity)),
+    var(--bew-theme-color) var(--bew-liquid-glass-theme-mix, 1%)
+  );
+  --bew-content-alt-hover: color-mix(
+    in oklab,
+    rgb(from color-mix(in oklab, var(--bew-dark-base-color), white 10%) r g b / var(--bew-content-opacity)),
+    var(--bew-theme-color) var(--bew-liquid-glass-theme-mix, 1%)
+  );
+  --bew-elevated: color-mix(
+    in oklab,
+    rgb(from color-mix(in oklab, var(--bew-dark-base-color), white 6%) r g b / var(--bew-content-opacity)),
+    var(--bew-theme-color) var(--bew-liquid-glass-theme-mix, 1%)
+  );
+  --bew-elevated-hover: color-mix(
+    in oklab,
+    rgb(from color-mix(in oklab, var(--bew-dark-base-color), white 11%) r g b / var(--bew-content-opacity)),
+    var(--bew-theme-color) var(--bew-liquid-glass-theme-mix, 1%)
+  );
+  --bew-elevated-alt: var(--bew-elevated);
+  --bew-elevated-alt-hover: var(--bew-elevated-hover);
+  --bew-shadow-edge-glow-1:
+    inset 0 1px 0 rgb(255 255 255 / 0.12), inset 0 -1px 0 rgb(0 0 0 / 0.14), inset 1px 0 0 rgb(255 255 255 / 0.04),
+    inset -1px 0 0 rgb(0 0 0 / 0.055);
+  --bew-shadow-edge-glow-2:
+    inset 0 1px 0 rgb(255 255 255 / 0.15), inset 0 -1px 0 rgb(0 0 0 / 0.17), inset 1px 0 0 rgb(255 255 255 / 0.05),
+    inset -1px 0 0 rgb(0 0 0 / 0.065);
+}
+
 :host(.disable-frosted-glass),
 :root.disable-frosted-glass {
   --bew-content-opacity: 1;
@@ -302,6 +408,7 @@
   --bew-filter-glass-2: none;
   --bew-shadow-edge-glow-1: 0 0 0 transparent;
   --bew-shadow-edge-glow-2: 0 0 0 transparent;
+  --bew-liquid-glass-surface-image: none;
   --bew-fill-alt: var(--bew-content-solid);
 }
 
@@ -316,6 +423,12 @@
   --bew-shadow-2: 0 0 0 transparent;
   --bew-shadow-3: 0 0 0 transparent;
   --bew-shadow-4: 0 0 0 transparent;
+  --bew-liquid-shadow-panel: 0 0 0 transparent;
+  --bew-liquid-shadow-dock-panel: 0 0 0 transparent;
+  --bew-liquid-shadow-floating: 0 0 0 transparent;
+  --bew-liquid-shadow-control: 0 0 0 transparent;
+  --bew-liquid-shadow-subtle: 0 0 0 transparent;
+  --bew-liquid-shadow-focus: 0 0 0 transparent;
 }
 :root.bewly-design,
 :root.bewly-design * {

--- a/src/utils/liquidGlass.ts
+++ b/src/utils/liquidGlass.ts
@@ -1,0 +1,258 @@
+const NEUTRAL_DISPLACEMENT_CHANNEL = 128
+const SVG_NAMESPACE = 'http://www.w3.org/2000/svg'
+const DOCK_FILTER_ID = 'bew-dock-liquid-glass-filter'
+const FILTER_DEFINITIONS_ATTRIBUTE = 'data-bew-dock-liquid-glass-definitions'
+const DOCK_REFRACTION_SCALE = 19.8
+
+export const DOCK_LIQUID_GLASS_FILTER_URL = `url("#${DOCK_FILTER_ID}")`
+
+function smoothStep(start: number, end: number, value: number): number {
+  const progress = Math.min(1, Math.max(0, (value - start) / (end - start)))
+  return progress * progress * (3 - 2 * progress)
+}
+
+function roundedRectDistance(
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number,
+): number {
+  const offsetX = Math.abs(x - width / 2) - (width / 2 - radius)
+  const offsetY = Math.abs(y - height / 2) - (height / 2 - radius)
+  const outsideDistance = Math.hypot(Math.max(offsetX, 0), Math.max(offsetY, 0))
+  const insideDistance = Math.min(Math.max(offsetX, offsetY), 0)
+
+  return outsideDistance + insideDistance - radius
+}
+
+function toDisplacementChannel(value: number): number {
+  return Math.round(Math.min(255, Math.max(0, NEUTRAL_DISPLACEMENT_CHANNEL + value * 127)))
+}
+
+/**
+ * 按元素实际尺寸生成药丸形边缘位移贴图，避免拉伸导致折射边缘变形。
+ * 贴图只在尺寸变化时生成，运行时不监听指针，也不执行逐帧计算。
+ */
+export function createPillDisplacementMap(width = 160, height = 48): string {
+  if (typeof document === 'undefined')
+    return ''
+
+  const canvas = document.createElement('canvas')
+  canvas.width = width
+  canvas.height = height
+
+  const context = canvas.getContext('2d')
+  if (!context)
+    return ''
+
+  const imageData = context.createImageData(width, height)
+  const pixels = imageData.data
+  const radius = Math.max(1, height / 2 - 1)
+  const edgeWidth = Math.max(3, height * 0.18)
+  const normalSampleOffset = 0.75
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const pixelIndex = (y * width + x) * 4
+      const distance = roundedRectDistance(x, y, width, height, radius)
+
+      pixels[pixelIndex] = NEUTRAL_DISPLACEMENT_CHANNEL
+      pixels[pixelIndex + 1] = NEUTRAL_DISPLACEMENT_CHANNEL
+      pixels[pixelIndex + 2] = 0
+      pixels[pixelIndex + 3] = 255
+
+      if (distance > 0)
+        continue
+
+      const edgeStrength = 1 - smoothStep(0, edgeWidth, -distance)
+      if (edgeStrength <= 0)
+        continue
+
+      const gradientX = roundedRectDistance(
+        x + normalSampleOffset,
+        y,
+        width,
+        height,
+        radius,
+      ) - roundedRectDistance(
+        x - normalSampleOffset,
+        y,
+        width,
+        height,
+        radius,
+      )
+      const gradientY = roundedRectDistance(
+        x,
+        y + normalSampleOffset,
+        width,
+        height,
+        radius,
+      ) - roundedRectDistance(
+        x,
+        y - normalSampleOffset,
+        width,
+        height,
+        radius,
+      )
+      const gradientLength = Math.hypot(gradientX, gradientY)
+
+      if (gradientLength === 0)
+        continue
+
+      const refractionStrength = edgeStrength ** 1.7
+      pixels[pixelIndex] = toDisplacementChannel(gradientX / gradientLength * refractionStrength)
+      pixels[pixelIndex + 1] = toDisplacementChannel(gradientY / gradientLength * refractionStrength)
+    }
+  }
+
+  context.putImageData(imageData, 0, 0)
+  return canvas.toDataURL('image/png')
+}
+
+let dockDisplacementMap = ''
+
+/**
+ * 生成可被不同宽高容器复用的边缘位移贴图。
+ * 位移只发生在四周，元素自身的圆角会负责裁切最终轮廓。
+ */
+function createDockDisplacementMap(size = 256): string {
+  if (typeof document === 'undefined')
+    return ''
+
+  const canvas = document.createElement('canvas')
+  canvas.width = size
+  canvas.height = size
+
+  const context = canvas.getContext('2d')
+  if (!context)
+    return ''
+
+  const imageData = context.createImageData(size, size)
+  const pixels = imageData.data
+  const edgeWidth = size * 0.13
+
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      const pixelIndex = (y * size + x) * 4
+      const leftStrength = 1 - smoothStep(0, edgeWidth, x)
+      const rightStrength = 1 - smoothStep(0, edgeWidth, size - 1 - x)
+      const topStrength = 1 - smoothStep(0, edgeWidth, y)
+      const bottomStrength = 1 - smoothStep(0, edgeWidth, size - 1 - y)
+      const displacementX = (leftStrength - rightStrength) ** 3
+      const displacementY = (topStrength - bottomStrength) ** 3
+
+      pixels[pixelIndex] = toDisplacementChannel(displacementX)
+      pixels[pixelIndex + 1] = toDisplacementChannel(displacementY)
+      pixels[pixelIndex + 2] = 0
+      pixels[pixelIndex + 3] = 255
+    }
+  }
+
+  context.putImageData(imageData, 0, 0)
+  return canvas.toDataURL('image/png')
+}
+
+function createSvgElement<K extends keyof SVGElementTagNameMap>(
+  documentRef: Document,
+  tagName: K,
+): SVGElementTagNameMap[K] {
+  return documentRef.createElementNS(SVG_NAMESPACE, tagName)
+}
+
+function createDockFilterDefinitions(documentRef: Document): SVGSVGElement {
+  const svg = createSvgElement(documentRef, 'svg')
+  svg.setAttribute(FILTER_DEFINITIONS_ATTRIBUTE, '')
+  svg.setAttribute('width', '0')
+  svg.setAttribute('height', '0')
+  svg.setAttribute('aria-hidden', 'true')
+  svg.style.cssText = 'position:fixed;inset:0;overflow:hidden;pointer-events:none'
+
+  const defs = createSvgElement(documentRef, 'defs')
+  const filter = createSvgElement(documentRef, 'filter')
+  filter.id = DOCK_FILTER_ID
+  filter.setAttribute('x', '-8%')
+  filter.setAttribute('y', '-8%')
+  filter.setAttribute('width', '116%')
+  filter.setAttribute('height', '116%')
+  filter.setAttribute('filterUnits', 'objectBoundingBox')
+  filter.setAttribute('color-interpolation-filters', 'sRGB')
+
+  const displacementImage = createSvgElement(documentRef, 'feImage')
+  displacementImage.setAttribute('href', dockDisplacementMap)
+  displacementImage.setAttribute('x', '0')
+  displacementImage.setAttribute('y', '0')
+  displacementImage.setAttribute('width', '100%')
+  displacementImage.setAttribute('height', '100%')
+  displacementImage.setAttribute('preserveAspectRatio', 'none')
+  displacementImage.setAttribute('result', 'bew-dock-displacement-map')
+
+  const displacement = createSvgElement(documentRef, 'feDisplacementMap')
+  displacement.setAttribute('in', 'SourceGraphic')
+  displacement.setAttribute('in2', 'bew-dock-displacement-map')
+  displacement.setAttribute('xChannelSelector', 'R')
+  displacement.setAttribute('yChannelSelector', 'G')
+  displacement.setAttribute('scale', '8')
+
+  filter.append(displacementImage, displacement)
+  defs.append(filter)
+  svg.append(defs)
+  return svg
+}
+
+function syncFilterInRoot(
+  root: Document | ShadowRoot,
+  enabled: boolean,
+  scale: number,
+) {
+  const existing = root.querySelector<SVGSVGElement>(`[${FILTER_DEFINITIONS_ATTRIBUTE}]`)
+
+  if (!enabled) {
+    existing?.remove()
+    return
+  }
+
+  const svg = existing ?? createDockFilterDefinitions(root.ownerDocument ?? root)
+  svg.querySelector(`#${DOCK_FILTER_ID} feDisplacementMap`)?.setAttribute('scale', scale.toFixed(2))
+
+  if (!existing) {
+    if (root instanceof Document)
+      root.documentElement.append(svg)
+    else
+      root.append(svg)
+  }
+}
+
+export function supportsDockLiquidGlass(): boolean {
+  return typeof CSS !== 'undefined'
+    && (
+      CSS.supports('backdrop-filter', DOCK_LIQUID_GLASS_FILTER_URL)
+      || CSS.supports('-webkit-backdrop-filter', DOCK_LIQUID_GLASS_FILTER_URL)
+    )
+}
+
+/**
+ * 仅在 Bewly Shadow DOM 中同步 Dock 专用滤镜。
+ * 贴图只生成一次，开关变化只同步 SVG 定义，不触发逐帧计算。
+ */
+export function syncDockLiquidGlassFilter(enabled: boolean): boolean {
+  const supported = supportsDockLiquidGlass()
+  const shouldEnable = enabled && supported
+  const shadowRoot = document.getElementById('bewly')?.shadowRoot
+
+  // 清理旧版本可能留在页面文档中的重复定义。
+  syncFilterInRoot(document, false, DOCK_REFRACTION_SCALE)
+
+  if (!shouldEnable || !shadowRoot) {
+    if (shadowRoot)
+      syncFilterInRoot(shadowRoot, false, DOCK_REFRACTION_SCALE)
+    return false
+  }
+
+  if (!dockDisplacementMap)
+    dockDisplacementMap = createDockDisplacementMap()
+
+  syncFilterInRoot(shadowRoot, true, DOCK_REFRACTION_SCALE)
+
+  return true
+}


### PR DESCRIPTION
## 背景

这是对 Liquid Glass 的一次 **V2 完全重构**，没有鼠标跟踪，只有少量实时运算，但依然大幅提升了UI美感。

之前的实现带有较强的试验性质，整体观感比较生硬，边缘、阴影和交互状态也不够统一；同时，大面积 SVG 位移和重复模糊带来了偏高的渲染成本。

这一版经过了较长时间的反复打磨，从材质体系、交互状态、设置项到渲染路径都重新设计，并不是对旧样式的简单微调。实际观感相比旧版提升了一个档次，性能开销也明显降低。

## 为什么保留这个选项

Liquid Glass 是大家仍在逐渐适应的一种美学趋势，它未必适合所有人，但值得给用户一个尝试的选择。

设备性能差异不应该通过直接取消功能来解决，更合适的方式是：

- 默认关闭，不影响现有用户
- 提供完整的启用开关
- 提供独立的模糊和着色强度
- 明确提示可能影响性能
- 让性能有限的设备保持关闭
- 让显卡有余量、喜欢这种风格的用户自行开启

视觉效果本身具有主观性，因此这次不会强制替换现有样式，而是给用户增加一个可控的外观选项。

## 主要改动

- 完全重构全局 Liquid Glass 材质、着色、边缘高光和阴影层级
- 适配顶栏按钮、Logo、搜索框与搜索弹窗
- 适配 Dock、菜单、对话框、选择器等通用组件
- 适配主页导航和布局切换器
- 适配播放页弹幕列表、选集列表和合集列表
- 调整按钮边缘、悬停高光和选中状态，减少过度凸起感
- 修复 Logo 悬停与激活状态互相覆盖的问题
- 修复暗黑模式切换时 Dock 阴影跟踪丢失的问题
- 移除 Dock 悬停时过强的白色阴影和高光
- 修复搜索弹窗高度锁死、滚动和展开后圆角变方的问题
- 修复播放页嵌套玻璃、重复模糊和弹幕列表边界异常
- 移除主页频道切换加载时右上角的小圆圈

## 设置调整

所有相关选项均移动到「外观」栏目：

- 启用伪 Liquid Glass 效果
- Liquid Glass 模糊强度
- Liquid Glass 玻璃着色
- 禁用阴影

Liquid Glass 与普通毛玻璃互斥，避免两套滤镜重复叠加。

功能默认关闭；开启后的默认模糊强度为 `8px`，默认玻璃着色为 `40%`，用户可以继续按设备性能和个人喜好调整。

## 性能优化

V2 不再对大面积面板全局使用昂贵的 SVG 位移，而是采用分层方案：

- 大面积区域使用加强版毛玻璃模拟 Liquid Glass 材质
- 仅 Dock 和主页选中控件保留局部 SVG 折射
- 合并重复的 `backdrop-filter`
- 避免嵌套玻璃和重复模糊
- 位移贴图按照元素实际尺寸生成
- 合并同一帧内的尺寸更新
- 使用有界缓存复用已经生成的位移贴图
- Dock 位移贴图只生成一次，不跟随鼠标逐帧计算
- Dock 滤镜只注入实际使用的 Shadow DOM
- 关闭效果或组件卸载时清理观察器、动画帧和缓存

相较旧实现，这一版的性能表现会好很多，尤其是在大面积面板、布局变化和播放页列表场景中。

## 测试

已经对以下场景进行了多轮手动测试，目前没有发现明显问题：

- 主页导航与布局切换
- 顶栏按钮和 Logo 状态
- 搜索框与搜索弹窗
- Dock 悬停、阴影跟踪和暗黑模式切换
- 播放页弹幕、选集和合集列表
- 模糊、着色、阴影及互斥开关
- Chrome/Edge 与 Firefox 构建

同时通过：

- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm build-firefox`

## 说明

Liquid Glass V2 是一个可选的视觉方向，不会默认开启，也不会强制所有用户承担额外性能开销。

保留默认关闭、完整开关、独立强度和性能提示，可以同时照顾性能有限的设备，以及希望获得更丰富视觉体验的用户。