### PR TITLE
fix: 修复设置开关聚焦导致页面滚动

### DIFF
--- a/src/components/Radio.vue
+++ b/src/components/Radio.vue
@@ -22,16 +22,19 @@ label {
   --b-switch-border-width: 1px;
   --b-switch-edge-inset: 2px;
   --b-switch-thumb-size: 20px;
+
+  position: relative;
 }
 
 .radio-input {
   position: absolute;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-  clip: rect(0 0 0 0);
-  clip-path: inset(50%);
-  white-space: nowrap;
+  z-index: 1;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  cursor: inherit;
+  opacity: 0;
 }
 
 .radio-switch {


### PR DESCRIPTION
## 改动说明

- 为公共 `Radio` 开关的 `label` 建立局部定位上下文。
- 将真实 checkbox 从脱离控件位置的 `1×1` 裁切元素，调整为透明覆盖在对应 label 内。
- 保留现有开关尺寸、配色、动画、状态样式、`v-model` 与键盘焦点反馈。

## 原因

原实现中的 checkbox 使用绝对定位，但其祖先没有定位上下文。设置页内容较长时，真实 checkbox 会落在距离可见开关很远的位置。通过鼠标点击开关后，浏览器会自动滚动以显示获得焦点的 checkbox，导致设置内容整体上移，看起来像页面空白或只剩一部分。

该问题由公共开关组件引起，因此会同时影响“启用背景遮罩效果”“移除中文标点符号的缩进”“覆盖弹幕字体”“自定义 CSS”等多个设置项，并非这些设置各自的 watcher 或功能实现导致。

## 影响

切换设置开关后不再发生设置面板异常滚动，同时继续使用真实 checkbox，保留鼠标、键盘和焦点可访问性行为。

## 验证

- `pnpm lint`
- `pnpm typecheck`
- 使用真实指针事件验证上述四个开关，切换前后设置容器位置与 `scrollTop` 保持不变。
- 检查设置组件，未发现另一处使用相同 `1×1` 绝对定位可聚焦输入的实现。

Closes #847
