### PR TITLE
fix:修复从 Search 页面切到 SearchResults 时会清空顶栏搜索框的问题;

### DIFF
--- a/src/contentScripts/views/Search/Search.vue
+++ b/src/contentScripts/views/Search/Search.vue
@@ -10,9 +10,13 @@ const searchInput = ref<string>('')
 const topBarStore = useTopBarStore()
 const { searchKeyword: topBarSearchKeyword } = storeToRefs(topBarStore)
 
-// 页面卸载时清空顶栏搜索框（真正离开搜索页面）
+// 仅在真正离开搜索流程时清空顶栏搜索框。
+// 从 Search 切换到 SearchResults 时，目标页会先把 URL 中的关键词同步到顶栏；
+// 此处若无条件清空，会在组件切换期间覆盖该关键词。
 onUnmounted(() => {
-  topBarSearchKeyword.value = ''
+  const destinationPage = new URLSearchParams(window.location.search).get('page')
+  if (destinationPage !== 'SearchResults')
+    topBarSearchKeyword.value = ''
 })
 
 function performInPlaceSearch(keyword: string) {


### PR DESCRIPTION
**背景**

从项目内 Search 页面跳转到 SearchResults 页面时，搜索结果能够正常加载，但顶栏搜索框中的关键词会被清空。

原因是 SearchResults 页面先将 URL 中的 `keyword` 同步到 `topBarSearchKeyword`，随后旧的 Search 组件卸载，并在 `onUnmounted` 中无条件清空该状态，覆盖了已同步的关键词。
<img width="2559" height="610" alt="image" src="https://github.com/user-attachments/assets/89fc3562-53a8-4042-aa8d-703b6a4c844f" />


**改动内容**

仅在真正离开搜索流程时清空顶栏搜索关键词  
从 Search 切换到 SearchResults 时保留输入框内容  
 修复组件切换期间搜索关键词被旧页面覆盖的问题


**验证**

`pnpm lint` 通过  
`pnpm typecheck` 通过  
从 Search 页面搜索后，顶栏正确显示当前关键词  
搜索结果能够正常加载  
在搜索结果页再次搜索时，输入框与 URL 关键词保持同步  
离开搜索相关页面后，顶栏搜索关键词正常清空  
<img width="2560" height="611" alt="image" src="https://github.com/user-attachments/assets/4daf4d50-f424-4c9a-8167-17fb9e4ed816" />
