### PR TITLE
fix: 统一 home-tabs-panel 与 grid-switcher 的 padding 结构

### DIFF
--- a/src/contentScripts/views/Home/Home.vue
+++ b/src/contentScripts/views/Home/Home.vue
@@ -581,7 +581,6 @@ function toggleTabContentLoading(loading: boolean) {
 .home-tabs-inside {
   position: relative;
   box-sizing: border-box;
-  padding: var(--bew-top-bar-control-padding);
   gap: var(--bew-top-bar-control-gap);
 }
 


### PR DESCRIPTION
去掉了 .home-tabs-inside 多余的 padding（2px），与 grid-switcher item 一致