### PR TITLE
refactor: 优化 liquid-indicator

### DIFF
--- a/src/composables/useLiquidSegmentIndicator.ts
+++ b/src/composables/useLiquidSegmentIndicator.ts
@@ -10,7 +10,7 @@ export interface LiquidSegmentRect {
 }
 
 /** Keep in sync with CSS move duration for wheel threshold / cooldown */
-export const LIQUID_MOVE_DURATION_MS = 580
+export const LIQUID_MOVE_DURATION_MS = 400
 
 function lerp(from: number, to: number, progress: number) {
   return from + (to - from) * progress
@@ -20,11 +20,9 @@ function clamp(value: number, min: number, max: number) {
   return Math.min(max, Math.max(min, value))
 }
 
-function easeInOutCubic(t: number) {
+function easeOutCubic(t: number) {
   const p = clamp(t, 0, 1)
-  return p < 0.5
-    ? 4 * p * p * p
-    : 1 - ((-2 * p + 2) ** 3) / 2
+  return 1 - (1 - p) ** 3
 }
 
 interface LiquidGeometry {
@@ -54,20 +52,22 @@ function computeLiquidGeometry(from: LiquidSegmentRect, to: LiquidSegmentRect, t
   const dist = Math.hypot(dx, dy)
   const isHoriz = Math.abs(dx) >= Math.abs(dy)
 
-  // Position eases with a slight lead so the blob reaches destination first
-  const posT = easeInOutCubic(progress)
-  // Size eases a bit slower → elastic length change
-  const sizeT = easeInOutCubic(clamp((progress - 0.02) / 0.98, 0, 1))
-
-  const baseW = lerp(from.width, to.width, sizeT)
-  const baseH = lerp(from.height, to.height, sizeT)
+  // Position and size share the same eased progress so width/height never
+  // lag behind translation — that was what produced the "runs, then shrinks"
+  // two-stage read.
+  const posT = easeOutCubic(progress)
+  const baseW = lerp(from.width, to.width, posT)
+  const baseH = lerp(from.height, to.height, posT)
   const baseCx = lerp(from.x + from.width / 2, to.x + to.width / 2, posT)
   const baseCy = lerp(from.y + from.height / 2, to.y + to.height / 2, posT)
 
-  // Mid-travel stretch (peaks at 0.5). Caps at a fraction of travel distance
-  // so short steps stay subtle and long steps feel liquid without becoming a ball.
-  const mid = Math.sin(Math.PI * progress)
-  const stretch = Math.min(dist * 0.42, Math.max(baseW, baseH) * 0.85) * mid
+  // Stretch is bound to *remaining* distance, not an independent envelope:
+  // the blob elongates while it still has ground to cover and snaps back to
+  // its resting pill shape the instant it arrives. This is what makes the
+  // motion read as a single liquid gesture instead of move + settle.
+  const remaining = 1 - posT
+  const envelope = remaining ** 0.5
+  const stretch = Math.min(dist * 0.40, Math.max(baseW, baseH) * 0.8) * envelope
 
   if (isHoriz) {
     const width = baseW + stretch

--- a/src/styles/segmentLiquidIndicator.scss
+++ b/src/styles/segmentLiquidIndicator.scss
@@ -14,11 +14,14 @@
     opacity 200ms ease,
     background-color 220ms ease,
     box-shadow 220ms ease;
-  will-change: transform, width, height;
+  // Only transform is compositor-friendly; width/height are set via JS
+  // inline styles and don't benefit from will-change hints.
+  will-change: transform;
+  contain: layout style;
   transform-origin: center center;
 
   &.is-moving {
-    filter: saturate(1.06);
+    filter: saturate(1.12);
   }
 }
 


### PR DESCRIPTION
## 概述

对液体指示器（liquid-indicator）的动画时序与合成做了一次综合优化

## 主要改动

**统一位置与尺寸的缓动**：位置（translate）与宽高（width / height）共用同一 `easeOutCubic` 进度，避免尺寸变化滞后于位移
**拉伸绑定剩余距离**：中段拉伸量改为随剩余位移衰减（`remaining^0.5`），位置到达时拉伸同步归零
**时长调整**：将 `LIQUID_MOVE_DURATION_MS` 调整为更克制的400
**合成与隔离优化**：在 `segmentLiquidIndicator.scss` 中显式声明 `will-change: transform` 与 `contain: layout style`，并将几何属性交由 rAF 驱动
**运动中视觉反馈**：`.is-moving` 状态下通过 `filter: saturate(...)` 给出轻微的材质反馈

## 验证

- `pnpm typecheck` 通过
- `pnpm lint` 通过