### PR TITLE
feat: 支持图文收藏展示 #641

### DIFF
--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -1011,7 +1011,10 @@ favorites:
   collected_season_prefix: 合集
   folder_section_title: 所有收藏夹
   season_section_title: 收藏的合集
+  article_section_title: 图文收藏
   video_count: 视频数：{count}
+  article_count: 图文数：{count}
+  article_load_failed: 图文收藏加载失败，请稍后重试
   unfavorite: 取消收藏
   unfavorite_confirm: |-
     要取消收藏选中的视频吗？

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -1026,7 +1026,10 @@ favorites:
   collected_season_prefix: 合集
   folder_section_title: 所有收藏夾
   season_section_title: 收藏的合集
+  article_section_title: 圖文收藏
   video_count: 影片數：{count}
+  article_count: 圖文數：{count}
+  article_load_failed: 圖文收藏載入失敗，請稍後再試
   unfavorite: 取消收藏
   unfavorite_confirm: |-
     要取消收藏選中的影片嗎？

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -1093,7 +1093,10 @@ favorites:
   collected_season_prefix: Season
   folder_section_title: All folders
   season_section_title: Collected seasons
+  article_section_title: Favorite articles
   video_count: 'Videos: {count}'
+  article_count: 'Articles: {count}'
+  article_load_failed: Failed to load favorite articles. Please try again later.
   unfavorite: Unfavorite
   unfavorite_confirm: >-
     Remove selected video(s)?

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -978,7 +978,10 @@ favorites:
   collected_season_prefix: 合集
   folder_section_title: 所有收藏夾
   season_section_title: 收藏嘅合集
+  article_section_title: 圖文收藏
   video_count: 影片數：{count}
+  article_count: 圖文數：{count}
+  article_load_failed: 圖文收藏載入失敗，請遲啲再試
   unfavorite: 唔愛喇
   unfavorite_confirm: |-
     係咪要剷走你揀過啲片呀？

--- a/src/background/messageListeners/api/favorite.ts
+++ b/src/background/messageListeners/api/favorite.ts
@@ -58,6 +58,17 @@ const API_FAVORITE = {
     },
     afterHandle: AHS.J_D,
   },
+  getFavoriteArticles: {
+    url: 'https://api.bilibili.com/x/article/favorites/list/all',
+    _fetch: {
+      method: 'get',
+    },
+    params: {
+      pn: 1,
+      ps: 16,
+    },
+    afterHandle: AHS.J_D,
+  },
   // https://github.com/SocialSisterYi/bilibili-API-collect/blob/master/docs/fav/action.md#%E6%89%B9%E9%87%8F%E5%88%A0%E9%99%A4%E5%86%85%E5%AE%B9
   patchDelFavoriteResources: {
     url: 'https://api.bilibili.com/x/v3/fav/resource/batch-del',

--- a/src/components/ArticleCard/ArticleCard.vue
+++ b/src/components/ArticleCard/ArticleCard.vue
@@ -2,7 +2,8 @@
 import ALink from '~/components/ALink.vue'
 
 interface ArticleCardProps {
-  id: number
+  id: number | string
+  url?: string
   title: string
   desc?: string
   cover?: string
@@ -16,7 +17,15 @@ interface ArticleCardProps {
   tags?: Array<{ name: string }>
 }
 
-defineProps<ArticleCardProps>()
+const props = defineProps<ArticleCardProps>()
+
+const articleUrl = computed(() => {
+  if (props.url)
+    return props.url
+
+  const id = String(props.id)
+  return `https://www.bilibili.com/read/${id.startsWith('cv') ? id : `cv${id}`}`
+})
 
 // 格式化数字
 function formatNumber(num: number | undefined) {
@@ -63,7 +72,7 @@ function formatDate(timestamp: number | undefined) {
 
 <template>
   <ALink
-    :href="`https://www.bilibili.com/read/cv${id}`"
+    :href="articleUrl"
     type="videoCard"
     class="article-card"
     flex gap-4 p-4

--- a/src/contentScripts/views/Favorites/FavoritesNew.vue
+++ b/src/contentScripts/views/Favorites/FavoritesNew.vue
@@ -3,6 +3,7 @@ import type { CSSProperties, Ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useToast } from 'vue-toastification'
 
+import ArticleCard from '~/components/ArticleCard/ArticleCard.vue'
 import type { ContextMenuOption } from '~/components/ContextMenu.vue'
 import type { FavoriteResource } from '~/components/TopBar/types'
 import type { Video } from '~/components/VideoCard/types'
@@ -11,6 +12,7 @@ import { useBewlyApp } from '~/composables/useAppProvider'
 import { useConfirmDialog } from '~/composables/useConfirmDialog'
 import { TOP_BAR_VISIBILITY_CHANGE } from '~/constants/globalEvents'
 import { settings } from '~/logic'
+import type { FavoriteArticle, FavoriteArticlesResult } from '~/models/article/favorite'
 import type { FavoritesResult, Media as FavoriteItem } from '~/models/video/favorite'
 import type { FavoritesCategoryResult, List as CategoryItem } from '~/models/video/favoriteCategory'
 import type { CollectedFavoriteSeason, CollectedFavoriteSeasonsResult, FavoriteSeasonMedia } from '~/models/video/favoriteSeason'
@@ -25,12 +27,15 @@ import {
 import { getCSRF, getUserID, openLinkToNewTab, removeHttpFromUrl } from '~/utils/main'
 import emitter from '~/utils/mitt'
 
-// 新版收藏页支持收藏夹与订阅合集。
+// 新版收藏页支持收藏夹、订阅合集与图文收藏。
 const { t } = useI18n()
 const toast = useToast()
 const { confirm: showConfirmDialog } = useConfirmDialog()
 
-type FavoriteCategorySource = 'folder' | 'season'
+const FAVORITE_ARTICLE_PAGE_SIZE = 16
+const FAVORITE_ARTICLE_CATEGORY_ID = -1
+
+type FavoriteCategorySource = 'folder' | 'season' | 'article'
 type BatchTransferAction = 'copy' | 'move'
 type SidebarManageSection = 'folder' | 'season'
 type ViewCategory = CategoryItem & {
@@ -43,6 +48,7 @@ type ViewCategory = CategoryItem & {
 const favoriteCategories = reactive<CategoryItem[]>([])
 const collectedFavoriteSeasons = reactive<CollectedFavoriteSeason[]>([])
 const favoriteResources = reactive<FavoriteItem[]>([])
+const favoriteArticles = reactive<FavoriteArticle[]>([])
 const categoryOptions = reactive<Array<{ value: ViewCategory, label: string }>>([])
 
 const selectedCategory = ref<ViewCategory>()
@@ -63,6 +69,7 @@ const isResolvingSeasonPlayAll = ref<boolean>(false)
 /** 当前订阅合集的原始 medias（与列表同套分页语义），供播放全部复用 */
 const loadedSeasonMedias = ref<FavoriteSeasonMedia[]>([])
 const loadedSeasonComplete = ref(false)
+const articleFavoriteCount = ref<number>()
 const selectedResourceKeys = ref<string[]>([])
 const folderSectionExpanded = ref<boolean>(true)
 const seasonSectionExpanded = ref<boolean>(true)
@@ -122,6 +129,8 @@ const selectedCategoryKey = computed(() => selectedCategory.value ? getCategoryK
 
 const selectedCategoryCover = computed(() => activatedCategoryCover.value || selectedCategory.value?.cover || '')
 
+const isArticleCategory = computed(() => selectedCategory.value?.source === 'article')
+
 const isManagingFolder = computed(() => sidebarManageSection.value === 'folder')
 const isManagingSeason = computed(() => sidebarManageSection.value === 'season')
 
@@ -158,9 +167,21 @@ const itemMenuOptions = computed((): ContextMenuOption[] => {
   return [{ value: 'unfav', label: t('favorites.unfavorite'), icon: 'i-tabler:star-off', danger: true }]
 })
 
-const selectedCategoryCount = computed(() => selectedCategory.value?.media_count ?? 0)
+const selectedCategoryCount = computed(() => isArticleCategory.value
+  ? articleFavoriteCount.value ?? favoriteArticles.length
+  : selectedCategory.value?.media_count ?? 0)
 
-const selectedCategoryTypeLabel = computed(() => selectedCategory.value?.source === 'season' ? t('favorites.collected_season_prefix') : t('favorites.folder_section_title'))
+const selectedCategoryTypeLabel = computed(() => {
+  if (isArticleCategory.value)
+    return t('favorites.article_section_title')
+  return selectedCategory.value?.source === 'season'
+    ? t('favorites.collected_season_prefix')
+    : t('favorites.folder_section_title')
+})
+
+const selectedCategoryCountLabel = computed(() => isArticleCategory.value
+  ? t('favorites.article_count', { count: selectedCategoryCount.value })
+  : t('favorites.video_count', { count: selectedCategoryCount.value }))
 
 const batchTransferDialogTitle = computed(() => {
   return batchTransferAction.value === 'copy'
@@ -223,6 +244,9 @@ function initPageAction() {
           const firstCategoryId = favoriteCategories.length > 0 ? favoriteCategories[0].id : 0
           getFavoriteResources(firstCategoryId, ++currentPageNum.value, keyword.value, 1)
         }
+        else if (selectedCategory.value?.source === 'article') {
+          getFavoriteArticles(++currentPageNum.value)
+        }
         else if (selectedCategory.value?.source === 'season') {
           getFavoriteSeasonResources(selectedCategory.value.id, ++currentPageNum.value)
         }
@@ -266,6 +290,20 @@ function toSeasonCategory(item: CollectedFavoriteSeason): ViewCategory {
   }
 }
 
+function toArticleCategory(): ViewCategory {
+  return {
+    id: FAVORITE_ARTICLE_CATEGORY_ID,
+    fid: FAVORITE_ARTICLE_CATEGORY_ID,
+    mid: Number(getUserID()),
+    attr: 0,
+    title: t('favorites.article_section_title'),
+    fav_state: 1,
+    media_count: articleFavoriteCount.value ?? favoriteArticles.length,
+    source: 'article',
+    cover: favoriteArticles[0] ? getFavoriteArticleCover(favoriteArticles[0]) : '',
+  }
+}
+
 function rebuildCategoryOptions() {
   categoryOptions.length = 0
   favoriteCategories.forEach((item) => {
@@ -279,6 +317,10 @@ function rebuildCategoryOptions() {
       label: `${t('favorites.collected_season_prefix')} ${item.title}`,
       value: toSeasonCategory(item),
     })
+  })
+  categoryOptions.push({
+    label: t('favorites.article_section_title'),
+    value: toArticleCategory(),
   })
 }
 
@@ -753,6 +795,52 @@ async function getFavoriteResources(
   }
 }
 
+async function getFavoriteArticles(pn: number) {
+  if (pn === 1)
+    isFullPageLoading.value = true
+  isLoading.value = true
+
+  try {
+    const res: FavoriteArticlesResult = await api.favorite.getFavoriteArticles({
+      pn,
+      ps: FAVORITE_ARTICLE_PAGE_SIZE,
+    })
+
+    if (res.code !== 0) {
+      noMoreContent.value = true
+      toast.error(res.message || t('favorites.article_load_failed'))
+      return
+    }
+
+    const pageArticles = Array.isArray(res.data?.favorites)
+      ? res.data.favorites.filter((item): item is FavoriteArticle => item != null)
+      : []
+    favoriteArticles.push(...pageArticles)
+
+    const total = Number(res.data?.count ?? res.data?.total)
+    if (Number.isFinite(total))
+      articleFavoriteCount.value = total
+
+    const firstCover = favoriteArticles[0] ? getFavoriteArticleCover(favoriteArticles[0]) : ''
+    activatedCategoryCover.value = firstCover
+    noMoreContent.value = pageArticles.length < FAVORITE_ARTICLE_PAGE_SIZE
+      || (articleFavoriteCount.value !== undefined && favoriteArticles.length >= articleFavoriteCount.value)
+
+    if (!(await haveScrollbar()) && !noMoreContent.value) {
+      currentPageNum.value = pn + 1
+      await getFavoriteArticles(currentPageNum.value)
+    }
+  }
+  catch {
+    noMoreContent.value = true
+    toast.error(t('favorites.article_load_failed'))
+  }
+  finally {
+    isLoading.value = false
+    isFullPageLoading.value = false
+  }
+}
+
 async function getFavoriteSeasonResources(
   season_id: number,
   pn: number,
@@ -796,6 +884,58 @@ async function getFavoriteSeasonResources(
   finally {
     isLoading.value = false
     isFullPageLoading.value = false
+  }
+}
+
+function getFavoriteArticleCover(item: FavoriteArticle) {
+  return item.image_urls?.[0] || item.cover || item.banner_url || ''
+}
+
+function normalizeFavoriteArticleUrl(url: string) {
+  if (url.startsWith('//'))
+    return `https:${url}`
+  if (url.startsWith('/'))
+    return `https://www.bilibili.com${url}`
+  return url
+}
+
+function getFavoriteArticleUrl(item: FavoriteArticle) {
+  const url = item.url || item.jump_url || item.uri || item.link
+  if (url)
+    return normalizeFavoriteArticleUrl(url)
+
+  const opusId = item.opus_id ?? item.dynamic_id
+  if (opusId)
+    return `https://www.bilibili.com/opus/${opusId}`
+
+  const id = String(item.id)
+  return `https://www.bilibili.com/read/${id.startsWith('cv') ? id : `cv${id}`}`
+}
+
+function transformFavoriteArticle(item: FavoriteArticle) {
+  const tags = item.tags
+    ?.map((tag) => {
+      if (typeof tag === 'string')
+        return { name: tag }
+      const name = tag.name || tag.tag_name
+      return name ? { name } : null
+    })
+    .filter((tag): tag is { name: string } => tag !== null)
+
+  return {
+    id: item.id,
+    url: getFavoriteArticleUrl(item),
+    title: item.title,
+    desc: item.summary || item.desc,
+    cover: getFavoriteArticleCover(item),
+    author: item.author?.name || item.upper?.name || item.author_name || '',
+    authorMid: item.author?.mid || item.upper?.mid || item.mid,
+    view: item.stats?.view ?? item.view,
+    like: item.stats?.like ?? item.like,
+    reply: item.stats?.reply ?? item.reply,
+    publishTime: item.publish_time || item.pub_time || item.ctime,
+    categoryName: item.category?.name || item.category_name,
+    tags,
   }
 }
 
@@ -846,9 +986,17 @@ async function changeCategory(categoryItem: ViewCategory, force = false) {
   if (targetCategory.value?.id === categoryItem.id)
     targetCategory.value = undefined
   favoriteResources.length = 0
+  favoriteArticles.length = 0
   loadedSeasonMedias.value = []
   loadedSeasonComplete.value = false
   noMoreContent.value = false
+
+  if (categoryItem.source === 'article') {
+    searchScope.value = 'current'
+    activatedCategoryCover.value = categoryItem.cover || ''
+    getFavoriteArticles(1)
+    return
+  }
 
   // 切换收藏夹时，如果是搜索当前收藏夹模式，则立即加载数据
   if (searchScope.value === 'current') {
@@ -866,6 +1014,14 @@ async function changeCategory(categoryItem: ViewCategory, force = false) {
 
 function handleSearch() {
   resetBatchSelection()
+
+  if (selectedCategory.value?.source === 'article') {
+    currentPageNum.value = 1
+    favoriteArticles.length = 0
+    noMoreContent.value = false
+    getFavoriteArticles(currentPageNum.value)
+    return
+  }
 
   if (selectedCategory.value?.source === 'season' && searchScope.value === 'current') {
     currentPageNum.value = 1
@@ -918,6 +1074,8 @@ async function handlePlayAll() {
     return
   }
   if (!selectedCategory.value || isResolvingSeasonPlayAll.value)
+    return
+  if (selectedCategory.value.source === 'article')
     return
 
   if (selectedCategory.value.source === 'season') {
@@ -1260,6 +1418,23 @@ function transformFavoriteItem(item: FavoriteItem): Video {
             </li>
           </ul>
         </section>
+
+        <section class="favorites-nav-section favorites-nav-section--single">
+          <ul class="category-list">
+            <li class="category-item">
+              <button
+                class="category-nav-item"
+                :class="{ active: selectedCategoryKey === `article:${FAVORITE_ARTICLE_CATEGORY_ID}` }"
+                :disabled="isFullPageLoading"
+                @click="changeCategory(toArticleCategory())"
+              >
+                <span class="category-icon" i-tabler:article />
+                <span class="category-title">{{ t('favorites.article_section_title') }}</span>
+                <span v-if="articleFavoriteCount !== undefined" class="category-count">{{ articleFavoriteCount }}</span>
+              </button>
+            </li>
+          </ul>
+        </section>
       </nav>
 
       <ContextMenu
@@ -1279,7 +1454,7 @@ function transformFavoriteItem(item: FavoriteItem): Video {
             :src="removeHttpFromUrl(`${selectedCategoryCover}@480w_270h_1c`)"
             :alt="selectedCategory?.title"
           >
-          <span v-else i-tabler:folder-star />
+          <span v-else :class="isArticleCategory ? 'i-tabler:article' : 'i-tabler:folder-star'" />
         </picture>
 
         <div class="favorites-hero-content">
@@ -1287,11 +1462,11 @@ function transformFavoriteItem(item: FavoriteItem): Video {
             <h2>{{ selectedCategory?.title }}</h2>
             <p>
               <span>{{ selectedCategoryTypeLabel }}</span>
-              <span>{{ t('favorites.video_count', { count: selectedCategoryCount }) }}</span>
+              <span>{{ selectedCategoryCountLabel }}</span>
             </p>
           </div>
 
-          <div class="favorites-hero-actions">
+          <div v-if="!isArticleCategory" class="favorites-hero-actions">
             <Button
               type="primary"
               :disabled="searchScope === 'all' || !selectedCategory || isResolvingSeasonPlayAll"
@@ -1306,7 +1481,7 @@ function transformFavoriteItem(item: FavoriteItem): Video {
         </div>
       </section>
 
-      <div class="favorites-toolbar" :class="{ hide: shouldMoveCtrlBarUp }">
+      <div v-if="!isArticleCategory" class="favorites-toolbar" :class="{ hide: shouldMoveCtrlBarUp }">
         <div class="toolbar-row">
           <div class="toolbar-search-group">
             <Select v-model="searchScope" w-120px :options="searchScopeOptions" @change="handleSearchScopeChange" />
@@ -1389,51 +1564,80 @@ function transformFavoriteItem(item: FavoriteItem): Video {
         </div>
       </div>
 
-      <Empty
-        v-if="searchScope === 'all' && !keyword.trim() && favoriteResources.length === 0 && !isLoading"
-        :style="contentTopStyle"
-        :description="t('favorites.global_search_hint')"
-      />
+      <template v-if="isArticleCategory">
+        <div v-if="favoriteArticles.length > 0" class="article-favorites-content" :style="contentTopStyle">
+          <div class="article-favorites-grid">
+            <ArticleCard
+              v-for="article in favoriteArticles"
+              :key="String(article.id)"
+              v-bind="transformFavoriteArticle(article)"
+            />
+          </div>
+          <div v-if="isLoading" class="article-favorites-loading">
+            <Loading />
+          </div>
+          <Empty
+            v-else-if="noMoreContent"
+            :description="t('common.no_more_content')"
+          />
+        </div>
+        <div v-else-if="isLoading || isFullPageLoading" class="article-favorites-loading article-favorites-loading--initial">
+          <Loading />
+        </div>
+        <Empty
+          v-else
+          :style="contentTopStyle"
+          :description="t('common.no_data')"
+        />
+      </template>
 
-      <VideoCardGrid
-        v-else
-        :style="contentTopStyle"
-        :items="favoriteResources"
-        :transform-item="transformFavoriteItem"
-        :get-item-key="(item) => item.id"
-        grid-layout="adaptive"
-        :loading="isLoading || isFullPageLoading"
-        :no-more-content="noMoreContent"
-        :empty-description="$t('common.no_more_content')"
-        :more-btn="!isBatchManaging"
-        :hide-author="searchScope === 'current' && selectedCategory?.source === 'season'"
-        :card-click-handler="isBatchManaging ? handleFavoriteCardClick : undefined"
-        :cover-top-left-always-visible="isBatchManaging"
-        enable-row-padding
-        @refresh="() => handlePageRefresh?.()"
-      >
-        <template v-if="searchScope !== 'current' || selectedCategory?.source !== 'season'" #coverTopLeft="{ item }">
-          <button
-            v-if="isBatchManaging"
-            class="favorite-card-action"
-            :class="{ selected: isSelectedFavoriteResource(item) }"
-            @click.prevent.stop="toggleFavoriteResourceSelection(item)"
-          >
-            <Tooltip :content="$t('favorites.batch_select_item')" placement="bottom-left" type="dark">
-              <div :class="isSelectedFavoriteResource(item) ? 'i-tabler:checkbox' : 'i-tabler:square'" />
-            </Tooltip>
-          </button>
-          <button
-            v-else
-            class="favorite-card-action danger"
-            @click.prevent.stop="handleUnfavorite(item)"
-          >
-            <Tooltip :content="$t('favorites.unfavorite')" placement="bottom-left" type="dark">
-              <div i-ic-baseline-clear />
-            </Tooltip>
-          </button>
-        </template>
-      </VideoCardGrid>
+      <template v-else>
+        <Empty
+          v-if="searchScope === 'all' && !keyword.trim() && favoriteResources.length === 0 && !isLoading"
+          :style="contentTopStyle"
+          :description="t('favorites.global_search_hint')"
+        />
+
+        <VideoCardGrid
+          v-else
+          :style="contentTopStyle"
+          :items="favoriteResources"
+          :transform-item="transformFavoriteItem"
+          :get-item-key="(item) => item.id"
+          grid-layout="adaptive"
+          :loading="isLoading || isFullPageLoading"
+          :no-more-content="noMoreContent"
+          :empty-description="$t('common.no_more_content')"
+          :more-btn="!isBatchManaging"
+          :hide-author="searchScope === 'current' && selectedCategory?.source === 'season'"
+          :card-click-handler="isBatchManaging ? handleFavoriteCardClick : undefined"
+          :cover-top-left-always-visible="isBatchManaging"
+          enable-row-padding
+          @refresh="() => handlePageRefresh?.()"
+        >
+          <template v-if="searchScope !== 'current' || selectedCategory?.source !== 'season'" #coverTopLeft="{ item }">
+            <button
+              v-if="isBatchManaging"
+              class="favorite-card-action"
+              :class="{ selected: isSelectedFavoriteResource(item) }"
+              @click.prevent.stop="toggleFavoriteResourceSelection(item)"
+            >
+              <Tooltip :content="$t('favorites.batch_select_item')" placement="bottom-left" type="dark">
+                <div :class="isSelectedFavoriteResource(item) ? 'i-tabler:checkbox' : 'i-tabler:square'" />
+              </Tooltip>
+            </button>
+            <button
+              v-else
+              class="favorite-card-action danger"
+              @click.prevent.stop="handleUnfavorite(item)"
+            >
+              <Tooltip :content="$t('favorites.unfavorite')" placement="bottom-left" type="dark">
+                <div i-ic-baseline-clear />
+              </Tooltip>
+            </button>
+          </template>
+        </VideoCardGrid>
+      </template>
 
       <Dialog
         v-if="renameDialogVisible"
@@ -1521,6 +1725,10 @@ function transformFavoriteItem(item: FavoriteItem): Video {
 }
 
 .favorites-nav-section.collapsed {
+  flex: 0 0 auto;
+}
+
+.favorites-nav-section--single {
   flex: 0 0 auto;
 }
 
@@ -1945,6 +2153,27 @@ function transformFavoriteItem(item: FavoriteItem): Video {
   max-width: 100%;
 }
 
+.article-favorites-content {
+  width: 100%;
+}
+
+.article-favorites-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--bew-space-4);
+}
+
+.article-favorites-loading {
+  display: grid;
+  place-items: center;
+  min-height: 64px;
+  padding: var(--bew-space-4);
+}
+
+.article-favorites-loading--initial {
+  min-height: 240px;
+}
+
 .batch-selected-count {
   color: var(--bew-text-2);
   font-size: var(--bew-font-size-control);
@@ -2086,6 +2315,12 @@ function transformFavoriteItem(item: FavoriteItem): Video {
 
   .favorites-hero-actions {
     justify-content: flex-start;
+  }
+}
+
+@media (max-width: 720px) {
+  .article-favorites-grid {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/src/models/article/favorite.ts
+++ b/src/models/article/favorite.ts
@@ -1,0 +1,56 @@
+export interface FavoriteArticlesResult {
+  code: number
+  message: string
+  ttl: number
+  data?: FavoriteArticlesData
+}
+
+export interface FavoriteArticlesData {
+  count?: number
+  total?: number
+  pn?: number
+  ps?: number
+  favorites?: FavoriteArticle[]
+}
+
+export interface FavoriteArticle {
+  id: number | string
+  opus_id?: number | string
+  dynamic_id?: number | string
+  title: string
+  summary?: string
+  desc?: string
+  image_urls?: string[]
+  cover?: string
+  banner_url?: string
+  author?: {
+    mid?: number
+    name?: string
+  }
+  upper?: {
+    mid?: number
+    name?: string
+  }
+  author_name?: string
+  mid?: number
+  stats?: {
+    view?: number
+    like?: number
+    reply?: number
+  }
+  view?: number
+  like?: number
+  reply?: number
+  publish_time?: number
+  pub_time?: number
+  ctime?: number
+  category?: {
+    name?: string
+  }
+  category_name?: string
+  tags?: Array<string | { name?: string, tag_name?: string }>
+  url?: string
+  jump_url?: string
+  uri?: string
+  link?: string
+}


### PR DESCRIPTION
## 改动内容

- 在新版收藏页侧栏新增“图文收藏”入口
- 接入图文收藏列表接口，并支持滚动分页、加载态与空状态
- 复用文章卡片展示标题、封面、作者和互动数据
- 兼容专栏与 Opus 跳转链接，并补齐四种语言文案
- 隔离视频专属的搜索、批量管理和“播放全部”操作

## 背景与影响

Issue #641 中收藏合集已经支持，但图文收藏仍无法在 BewlyCat 收藏页查看。本次改动补齐该入口，用户无需切回原站收藏页即可浏览已收藏的图文内容；现有视频收藏夹和订阅合集逻辑保持不变。

Closes #641

## 验证

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] 登录态页面手动测试