### PR TITLE
feat: 支持单独设置毛玻璃颜色

### DIFF
--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -277,9 +277,9 @@ settings:
     Bilibili 默认会专门处理中文标点符号以实现左对齐。 如果你正在使用自定义字体，建议移除缩进。
   enable_frosted_glass: 启用毛玻璃效果
   frosted_glass_blur_intensity: 毛玻璃模糊强度
-  use_separate_frosted_glass_color: 使用独立毛玻璃颜色
-  use_separate_frosted_glass_color_desc: 关闭时跟随深色模式基准颜色；仅在深色模式下生效。
-  frosted_glass_base_color: 毛玻璃基准颜色
+  frosted_glass_base_color: 独立毛玻璃颜色
+  frosted_glass_base_color_desc: 第一个选项表示跟随深色模式基准颜色；仅在深色模式下生效。
+  frosted_glass_base_color_default: 跟随深色模式基准颜色
   disable_shadow: 禁用阴影
   link_opening_behavior_opt:
     current_tab: 当前标签页

--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -277,6 +277,9 @@ settings:
     Bilibili 默认会专门处理中文标点符号以实现左对齐。 如果你正在使用自定义字体，建议移除缩进。
   enable_frosted_glass: 启用毛玻璃效果
   frosted_glass_blur_intensity: 毛玻璃模糊强度
+  use_separate_frosted_glass_color: 使用独立毛玻璃颜色
+  use_separate_frosted_glass_color_desc: 关闭时跟随深色模式基准颜色；仅在深色模式下生效。
+  frosted_glass_base_color: 毛玻璃基准颜色
   disable_shadow: 禁用阴影
   link_opening_behavior_opt:
     current_tab: 当前标签页

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -275,6 +275,9 @@ settings:
     Bilibili 預設會特別處理中文標點符號以達到左對齊。 如果你正在使用自訂字型，建議移除縮排。
   enable_frosted_glass: 啟用毛玻璃效果
   frosted_glass_blur_intensity: 毛玻璃模糊強度
+  use_separate_frosted_glass_color: 使用獨立毛玻璃顏色
+  use_separate_frosted_glass_color_desc: 關閉時跟隨深色模式基準顏色；僅在深色模式下生效。
+  frosted_glass_base_color: 毛玻璃基準顏色
   disable_shadow: 停用陰影
   link_opening_behavior_opt:
     current_tab: 目前索引標籤

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -275,9 +275,9 @@ settings:
     Bilibili 預設會特別處理中文標點符號以達到左對齊。 如果你正在使用自訂字型，建議移除縮排。
   enable_frosted_glass: 啟用毛玻璃效果
   frosted_glass_blur_intensity: 毛玻璃模糊強度
-  use_separate_frosted_glass_color: 使用獨立毛玻璃顏色
-  use_separate_frosted_glass_color_desc: 關閉時跟隨深色模式基準顏色；僅在深色模式下生效。
-  frosted_glass_base_color: 毛玻璃基準顏色
+  frosted_glass_base_color: 獨立毛玻璃顏色
+  frosted_glass_base_color_desc: 第一個選項表示跟隨深色模式基準顏色；僅在深色模式下生效。
+  frosted_glass_base_color_default: 跟隨深色模式基準顏色
   disable_shadow: 停用陰影
   link_opening_behavior_opt:
     current_tab: 目前索引標籤

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -290,9 +290,9 @@ settings:
     the indent.
   enable_frosted_glass: Enable frosted glass effect
   frosted_glass_blur_intensity: Frosted glass blur intensity
-  use_separate_frosted_glass_color: Use a separate frosted glass color
-  use_separate_frosted_glass_color_desc: When off, the dark mode base color is used. This only affects dark mode.
-  frosted_glass_base_color: Frosted glass base color
+  frosted_glass_base_color: Independent frosted glass color
+  frosted_glass_base_color_desc: The first option follows the dark mode base color. This only affects dark mode.
+  frosted_glass_base_color_default: Follow dark mode base color
   disable_shadow: Disable shadow
   link_opening_behavior_opt:
     current_tab: Current tab

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -290,6 +290,9 @@ settings:
     the indent.
   enable_frosted_glass: Enable frosted glass effect
   frosted_glass_blur_intensity: Frosted glass blur intensity
+  use_separate_frosted_glass_color: Use a separate frosted glass color
+  use_separate_frosted_glass_color_desc: When off, the dark mode base color is used. This only affects dark mode.
+  frosted_glass_base_color: Frosted glass base color
   disable_shadow: Disable shadow
   link_opening_behavior_opt:
     current_tab: Current tab

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -299,9 +299,9 @@ settings:
     Bilibili 預設會專登執吓中文標點符號，令到佢可以左對齊。如果你係用緊自訂字字型，最好係移除縮排。
   enable_frosted_glass: 啓用毛玻璃效果
   frosted_glass_blur_intensity: 毛玻璃模糊強度
-  use_separate_frosted_glass_color: 使用獨立毛玻璃顏色
-  use_separate_frosted_glass_color_desc: 閂咗嗰陣會跟隨深色模式基準顏色；只會喺深色模式生效。
-  frosted_glass_base_color: 毛玻璃基準顏色
+  frosted_glass_base_color: 獨立毛玻璃顏色
+  frosted_glass_base_color_desc: 第一個選項代表跟隨深色模式基準顏色；只會喺深色模式生效。
+  frosted_glass_base_color_default: 跟隨深色模式基準顏色
   disable_shadow: 閂咗陰影
   link_opening_behavior_opt:
     current_tab: 目前分頁

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -299,6 +299,9 @@ settings:
     Bilibili 預設會專登執吓中文標點符號，令到佢可以左對齊。如果你係用緊自訂字字型，最好係移除縮排。
   enable_frosted_glass: 啓用毛玻璃效果
   frosted_glass_blur_intensity: 毛玻璃模糊強度
+  use_separate_frosted_glass_color: 使用獨立毛玻璃顏色
+  use_separate_frosted_glass_color_desc: 閂咗嗰陣會跟隨深色模式基準顏色；只會喺深色模式生效。
+  frosted_glass_base_color: 毛玻璃基準顏色
   disable_shadow: 閂咗陰影
   link_opening_behavior_opt:
     current_tab: 目前分頁

--- a/src/background/contentScriptRefreshPrompt.ts
+++ b/src/background/contentScriptRefreshPrompt.ts
@@ -122,6 +122,7 @@ function showRefreshPrompt(...args: unknown[]): void {
     '--bew-theme-color-80',
     '--bew-theme-color-40',
     '--bew-dark-base-color',
+    '--bew-frosted-glass-base-color',
     '--bew-text-1',
     '--bew-text-2',
     '--bew-border-color',

--- a/src/components/Settings/Appearance/Appearance.vue
+++ b/src/components/Settings/Appearance/Appearance.vue
@@ -124,6 +124,11 @@ function changeDarkModeBaseColor(color: string) {
 }
 const changeDarkModeBaseColorThrottle = useThrottleFn((color: string) => changeDarkModeBaseColor(color), 100)
 
+function changeFrostedGlassBaseColor(color: string) {
+  settings.value.frostedGlassBaseColor = color
+}
+const changeFrostedGlassBaseColorThrottle = useThrottleFn((color: string) => changeFrostedGlassBaseColor(color), 100)
+
 function changeWallpaper(url: string) {
   // If you had already set the wallpaper, it enables the wallpaper masking to prevent text hard to see
   if (url)
@@ -168,6 +173,32 @@ function changeWallpaper(url: string) {
             :label="`${settings.frostedGlassBlurIntensity}`"
           />
         </div>
+      </SettingsItem>
+      <SettingsItem
+        v-if="settings.enableFrostedGlass"
+        :title="$t('settings.use_separate_frosted_glass_color')"
+        :desc="$t('settings.use_separate_frosted_glass_color_desc')"
+        right-width="auto"
+      >
+        <Radio v-model="settings.useSeparateFrostedGlassColor" />
+      </SettingsItem>
+      <SettingsItem
+        v-if="settings.enableFrostedGlass && settings.useSeparateFrostedGlassColor"
+        :title="$t('settings.frosted_glass_base_color')"
+        right-width="auto"
+      >
+        <label
+          class="frosted-glass-color-picker"
+          :style="{ '--frosted-glass-preview-color': settings.frostedGlassBaseColor }"
+        >
+          <span class="frosted-glass-color-preview" aria-hidden="true" />
+          <input
+            :value="settings.frostedGlassBaseColor"
+            type="color"
+            :aria-label="$t('settings.frosted_glass_base_color')"
+            @input="(e) => changeFrostedGlassBaseColorThrottle((e.target as HTMLInputElement)?.value)"
+          >
+        </label>
       </SettingsItem>
       <SettingsItem :title="$t('settings.disable_shadow')" right-width="auto">
         <Radio v-model="settings.disableShadow" />
@@ -329,6 +360,59 @@ function changeWallpaper(url: string) {
 
 .dark-mode-base-color-options {
   width: 252px;
+}
+
+.frosted-glass-color-picker {
+  position: relative;
+  display: flex;
+  width: var(--bew-control-height);
+  min-width: var(--bew-control-height);
+  height: var(--bew-control-height);
+  padding: var(--bew-control-padding);
+  overflow: hidden;
+  cursor: pointer;
+  background: var(--bew-control-background);
+  border: 1px solid var(--bew-fill-2);
+  border-radius: var(--bew-interactive-radius);
+  box-sizing: border-box;
+  transition:
+    background-color 150ms ease,
+    border-color 150ms ease,
+    box-shadow 150ms ease;
+
+  &:hover {
+    background: var(--bew-fill-1);
+    border-color: var(--bew-fill-3);
+  }
+
+  &:active .frosted-glass-color-preview {
+    transform: scale(0.92);
+  }
+
+  &:has(input:focus-visible) {
+    border-color: var(--bew-theme-color);
+    box-shadow: 0 0 0 2px var(--bew-theme-color-30);
+  }
+
+  input {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    cursor: pointer;
+    opacity: 0;
+  }
+}
+
+.frosted-glass-color-preview {
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  background: var(--frosted-glass-preview-color);
+  border-radius: var(--bew-radius-sm);
+  box-shadow: var(--bew-shadow-edge-glow-1);
+  transition: transform 150ms ease;
 }
 
 .theme-schedule input {

--- a/src/components/Settings/Appearance/Appearance.vue
+++ b/src/components/Settings/Appearance/Appearance.vue
@@ -224,6 +224,11 @@ function changeWallpaper(url: string) {
             }"
           >
             <span class="frosted-glass-color-preview" aria-hidden="true" />
+            <div
+              i-mingcute:color-picker-line pos="absolute" text-white w-12px h-12px
+              pointer-events-none
+              aria-hidden="true"
+            />
             <input
               :value="settings.frostedGlassBaseColor || settings.darkModeBaseColor"
               type="color"

--- a/src/components/Settings/Appearance/Appearance.vue
+++ b/src/components/Settings/Appearance/Appearance.vue
@@ -220,10 +220,9 @@ function changeWallpaper(url: string) {
             class="frosted-glass-color-picker"
             :class="{ 'is-selected': isCustomFrostedGlassBaseColor }"
             :style="{
-              '--frosted-glass-preview-color': settings.frostedGlassBaseColor || settings.darkModeBaseColor,
+              background: settings.frostedGlassBaseColor || settings.darkModeBaseColor,
             }"
           >
-            <span class="frosted-glass-color-preview" aria-hidden="true" />
             <div
               i-mingcute:color-picker-line pos="absolute" text-white w-12px h-12px
               pointer-events-none
@@ -444,10 +443,6 @@ function changeWallpaper(url: string) {
     transform: scale(1.12);
   }
 
-  &:active .frosted-glass-color-preview {
-    transform: scale(0.92);
-  }
-
   input {
     position: absolute;
     inset: 0;
@@ -482,16 +477,6 @@ function changeWallpaper(url: string) {
   background: var(--bew-error-color);
   border-radius: var(--bew-radius-full);
   transform: rotate(-45deg);
-}
-
-.frosted-glass-color-preview {
-  width: 100%;
-  height: 100%;
-  pointer-events: none;
-  background: var(--frosted-glass-preview-color);
-  border-radius: var(--bew-radius-sm);
-  box-shadow: var(--bew-shadow-edge-glow-1);
-  transition: transform 150ms ease;
 }
 
 .theme-schedule input {

--- a/src/components/Settings/Appearance/Appearance.vue
+++ b/src/components/Settings/Appearance/Appearance.vue
@@ -64,12 +64,29 @@ const darkModeBaseColorOptions = computed<Array<string>>(() => {
   ]
 })
 
+const frostedGlassBaseColorOptions = computed<Array<string>>(() => {
+  return [
+    '',
+    '#1a1b1e',
+    '#20252d',
+    '#262230',
+    '#202a26',
+    '#2c2520',
+    '#2b2226',
+  ]
+})
+
 const isCustomColor = computed<boolean>(() => {
   return !themeColorOptions.value.includes(settings.value.themeColor)
 })
 
 const isCustomDarkModeBaseColor = computed<boolean>(() => {
   return !darkModeBaseColorOptions.value.includes(settings.value.darkModeBaseColor)
+})
+
+const isCustomFrostedGlassBaseColor = computed<boolean>(() => {
+  return Boolean(settings.value.frostedGlassBaseColor)
+    && !frostedGlassBaseColorOptions.value.includes(settings.value.frostedGlassBaseColor)
 })
 
 const fontPreferenceOptions = computed(() => {
@@ -176,29 +193,45 @@ function changeWallpaper(url: string) {
       </SettingsItem>
       <SettingsItem
         v-if="settings.enableFrostedGlass"
-        :title="$t('settings.use_separate_frosted_glass_color')"
-        :desc="$t('settings.use_separate_frosted_glass_color_desc')"
-        right-width="auto"
-      >
-        <Radio v-model="settings.useSeparateFrostedGlassColor" />
-      </SettingsItem>
-      <SettingsItem
-        v-if="settings.enableFrostedGlass && settings.useSeparateFrostedGlassColor"
         :title="$t('settings.frosted_glass_base_color')"
+        :desc="$t('settings.frosted_glass_base_color_desc')"
         right-width="auto"
       >
-        <label
-          class="frosted-glass-color-picker"
-          :style="{ '--frosted-glass-preview-color': settings.frostedGlassBaseColor }"
-        >
-          <span class="frosted-glass-color-preview" aria-hidden="true" />
-          <input
-            :value="settings.frostedGlassBaseColor"
-            type="color"
-            :aria-label="$t('settings.frosted_glass_base_color')"
-            @input="(e) => changeFrostedGlassBaseColorThrottle((e.target as HTMLInputElement)?.value)"
+        <div class="frosted-glass-color-options">
+          <button
+            v-for="color in frostedGlassBaseColorOptions"
+            :key="color || 'default'"
+            class="frosted-glass-color-option"
+            :class="{
+              'frosted-glass-color-option--empty': !color,
+              'is-selected': color === settings.frostedGlassBaseColor,
+            }"
+            :style="color ? { background: color } : undefined"
+            type="button"
+            :aria-label="color
+              ? `${$t('settings.frosted_glass_base_color')}: ${color}`
+              : $t('settings.frosted_glass_base_color_default')"
+            :title="color || $t('settings.frosted_glass_base_color_default')"
+            @click="changeFrostedGlassBaseColor(color)"
           >
-        </label>
+            <span v-if="!color" class="frosted-glass-color-empty-mark" aria-hidden="true" />
+          </button>
+          <label
+            class="frosted-glass-color-picker"
+            :class="{ 'is-selected': isCustomFrostedGlassBaseColor }"
+            :style="{
+              '--frosted-glass-preview-color': settings.frostedGlassBaseColor || settings.darkModeBaseColor,
+            }"
+          >
+            <span class="frosted-glass-color-preview" aria-hidden="true" />
+            <input
+              :value="settings.frostedGlassBaseColor || settings.darkModeBaseColor"
+              type="color"
+              :aria-label="$t('settings.frosted_glass_base_color')"
+              @input="(e) => changeFrostedGlassBaseColorThrottle((e.target as HTMLInputElement)?.value)"
+            >
+          </label>
+        </div>
       </SettingsItem>
       <SettingsItem :title="$t('settings.disable_shadow')" right-width="auto">
         <Radio v-model="settings.disableShadow" />
@@ -362,36 +395,52 @@ function changeWallpaper(url: string) {
   width: 252px;
 }
 
+.frosted-glass-color-options {
+  display: flex;
+  gap: var(--bew-space-2);
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.frosted-glass-color-option,
 .frosted-glass-color-picker {
   position: relative;
-  display: flex;
-  width: var(--bew-control-height);
-  min-width: var(--bew-control-height);
-  height: var(--bew-control-height);
-  padding: var(--bew-control-padding);
+  display: grid;
+  width: var(--bew-control-item-height);
+  min-width: var(--bew-control-item-height);
+  height: var(--bew-control-item-height);
+  padding: 0;
   overflow: hidden;
   cursor: pointer;
-  background: var(--bew-control-background);
-  border: 1px solid var(--bew-fill-2);
+  border: 2px solid transparent;
   border-radius: var(--bew-interactive-radius);
   box-sizing: border-box;
+  place-items: center;
   transition:
-    background-color 150ms ease,
     border-color 150ms ease,
-    box-shadow 150ms ease;
+    box-shadow 150ms ease,
+    transform 150ms ease;
 
   &:hover {
-    background: var(--bew-fill-1);
-    border-color: var(--bew-fill-3);
+    transform: scale(1.08);
+  }
+
+  &:focus-visible,
+  &:has(input:focus-visible) {
+    outline: 2px solid var(--bew-theme-color);
+    outline-offset: var(--bew-space-0-5);
+  }
+
+  &.is-selected {
+    border-color: white;
+    box-shadow:
+      0 0 0 1px var(--bew-border-color),
+      var(--bew-shadow-1);
+    transform: scale(1.12);
   }
 
   &:active .frosted-glass-color-preview {
     transform: scale(0.92);
-  }
-
-  &:has(input:focus-visible) {
-    border-color: var(--bew-theme-color);
-    box-shadow: 0 0 0 2px var(--bew-theme-color-30);
   }
 
   input {
@@ -403,6 +452,31 @@ function changeWallpaper(url: string) {
     cursor: pointer;
     opacity: 0;
   }
+}
+
+.frosted-glass-color-option--empty {
+  background:
+    linear-gradient(45deg, var(--bew-fill-1) 25%, transparent 25%, transparent 75%, var(--bew-fill-1) 75%),
+    linear-gradient(
+      45deg,
+      var(--bew-fill-1) 25%,
+      var(--bew-elevated-solid) 25%,
+      var(--bew-elevated-solid) 75%,
+      var(--bew-fill-1) 75%
+    );
+  background-position:
+    0 0,
+    var(--bew-space-1) var(--bew-space-1);
+  background-size: var(--bew-space-2) var(--bew-space-2);
+}
+
+.frosted-glass-color-empty-mark {
+  width: var(--bew-icon-size-sm);
+  height: var(--bew-space-0-5);
+  pointer-events: none;
+  background: var(--bew-error-color);
+  border-radius: var(--bew-radius-full);
+  transform: rotate(-45deg);
 }
 
 .frosted-glass-color-preview {

--- a/src/components/Settings/searchCatalog.ts
+++ b/src/components/Settings/searchCatalog.ts
@@ -406,6 +406,8 @@ export const settingsSearchEntries: SettingsSearchEntry[] = [
     'settings.group_visual_effects',
     'settings.enable_frosted_glass',
     'settings.frosted_glass_blur_intensity',
+    'settings.use_separate_frosted_glass_color',
+    'settings.frosted_glass_base_color',
     'settings.disable_shadow',
     'settings.group_color',
     'settings.theme',

--- a/src/components/Settings/searchCatalog.ts
+++ b/src/components/Settings/searchCatalog.ts
@@ -406,7 +406,6 @@ export const settingsSearchEntries: SettingsSearchEntry[] = [
     'settings.group_visual_effects',
     'settings.enable_frosted_glass',
     'settings.frosted_glass_blur_intensity',
-    'settings.use_separate_frosted_glass_color',
     'settings.frosted_glass_base_color',
     'settings.disable_shadow',
     'settings.group_color',

--- a/src/contentScripts/index.ts
+++ b/src/contentScripts/index.ts
@@ -769,6 +769,10 @@ else if (shouldInitializeContentScript) {
       container.style.setProperty('--bew-dark-base-color', settings.value.darkModeBaseColor)
     }
 
+    if (settings.value.enableFrostedGlass && settings.value.useSeparateFrostedGlassColor) {
+      container.style.setProperty('--bew-frosted-glass-base-color', settings.value.frostedGlassBaseColor)
+    }
+
     const root = document.createElement('div')
     const useViewportLayout = !isInIframe() && !settings.value.useOriginalBilibiliHomepage && isHomePage()
 

--- a/src/contentScripts/index.ts
+++ b/src/contentScripts/index.ts
@@ -769,7 +769,7 @@ else if (shouldInitializeContentScript) {
       container.style.setProperty('--bew-dark-base-color', settings.value.darkModeBaseColor)
     }
 
-    if (settings.value.enableFrostedGlass && settings.value.useSeparateFrostedGlassColor) {
+    if (settings.value.enableFrostedGlass && settings.value.frostedGlassBaseColor) {
       container.style.setProperty('--bew-frosted-glass-base-color', settings.value.frostedGlassBaseColor)
     }
 

--- a/src/contentScripts/views/necessarySettingsWatchers.ts
+++ b/src/contentScripts/views/necessarySettingsWatchers.ts
@@ -62,7 +62,7 @@ export function setupNecessarySettingsWatchers() {
     const bewlyElement = document.querySelector('#bewly') as HTMLElement | null
     const targets: HTMLElement[] = [document.documentElement]
     const shouldUseSeparateColor = settings.value.enableFrostedGlass
-      && settings.value.useSeparateFrostedGlassColor
+      && Boolean(settings.value.frostedGlassBaseColor)
 
     if (bewlyElement)
       targets.push(bewlyElement)
@@ -219,10 +219,7 @@ export function setupNecessarySettingsWatchers() {
   )
 
   watch(
-    [
-      () => settings.value.useSeparateFrostedGlassColor,
-      () => settings.value.frostedGlassBaseColor,
-    ],
+    () => settings.value.frostedGlassBaseColor,
     applyFrostedGlassBaseColor,
     { immediate: true },
   )

--- a/src/contentScripts/views/necessarySettingsWatchers.ts
+++ b/src/contentScripts/views/necessarySettingsWatchers.ts
@@ -58,6 +58,23 @@ export function setupNecessarySettingsWatchers() {
     })
   }
 
+  const applyFrostedGlassBaseColor = () => {
+    const bewlyElement = document.querySelector('#bewly') as HTMLElement | null
+    const targets: HTMLElement[] = [document.documentElement]
+    const shouldUseSeparateColor = settings.value.enableFrostedGlass
+      && settings.value.useSeparateFrostedGlassColor
+
+    if (bewlyElement)
+      targets.push(bewlyElement)
+
+    targets.forEach((element) => {
+      if (shouldUseSeparateColor)
+        element.style.setProperty('--bew-frosted-glass-base-color', settings.value.frostedGlassBaseColor)
+      else
+        element.style.removeProperty('--bew-frosted-glass-base-color')
+    })
+  }
+
   const applyFrostedGlassState = () => {
     const bewlyElement = document.querySelector('#bewly') as HTMLElement | null
     const shouldDisable = !settings.value.enableFrostedGlass
@@ -65,6 +82,7 @@ export function setupNecessarySettingsWatchers() {
     bewlyElement?.classList.toggle('disable-frosted-glass', shouldDisable)
     document.documentElement.classList.toggle('disable-frosted-glass', shouldDisable)
     applyFrostedGlassBlur(settings.value.frostedGlassBlurIntensity)
+    applyFrostedGlassBaseColor()
   }
 
   watch(
@@ -197,6 +215,15 @@ export function setupNecessarySettingsWatchers() {
 
       applyFrostedGlassBlur(clamped)
     },
+    { immediate: true },
+  )
+
+  watch(
+    [
+      () => settings.value.useSeparateFrostedGlassColor,
+      () => settings.value.frostedGlassBaseColor,
+    ],
+    applyFrostedGlassBaseColor,
     { immediate: true },
   )
 

--- a/src/logic/storage.ts
+++ b/src/logic/storage.ts
@@ -217,7 +217,6 @@ export interface Settings {
 
   enableFrostedGlass: boolean
   frostedGlassBlurIntensity: number
-  useSeparateFrostedGlassColor: boolean
   frostedGlassBaseColor: string
   disableShadow: boolean
 
@@ -486,8 +485,7 @@ export const originalSettings: Settings = {
 
   enableFrostedGlass: false,
   frostedGlassBlurIntensity: 20,
-  useSeparateFrostedGlassColor: false,
-  frostedGlassBaseColor: '#2a2d32',
+  frostedGlassBaseColor: '',
   disableShadow: false,
 
   // Link Opening Behavior
@@ -793,11 +791,19 @@ watch(
     if (record.frostedGlassBlurIntensity > FROSTED_GLASS_BLUR_MAX_PX)
       record.frostedGlassBlurIntensity = FROSTED_GLASS_BLUR_MAX_PX
 
-    if (typeof record.useSeparateFrostedGlassColor !== 'boolean')
-      record.useSeparateFrostedGlassColor = originalSettings.useSeparateFrostedGlassColor
+    if ('useSeparateFrostedGlassColor' in record) {
+      if (record.useSeparateFrostedGlassColor !== true)
+        record.frostedGlassBaseColor = ''
 
-    if (typeof record.frostedGlassBaseColor !== 'string' || !/^#[\da-f]{6}$/i.test(record.frostedGlassBaseColor))
+      Reflect.deleteProperty(record, 'useSeparateFrostedGlassColor')
+    }
+
+    if (
+      typeof record.frostedGlassBaseColor !== 'string'
+      || (record.frostedGlassBaseColor !== '' && !/^#[\da-f]{6}$/i.test(record.frostedGlassBaseColor))
+    ) {
       record.frostedGlassBaseColor = originalSettings.frostedGlassBaseColor
+    }
 
     // 迁移旧的布尔类型自动播放设置到新的 AutoPlayMode 类型
     const autoPlayFields = ['autoPlayMultipart', 'autoPlayCollection', 'autoPlayRecommend', 'autoPlayPlaylist'] as const

--- a/src/logic/storage.ts
+++ b/src/logic/storage.ts
@@ -217,6 +217,8 @@ export interface Settings {
 
   enableFrostedGlass: boolean
   frostedGlassBlurIntensity: number
+  useSeparateFrostedGlassColor: boolean
+  frostedGlassBaseColor: string
   disableShadow: boolean
 
   enableVideoPreview: boolean
@@ -484,6 +486,8 @@ export const originalSettings: Settings = {
 
   enableFrostedGlass: false,
   frostedGlassBlurIntensity: 20,
+  useSeparateFrostedGlassColor: false,
+  frostedGlassBaseColor: '#2a2d32',
   disableShadow: false,
 
   // Link Opening Behavior
@@ -788,6 +792,12 @@ watch(
 
     if (record.frostedGlassBlurIntensity > FROSTED_GLASS_BLUR_MAX_PX)
       record.frostedGlassBlurIntensity = FROSTED_GLASS_BLUR_MAX_PX
+
+    if (typeof record.useSeparateFrostedGlassColor !== 'boolean')
+      record.useSeparateFrostedGlassColor = originalSettings.useSeparateFrostedGlassColor
+
+    if (typeof record.frostedGlassBaseColor !== 'string' || !/^#[\da-f]{6}$/i.test(record.frostedGlassBaseColor))
+      record.frostedGlassBaseColor = originalSettings.frostedGlassBaseColor
 
     // 迁移旧的布尔类型自动播放设置到新的 AutoPlayMode 类型
     const autoPlayFields = ['autoPlayMultipart', 'autoPlayCollection', 'autoPlayRecommend', 'autoPlayPlaylist'] as const

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -328,6 +328,8 @@
 
   // 深色模式基准颜色（通过 JS 动态设置）
   --bew-dark-base-color: #2a2d32;
+  // 毛玻璃默认跟随深色模式基准颜色，用户可通过设置单独覆盖
+  --bew-frosted-glass-base-color: var(--bew-dark-base-color);
 
   // #region shadow
   --bew-shadow-1: 0 4px 6px -1px rgb(0 0 0 / 0.08), 0 2px 4px -2px rgb(0 0 0 / 0.06);
@@ -359,15 +361,17 @@
   --bew-homepage-bg-mask-opacity: 0;
   --bew-homepage-bg-mask: hsl(210 8% 16% / var(--bew-homepage-bg-mask-opacity));
 
-  --bew-content: rgb(from color-mix(in oklab, var(--bew-dark-base-color), white 3%) r g b / var(--bew-content-opacity));
+  --bew-content: rgb(
+    from color-mix(in oklab, var(--bew-frosted-glass-base-color), white 3%) r g b / var(--bew-content-opacity)
+  );
   --bew-content-hover: rgb(
-    from color-mix(in oklab, var(--bew-dark-base-color), white 8%) r g b / var(--bew-content-opacity)
+    from color-mix(in oklab, var(--bew-frosted-glass-base-color), white 8%) r g b / var(--bew-content-opacity)
   );
   --bew-content-alt: rgb(
-    from color-mix(in oklab, var(--bew-dark-base-color), white 5%) r g b / var(--bew-content-opacity)
+    from color-mix(in oklab, var(--bew-frosted-glass-base-color), white 5%) r g b / var(--bew-content-opacity)
   );
   --bew-content-alt-hover: rgb(
-    from color-mix(in oklab, var(--bew-dark-base-color), white 10%) r g b / var(--bew-content-opacity)
+    from color-mix(in oklab, var(--bew-frosted-glass-base-color), white 10%) r g b / var(--bew-content-opacity)
   );
 
   --bew-content-solid: color-mix(in oklab, var(--bew-dark-base-color), white 3%);
@@ -376,10 +380,10 @@
   --bew-content-alt-solid-hover: color-mix(in oklab, var(--bew-dark-base-color), white 10%);
 
   --bew-elevated: rgb(
-    from color-mix(in oklab, var(--bew-dark-base-color), white 6%) r g b / var(--bew-content-opacity)
+    from color-mix(in oklab, var(--bew-frosted-glass-base-color), white 6%) r g b / var(--bew-content-opacity)
   );
   --bew-elevated-hover: rgb(
-    from color-mix(in oklab, var(--bew-dark-base-color), white 11%) r g b / var(--bew-content-opacity)
+    from color-mix(in oklab, var(--bew-frosted-glass-base-color), white 11%) r g b / var(--bew-content-opacity)
   );
   --bew-elevated-alt: var(--bew-elevated);
   --bew-elevated-alt-hover: var(--bew-elevated-hover);


### PR DESCRIPTION
## 改动内容

- 在外观设置中新增“独立毛玻璃颜色”调色板
- 第一个空白选项表示跟随深色模式基准颜色，后续提供 6 个适合作为背景的低亮度推荐色，并保留自定义取色器
- 新增毛玻璃基准颜色设置，并同步到页面根节点与 Shadow DOM
- 仅让深色模式下的半透明 content/elevated surface 使用独立颜色，页面背景与 solid surface 仍跟随深色模式基准颜色
- 空值或关闭毛玻璃效果时自动移除覆盖变量，保持原有回退行为
- 补充设置搜索、配置迁移与校验，以及简中、繁中、英文和粤语文案

## 背景

现有深色模式毛玻璃 surface 直接从 `--bew-dark-base-color` 派生，调整毛玻璃色调时会同时改变页面背景和实色面板。本次增加单独的毛玻璃基准色，使两套颜色可以独立配置。

## 用户影响

默认选择第一个空白项并保持现有行为；只有选择推荐色或自定义颜色后，才会在深色模式下应用独立毛玻璃色调。

## 验证

- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `git diff --check`

Closes #670
