### PR TITLE
fix: 修复稍后再看入口顶栏与 URL 参数处理

### DIFF
--- a/src/contentScripts/index.ts
+++ b/src/contentScripts/index.ts
@@ -16,7 +16,7 @@ import { captureOriginalBilibiliTopBar, ensureOriginalBilibiliTopBarAppended, re
 import { initFavoriteDialogEnhancement } from '~/utils/favoriteDialog'
 import { runWhenIdle } from '~/utils/lazyLoad'
 import { getLocalWallpaper, hasLocalWallpaper, isLocalWallpaperUrl } from '~/utils/localWallpaper'
-import { compareVersions, getCookie, injectCSS, isElectron, isHomePage, isInIframe, isNotificationPage, isVideoOrBangumiPage, isVideoPlaybackPage } from '~/utils/main'
+import { compareVersions, getCookie, injectCSS, isElectron, isHomePage, isInIframe, isNotificationPage, isVideoOrBangumiPage, isVideoPlaybackPage, isWatchLaterListPage } from '~/utils/main'
 import { initNativeFavoriteSeasonPlayAllIntercept } from '~/utils/nativeFavoriteSeasonPlayAll'
 import { applyAutoPlayByVideoType, applyDefaultCaptionState, applyDefaultDanmakuState, defaultMode, handleVideoPageNavigation, isPlayerDisplayModeReady, isVideoPage, resolveDefaultVideoPlayerMode, startAutoExitFullscreenMonitoring, startAutoPlayUserChangeMonitoring, webFullscreen, widescreen } from '~/utils/player'
 import { applyRandomPlayActivationSettings, destroyRandomPlay, initRandomPlay, isCustomPlayPage, resetRandomPlayInitialization, syncRandomPlayOrder } from '~/utils/randomPlay'
@@ -72,8 +72,8 @@ function isSupportedPages(): boolean {
     isHomePage()
     // video or bangumi page
     || isVideoOrBangumiPage()
-    // watchlater list page
-    || /https?:\/\/(?:www\.)?bilibili\.com\/watchlater\/list.*/.test(currentUrl)
+    // watch later list page
+    || isWatchLaterListPage(currentUrl)
     // popular page https://www.bilibili.com/v/popular/all
     || /https?:\/\/(?:www\.)?bilibili\.com\/v\/popular\/all.*/.test(currentUrl)
     // search page
@@ -89,9 +89,6 @@ function isSupportedPages(): boolean {
     // history page
     || /https?:\/\/(?:www\.)?bilibili\.com\/history.*/.test(currentUrl)
     || /https?:\/\/(?:www\.)?bilibili\.com\/account\/history.*/.test(currentUrl)
-    // watcher later page
-    || /https?:\/\/(?:www\.)?bilibili\.com\/watchlater\/#\/list.*/.test(currentUrl)
-    || /https?:\/\/(?:www\.)?bilibili\.com\/watchlater\/list.*/.test(currentUrl)
     // user space page
     || /https?:\/\/space\.bilibili\.com\.*/.test(currentUrl)
     // notifications page
@@ -140,8 +137,7 @@ export function isSupportedIframePages(): boolean {
       || /https?:\/\/www\.bilibili\.com\/anime.*/.test(currentUrl)
       || /https?:\/\/space\.bilibili\.com\/\d+\/favlist.*/.test(currentUrl)
       || /https?:\/\/www\.bilibili\.com\/history.*/.test(currentUrl)
-      || /https?:\/\/www\.bilibili\.com\/watchlater\/#\/list.*/.test(currentUrl)
-      || /https?:\/\/www\.bilibili\.com\/watchlater\/list.*/.test(currentUrl)
+      || isWatchLaterListPage(currentUrl)
       // moments page
       // https://github.com/BewlyBewly/BewlyBewly/issues/1246
       // https://github.com/BewlyBewly/BewlyBewly/issues/1256

--- a/src/styles/adaptedStyles/index.ts
+++ b/src/styles/adaptedStyles/index.ts
@@ -3,7 +3,7 @@ import './shadowDom'
 import './thirdParties'
 
 import { settings, settingsReady } from '~/logic/storage'
-import { isHomePage, isInIframe } from '~/utils/main'
+import { isHomePage, isInIframe, isWatchLaterListPage } from '~/utils/main'
 
 async function setupStyles() {
   const currentUrl = document.URL
@@ -96,10 +96,7 @@ async function setupStyles() {
   }
 
   // watch later page 稍候再看页
-  else if (
-    /https?:\/\/(?:www\.)?bilibili\.com\/watchlater\/list.*/.test(currentUrl)
-    || /https?:\/\/(?:www\.)?bilibili\.com\/watchlater\/#\/list.*/.test(currentUrl)
-  ) {
+  else if (isWatchLaterListPage(currentUrl)) {
     await import('./pages/watchLaterPage.scss')
     document.documentElement.classList.add('watchLaterPage')
   }

--- a/src/utils/main.ts
+++ b/src/utils/main.ts
@@ -175,6 +175,33 @@ export function isHomePage(url: string = location.href): boolean {
 }
 
 /**
+ * Check if the URL points to Bilibili's watch later list page.
+ * Supports both the canonical path and the legacy hash route used by the
+ * user-space favorites entry. See https://github.com/keleus/BewlyCat/issues/841
+ *
+ * @param url the url to check
+ * @returns true if the URL is a watch later list page
+ */
+export function isWatchLaterListPage(url: string): boolean {
+  try {
+    const urlObj = new URL(url)
+    const isHttp = urlObj.protocol === 'http:' || urlObj.protocol === 'https:'
+    const isBilibiliHost = urlObj.hostname === 'www.bilibili.com' || urlObj.hostname === 'bilibili.com'
+    if (!isHttp || !isBilibiliHost)
+      return false
+
+    if (urlObj.pathname === '/watchlater/list' || urlObj.pathname === '/watchlater/list/')
+      return true
+
+    const isLegacyWatchLaterPath = urlObj.pathname === '/watchlater' || urlObj.pathname === '/watchlater/'
+    return isLegacyWatchLaterPath && /^#\/list(?:[/?]|$)/.test(urlObj.hash)
+  }
+  catch {
+    return false
+  }
+}
+
+/**
  * Check if the current page is a video or bangumi page
  * @param url the url to check
  * @returns true if the current page is a video or bangumi page


### PR DESCRIPTION
Closes #841

Summary: 统一稍后再看页面的 URL 判定，修复从个人空间收藏入口进入时追踪参数未清理、BewlyCat 顶栏未生效的问题。