### PR TITLE
fix: 回退 1.6.10 顶栏设计并修复超出 main 内容区

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ node_modules
 extension-safari-macos/
 # src/old-extension/
 .playwright-mcp/
+# 本地计划
+UI-FIX-PLAN.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,14 @@ BewlyCat is a browser extension that enhances the Bilibili homepage experience. 
 - `pnpm lint:fix` - Run ESLint with auto-fix
 - `pnpm typecheck` - Run TypeScript type checking
 
+### Verification Requirement (MANDATORY)
+After **every** code change—no matter how small—agents MUST run both commands below and ensure they pass before considering the work complete:
+```powershell
+pnpm lint
+pnpm typecheck
+```
+This is non-negotiable. A "one-line cosmetic change" can still break TypeScript (e.g. a component prop that became `required` upstream) or trip ESLint rules. Local `typecheck` passing is the leading indicator for CI; skipping it lets failures reach the PR and wastes a CI cycle.
+
 ### Build Process
 The project uses a multi-target build system:
 - Chrome/Edge: builds to `extension/` directory

--- a/src/components/TopBar/components/TopBarHeader.vue
+++ b/src/components/TopBar/components/TopBarHeader.vue
@@ -119,9 +119,9 @@ function refreshSearchContent() {
 <template>
   <main
     class="top-bar-header"
-    w-full
+    max-w="$bew-page-max-width"
     grid="~ cols-[auto_1fr_auto] items-center gap-4"
-    p="x-4 md:x-6 xl:x-8" m-auto
+    p="x-12" m-auto
     h="$bew-top-bar-height"
   >
     <!-- Top bar mask -->
@@ -275,6 +275,7 @@ function refreshSearchContent() {
   flex: 1 1 auto;
 }
 
+// 窄屏响应式 padding（避免窄屏下 x-48px 过于挤压）
 @media (max-width: 1279px) {
   .top-bar-header {
     gap: 12px;

--- a/src/components/TopBar/components/TopBarLogo.vue
+++ b/src/components/TopBar/components/TopBarLogo.vue
@@ -110,7 +110,7 @@ const channels = setupTopBarItemHoverEvent('channels')
       </a>
     </div>
 
-    <BewlyOrBiliPageSwitcher v-if="settings.showBewlyOrBiliPageSwitcher" z-1 />
+    <BewlyOrBiliPageSwitcher v-if="settings.showBewlyOrBiliPageSwitcher" :force-white-icon="forceWhiteIcon" z-1 />
 
     <TopBarPinnedChannels :force-white-icon="forceWhiteIcon" />
   </div>

--- a/src/components/TopBar/components/TopBarLogo.vue
+++ b/src/components/TopBar/components/TopBarLogo.vue
@@ -2,7 +2,6 @@
 import { storeToRefs } from 'pinia'
 import { ref } from 'vue'
 
-import bilibiliBrandLogoUrl from '~/assets/branding/bilibili-brand-logo.png'
 import { settings } from '~/logic'
 import { useTopBarStore } from '~/stores/topBarStore'
 
@@ -42,22 +41,36 @@ const channels = setupTopBarItemHoverEvent('channels')
           ref="logo"
           href="//www.bilibili.com"
           target="_top"
-          class="group logo top-bar-brand-button"
+          class="group logo"
           :class="{
-            'activated': popupVisible.channels,
-            'top-bar-brand-button--white': forceWhiteIcon,
+            activated: popupVisible.channels,
           }"
-          aria-label="Bilibili"
+          grid="~ place-items-center"
+          rounded="46px"
+          duration-300
+          w-46px h-46px
+          bg="hover:$bew-theme-color"
           @click="(event: MouseEvent) => handleClickTopBarItem(event, 'channels')"
         >
-          <span
-            class="top-bar-brand-button__logo"
+          <svg
+            t="1720198072316"
+            class="icon"
+            viewBox="0 0 1024 1024"
+            version="1.1"
+            xmlns="http://www.w3.org/2000/svg"
+            p-id="1477"
+            width="36"
+            height="36"
             :style="{
-              maskImage: `url(${bilibiliBrandLogoUrl})`,
-              WebkitMaskImage: `url(${bilibiliBrandLogoUrl})`,
+              fill: forceWhiteIcon ? 'white' : 'var(--bew-theme-color)',
+              filter: forceWhiteIcon ? 'drop-shadow(0 0 4px rgba(0, 0, 0, 0.6))' : 'drop-shadow(0 0 4px var(--bew-theme-color-60))',
             }"
-            aria-hidden="true"
-          />
+            group-hover:fill="!white"
+            group-hover:filter="!none"
+            duration-300 mt--1px
+          >
+            <path d="M450.803484 456.506027l-120.670435 23.103715 10.333298 45.288107 119.454151-23.102578-9.117014-45.289244z m65.04448 120.060586c-29.483236 63.220622-55.926329 15.502222-55.926328 15.502223l-19.754098 12.768142s38.90176 53.192249 75.986489 12.764729c43.770311 40.42752 77.203911-13.068516 77.203911-13.068516l-17.934791-11.55072c0.001138-0.304924-31.305956 44.983182-59.575183-16.415858z m59.57632-74.773617L695.182222 524.895573l10.029511-45.288106-120.364373-23.103716-9.423076 45.289245z m237.784178-88.926436c-1.905778-84.362809-75.487004-100.540871-75.487004-100.540871s-57.408853-0.316302-131.944676-0.95232l54.237867-52.332089s8.562916-10.784996-6.026809-22.834062c-14.592-12.051342-15.543182-6.660551-20.615396-3.487289-4.441884 3.169849-69.462471 66.920676-80.878933 78.340551-29.494613 0-60.2624-0.319716-90.075591-0.319716h10.466418s-77.705671-76.754489-82.781298-80.241777c-5.075627-3.488427-5.709369-8.56064-20.616533 3.487289-14.589724 12.05248-6.026809 22.8352-6.026809 22.8352l55.504213 53.919288c-60.261262 0-112.280462 0.319716-136.383147 1.268623-78.025387 22.521173-71.99744 100.859449-71.99744 100.859449s0.950044 168.100978 0 253.103217c8.562916 85.00224 73.899804 98.636231 73.899805 98.636231s26.007324 0.63488 45.357511 0.63488c1.900089 5.391929 3.486151 32.034133 33.302756 32.034134 29.495751 0 33.30048-32.034133 33.30048-32.034134s217.263218-0.950044 235.340231-0.950044c0.953458 9.196658 5.394204 33.619058 35.207395 33.303893 29.494613-0.636018 31.714418-35.20512 31.714418-35.20512s10.151253-0.95232 40.280747 0c70.413653-13.005938 74.534684-95.468658 74.534684-95.468657s-1.265209-169.689316-0.312889-254.056676zM752.628622 681.8304c0 13.319964-10.467556 24.102684-23.471218 24.102684H300.980907c-13.003662 0-23.47008-10.78272-23.47008-24.102684V397.961671c0-13.32224 10.467556-24.106098 23.47008-24.106098h428.176497c13.003662 0 23.471218 10.783858 23.471218 24.106098v283.868729z" p-id="1478" />
+          </svg>
         </a>
 
         <Transition name="slide-in">
@@ -97,11 +110,7 @@ const channels = setupTopBarItemHoverEvent('channels')
       </a>
     </div>
 
-    <BewlyOrBiliPageSwitcher
-      v-if="settings.showBewlyOrBiliPageSwitcher"
-      :force-white-icon="forceWhiteIcon"
-      z-1
-    />
+    <BewlyOrBiliPageSwitcher v-if="settings.showBewlyOrBiliPageSwitcher" z-1 />
 
     <TopBarPinnedChannels :force-white-icon="forceWhiteIcon" />
   </div>
@@ -118,7 +127,10 @@ const channels = setupTopBarItemHoverEvent('channels')
 .logo {
   &.activated {
     background-color: var(--bew-theme-color);
-    color: white;
+    svg {
+      fill: white !important;
+      filter: none !important;
+    }
   }
 }
 
@@ -133,88 +145,8 @@ const channels = setupTopBarItemHoverEvent('channels')
   }
 }
 
-.top-bar-brand-button {
-  display: inline-flex;
-  box-sizing: border-box;
-  align-items: center;
-  justify-content: center;
-  height: 46px;
-  padding: 0 9px;
-  border: 0;
-  border-radius: var(--bew-top-bar-control-radius);
-  background: transparent;
-  color: var(--bew-theme-color);
-  backdrop-filter: none;
-  transition:
-    color 0.2s ease,
-    background-color 0.2s ease;
-
-  &:hover {
-    background: var(--bew-theme-color);
-    color: white;
-  }
-
-  &--white {
-    background: transparent;
-    color: white;
-
-    &:hover {
-      background: rgba(255, 255, 255, 0.2);
-    }
-  }
-
-  &__logo {
-    width: 84px;
-    height: 28px;
-    flex: none;
-    background: currentColor;
-    mask-position: center;
-    mask-repeat: no-repeat;
-    mask-size: contain;
-    -webkit-mask-position: center;
-    -webkit-mask-repeat: no-repeat;
-    -webkit-mask-size: contain;
-    filter: drop-shadow(0 0 4px currentColor);
-  }
-}
-
 .top-bar-logo {
   min-width: 0;
   flex: 0 1 auto;
-}
-
-@media (max-width: 1100px) {
-  .top-bar-brand-button {
-    height: 46px;
-    padding: 0 7px;
-
-    &__logo {
-      width: 72px;
-      height: 24px;
-    }
-  }
-}
-
-@media (max-width: 767px) {
-  .top-bar-brand-button {
-    width: 46px;
-    height: 46px;
-    padding: 0 8px;
-
-    &__logo {
-      width: 24px;
-      height: 24px;
-      mask-position: left center;
-      mask-size: auto 24px;
-      -webkit-mask-position: left center;
-      -webkit-mask-size: auto 24px;
-    }
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .top-bar-brand-button {
-    transition: none;
-  }
 }
 </style>

--- a/src/components/TopBar/components/TopBarRight.vue
+++ b/src/components/TopBar/components/TopBarRight.vue
@@ -188,14 +188,18 @@ function handleNotificationsClick(item: { name: string, url: string, unreadCount
   emit('notificationsClick', item)
 }
 
-// 分组内没有可见功能时隐藏容器，避免出现空胶囊
-const showContentActionGroup = computed(() => {
-  return ['moments', 'favorites', 'history', 'watchLater', 'creatorCenter']
-    .some(key => isComponentVisible(key))
-})
+// 判断分割线是否应该显示：左右两组至少各有一个可见时才显示
+const shouldShowDivider = computed(() => {
+  const leftSideVisible = isComponentVisible('moments')
+    || isComponentVisible('favorites')
+    || isComponentVisible('history')
+    || isComponentVisible('watchLater')
+    || isComponentVisible('creatorCenter')
 
-const showUtilityActionGroup = computed(() => {
-  return ['upload', 'notifications'].some(key => isComponentVisible(key))
+  const rightSideVisible = isComponentVisible('upload')
+    || isComponentVisible('notifications')
+
+  return leftSideVisible && rightSideVisible
 })
 </script>
 
@@ -206,7 +210,7 @@ const showUtilityActionGroup = computed(() => {
   >
     <div
       class="others"
-      flex="~ items-center gap-2" h-46px px-5px
+      flex="~ items-center gap-1" h-46px px-5px
       text="$bew-text-1"
     >
       <div
@@ -215,16 +219,13 @@ const showUtilityActionGroup = computed(() => {
         important-w-auto
       >
         <a href="https://passport.bilibili.com/login" class="login">
-          <div i-solar:user-circle-bold-duotone class="text-xl login-icon" />
-          <span class="login-label">{{ $t('topbar.sign_in') }}</span>
+          <div i-solar:user-circle-bold-duotone class="text-xl mr-2" />{{
+            $t('topbar.sign_in')
+          }}
         </a>
       </div>
       <template v-if="isLogin">
-        <div
-          v-if="showContentActionGroup"
-          class="top-bar-action-group top-bar-action-group--content hidden xl:flex"
-          :class="{ 'top-bar-action-group--white': forceWhiteIcon }"
-        >
+        <div class="hidden lg:flex" gap-1>
           <!-- Moments -->
           <div
             v-if="isComponentVisible('moments')"
@@ -375,7 +376,7 @@ const showUtilityActionGroup = computed(() => {
         <!-- More -->
         <div
           ref="more"
-          class="right-side-item xl:!hidden flex"
+          class="right-side-item lg:!hidden flex"
           :class="{ active: popupVisible?.more }"
           @click="(event: MouseEvent) => handleClickTopBarItem(event, 'more')"
         >
@@ -396,11 +397,15 @@ const showUtilityActionGroup = computed(() => {
           </Transition>
         </div>
 
-        <div
-          v-if="showUtilityActionGroup"
-          class="top-bar-action-group top-bar-action-group--utility hidden xl:flex"
-          :class="{ 'top-bar-action-group--white': forceWhiteIcon }"
-        >
+        <div class="hidden lg:flex" gap-1 items-center>
+          <!-- Divider -->
+          <div
+            v-if="shouldShowDivider"
+            :class="{ 'white-icon': forceWhiteIcon }"
+            w-2px h-16px bg="$bew-border-color" mx-1
+            rounded-4px
+          />
+
           <!-- Upload -->
           <div
             v-if="isComponentVisible('upload')"
@@ -540,51 +545,4 @@ const showUtilityActionGroup = computed(() => {
 
 <style lang="scss" scoped>
 @use "../styles/index.scss";
-
-.top-bar-action-group {
-  position: relative;
-  box-sizing: border-box;
-  align-items: center;
-  gap: 2px;
-  height: var(--bew-top-bar-control-height);
-  padding: 2px 3px;
-  border: 1px solid var(--bew-top-bar-control-border-color);
-  border-radius: var(--bew-top-bar-control-radius);
-  transition: border-color 0.3s ease;
-
-  // 将胶囊磨砂放在伪元素上，避免父级背板阻断子级 POP 的背景模糊
-  &::before {
-    position: absolute;
-    border-radius: inherit;
-    background: var(--bew-top-bar-control-background);
-    backdrop-filter: var(--bew-filter-glass-1);
-    content: "";
-    inset: 0;
-    pointer-events: none;
-    transition: background-color 0.3s ease;
-  }
-
-  &--white {
-    border-color: rgba(255, 255, 255, 0.18);
-
-    &::before {
-      background: rgba(255, 255, 255, 0.1);
-    }
-  }
-}
-
-.login {
-  gap: 8px;
-}
-
-@media (max-width: 767px) {
-  .others {
-    gap: 4px;
-    padding-inline: 0;
-  }
-
-  .login-label {
-    display: none;
-  }
-}
 </style>


### PR DESCRIPTION
## 背景

1.6.10 的PR导致三处可见的 UI 问题：

1. **左上角 Logo** 从 46×46 圆形 SVG 图标按钮改为横向品牌字胶囊
   （`top-bar-brand-button` + `bilibili-brand-logo.png`）
2. **右侧按钮组** 被新增的 `top-bar-action-group` 胶囊容器包裹
   （border + radius:999px + 玻璃），同时分割线被删除、响应式断点从
   `lg` 改为 `xl`（1024-1280px 按钮被折进 More 菜单）
3. **顶栏宽度** 因 `max-w="$bew-page-max-width"` 被改为 `w-full` 而
   满宽溢出 main 内容区

## 改动内容

`fix(topbar): Logo 回退为 v1.6.9 圆形 SVG 图标按钮`
`fix(topbar): 右侧按钮组去除胶囊容器并恢复分割线`
`fix(topbar): 修复顶栏超出 main 内容区`

## 保留部分

`BewlyOrBiliPageSwitcher.vue`
`--bew-top-bar-control-*` CSS 变量
`syncSharedData` 优化
底部分割线、窄屏搜索框补偿优化、search-content wrapper 等

## 验证

- [x] `pnpm typecheck` 通过
- [x] 亮色/暗色模式视觉正常
- [x] 不同窗口宽度下按钮组完整可见
- [x] 顶栏左右边缘与 main 内容区对齐
- [ ] 消息同步功能正常