### PR TITLE
fix: 停止失效上下文的顶栏状态同步

### DIFF
--- a/src/stores/topBarStore.ts
+++ b/src/stores/topBarStore.ts
@@ -30,7 +30,7 @@ import { settings } from '~/logic'
 import type { List as VideoItem } from '~/models/video/watchLater'
 import api from '~/utils/api'
 import { getCSRF, isHomePage } from '~/utils/main'
-import { onMessage, sendMessage } from '~/utils/messaging'
+import { isExtensionContextInvalidatedError, onMessage, sendMessage } from '~/utils/messaging'
 
 export const useTopBarStore = defineStore('topBar', () => {
   const toast = useToast()
@@ -746,6 +746,12 @@ export const useTopBarStore = defineStore('topBar', () => {
   }
 
   let updateTimer: ReturnType<typeof setInterval> | null = null
+  let sharedStateMessagingUnavailable = false
+
+  function disableSharedStateMessaging() {
+    sharedStateMessagingUnavailable = true
+    stopUpdateTimer()
+  }
 
   function createSharedStateSnapshot(): TopBarSharedState {
     return {
@@ -804,7 +810,7 @@ export const useTopBarStore = defineStore('topBar', () => {
     refresh?: () => Promise<void>
   }
 
-  async function syncSharedData(options: SyncSharedDataOptions = {}) {
+  async function syncSharedDataFromBroker(options: SyncSharedDataOptions) {
     if (!isLogin.value)
       return
 
@@ -855,6 +861,23 @@ export const useTopBarStore = defineStore('topBar', () => {
     }
   }
 
+  async function syncSharedData(options: SyncSharedDataOptions = {}) {
+    if (sharedStateMessagingUnavailable)
+      return
+
+    try {
+      await syncSharedDataFromBroker(options)
+    }
+    catch (error) {
+      if (!isExtensionContextInvalidatedError(error))
+        throw error
+
+      // 扩展重新加载后，旧 content script 的 runtime 无法恢复。
+      // 停止轮询并让后续同步短路，等待后台刷新提示引导页面加载新脚本。
+      disableSharedStateMessaging()
+    }
+  }
+
   function syncUnreadMessageState() {
     return syncSharedData({
       force: true,
@@ -878,13 +901,18 @@ export const useTopBarStore = defineStore('topBar', () => {
 
   function invalidateUnreadMessageState() {
     const accountId = userInfo.mid
-    if (!accountId)
+    if (!accountId || sharedStateMessagingUnavailable)
       return Promise.resolve()
 
     return sendMessage<TopBarStateInvalidate>(
       TOP_BAR_STATE_MESSAGE.INVALIDATE,
       { accountId },
-    )
+    ).catch((error) => {
+      if (!isExtensionContextInvalidatedError(error))
+        throw error
+
+      disableSharedStateMessaging()
+    })
   }
 
   async function initData() {

--- a/src/utils/messaging.ts
+++ b/src/utils/messaging.ts
@@ -10,6 +10,11 @@ export type MessageHandler<T = any, R = any> = (
   sender?: browser.Runtime.MessageSender,
 ) => R | Promise<R>
 
+export function isExtensionContextInvalidatedError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  return message.toLowerCase().includes('extension context invalidated')
+}
+
 /**
  * 从 content script 发送消息到 background
  */


### PR DESCRIPTION
## 改动

- 增加扩展上下文失效错误的统一识别方法。
- 顶栏共享状态同步遇到 `Extension context invalidated` 后停止定时轮询，并让后续同步与缓存失效请求直接短路。
- 保留其他网络、API 和状态 broker 错误的原有抛出与日志行为。

## 原因

扩展被重新编译或重新加载后，已打开页面中的旧 content script 仍可能响应窗口聚焦、弹窗关闭或定时刷新事件。Chrome 会永久废弃这些脚本持有的扩展 runtime，上述事件再次向 background 发送消息时便会抛出 `Extension context invalidated`。

旧 runtime 无法在原执行上下文中恢复；继续重试只会重复产生预期错误。项目已有的后台刷新提示负责引导页面加载新脚本，因此这里在首次识别失效后安全停用共享状态消息通道。

## 影响

- 旧页面不会再反复输出“同步顶栏共享状态失败”。
- 不会继续对已失效的 runtime 发起顶栏状态同步。
- 页面刷新后仍按现有流程恢复完整扩展功能。
- 非上下文失效错误仍会正常暴露，避免掩盖真实故障。

## 验证

- `pnpm lint`
- `pnpm typecheck`
- `git diff --check`
