### PR TITLE
fix: 修复设置页窄屏侧栏重叠

### DIFF
--- a/src/components/Settings/Settings.vue
+++ b/src/components/Settings/Settings.vue
@@ -909,6 +909,24 @@ function changeMenuItem(menuItem: MenuType) {
   }
 }
 
+@media (max-width: 1279px) {
+  #settings-window {
+    /* 侧栏进入布局后先维持 1000px 内容宽度，空间不足时再连续收缩。 */
+    width: min(calc(1000px + 72px), calc(100% - var(--bew-space-6)));
+    max-width: none;
+    margin-left: calc(-1 * var(--bew-space-1));
+  }
+
+  .settings-primary-navigation {
+    /* xl 以下外侧空间不足：让折叠导航占据布局宽度，展开时仍可覆盖 content。 */
+    position: relative;
+    left: auto !important;
+    width: 72px;
+    box-sizing: border-box;
+    padding-inline: var(--bew-space-2);
+  }
+}
+
 @media (max-width: 760px) {
   .settings-header {
     gap: var(--bew-space-2);
@@ -916,13 +934,7 @@ function changeMenuItem(menuItem: MenuType) {
   }
 
   .settings-primary-navigation {
-    /* 窄屏：取消浮动，改为常驻图标列，避免遮挡 content（触屏无 hover） */
-    position: relative;
-    left: auto !important;
-    width: 72px;
-    box-sizing: border-box;
-    padding-inline: var(--bew-space-2);
-
+    /* 触屏窄屏不依赖 hover，保持常驻图标列。 */
     li {
       width: 100%;
     }


### PR DESCRIPTION
## 变更内容

- 在 `xl` 以下让折叠的设置导航进入布局流，避免覆盖设置内容。
- 保留 `1000px` 设置内容宽度，只有组合布局空间不足时才连续收缩，避免断点处突然贴边。
- 窄屏最终保留左侧 `8px`、右侧 `16px` 安全边距。
- 保持桌面端默认收起、悬停展开；触屏窄屏继续使用常驻图标列。

## 问题原因

原设置导航在 `761–1279px` 视口下仍使用绝对定位和 `left: -44px`。当窗口较窄或浏览器缩放后，导航外侧空间不足，折叠状态就会覆盖设置内容；同时直接切换到近乎全宽会在响应式断点产生明显的尺寸跳变。

## 用户影响

设置页在窄屏和浏览器缩放场景下不再与左侧菜单重叠，内容区域会在空间不足时自然缩小，并保留适当的视口安全边距。

## 验证

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
