### PR TITLE
fix: 修复刷新提示未读取当前语言

### DIFF
--- a/src/background/contentScriptRefreshPrompt.ts
+++ b/src/background/contentScriptRefreshPrompt.ts
@@ -2,6 +2,7 @@ import type { Scripting, Tabs } from 'webextension-polyfill'
 import browser from 'webextension-polyfill'
 
 import { CONTENT_SCRIPT_PING, CONTENT_SCRIPT_PONG, isContentScriptTargetUrl } from '~/constants/contentScript'
+import { LanguageType } from '~/enums/appEnums'
 
 const CONTENT_SCRIPT_STARTUP_GRACE_PERIOD_MS = 100
 
@@ -25,7 +26,12 @@ export type ContentScriptRefreshResult = 'ineligible' | 'already-injected' | 're
 function getRefreshPromptCopy(locale: string, currentVersion: string): RefreshPromptCopy {
   const normalizedLocale = locale.toLowerCase()
 
-  if (normalizedLocale.startsWith('zh-tw') || normalizedLocale.startsWith('zh-hk')) {
+  if (
+    normalizedLocale === LanguageType.Mandarin_TW.toLowerCase()
+    || normalizedLocale === LanguageType.Cantonese
+    || normalizedLocale.startsWith('zh-tw')
+    || normalizedLocale.startsWith('zh-hk')
+  ) {
     return {
       currentVersion,
       refresh: '立即重新整理',
@@ -37,7 +43,7 @@ function getRefreshPromptCopy(locale: string, currentVersion: string): RefreshPr
     }
   }
 
-  if (normalizedLocale.startsWith('zh')) {
+  if (normalizedLocale === LanguageType.Mandarin_CN.toLowerCase() || normalizedLocale.startsWith('zh')) {
     return {
       currentVersion,
       refresh: '立即刷新',
@@ -81,6 +87,35 @@ function getRefreshPromptCopy(locale: string, currentVersion: string): RefreshPr
     missingDescription: 'The extension was reloaded. Refresh this page to restore all styles and features.',
     updatedTitle: 'BewlyCat was updated',
     updatedDescription: 'This page is still running an older version. Refresh to apply v{version}.',
+  }
+}
+
+function getStoredLanguage(value: unknown): string | undefined {
+  let storedSettings = value
+
+  if (typeof storedSettings === 'string') {
+    try {
+      storedSettings = JSON.parse(storedSettings)
+    }
+    catch {
+      return undefined
+    }
+  }
+
+  if (typeof storedSettings !== 'object' || storedSettings === null || Array.isArray(storedSettings))
+    return undefined
+
+  const language = (storedSettings as Record<string, unknown>).language
+  return typeof language === 'string' && language ? language : undefined
+}
+
+async function getRefreshPromptLocale(): Promise<string> {
+  try {
+    const stored = await browser.storage.local.get('settings')
+    return getStoredLanguage(stored.settings) || browser.i18n.getUILanguage()
+  }
+  catch {
+    return browser.i18n.getUILanguage()
   }
 }
 
@@ -392,7 +427,7 @@ export async function promptContentScriptRefresh(
   if (await pingContentScript(tabId, extensionApi))
     return 'already-injected'
 
-  const copy = getRefreshPromptCopy(browser.i18n.getUILanguage(), browser.runtime.getManifest().version)
+  const copy = getRefreshPromptCopy(await getRefreshPromptLocale(), browser.runtime.getManifest().version)
   await extensionApi.scripting.executeScript({
     target: { tabId, frameIds: [0] },
     func: showRefreshPrompt,


### PR DESCRIPTION
## 改动内容

- 刷新提示显示前优先读取 BewlyCat 保存的 `settings.language`
- 正确识别 `cmn-CN`、`cmn-TW` 和 `jyut` 语言代码
- 在语言未设置或存储读取失败时回退到浏览器界面语言

## 问题原因

原实现只使用 `browser.i18n.getUILanguage()`，因此忽略了用户在 BewlyCat 内选择的语言。同时，BewlyCat 保存的中文语言代码不是 `zh-*` 格式，直接用于原有匹配逻辑也会回退到英文。

## 用户影响

当浏览器界面语言与 BewlyCat 设置不一致时，扩展重载或更新后的页面刷新提示现在会使用 BewlyCat 当前语言。

## 验证

- `pnpm lint`
- `pnpm typecheck`
