### PR TITLE
feat: 显示评论区楼层号

### DIFF
--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -768,6 +768,8 @@ settings:
   show_sex_desc: 在视频/动态评论区显示用户性别
   show_comment_host_tag: 显示楼主标识
   show_comment_host_tag_desc: 在评论回复详情页中标注楼主
+  show_comment_floor_number: 显示评论楼层号
+  show_comment_floor_number_desc: 从 Bilibili 接口读取并显示评论与回复的原始楼层号；启用后会产生额外请求
   adjust_comment_image_height: 调整评论区图片高度
   adjust_comment_image_height_desc: 自动调整评论区图片高度以匹配实际长宽比，避免图片变形
   detect_comment_shadow_ban: 检测评论仅自己可见

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -758,6 +758,8 @@ settings:
   show_sex_desc: 在影片/動態評論區顯示使用者性別
   show_comment_host_tag: 顯示樓主標示
   show_comment_host_tag_desc: 在評論回覆詳情頁標示樓主
+  show_comment_floor_number: 顯示評論樓層號
+  show_comment_floor_number_desc: 從 Bilibili 介面讀取並顯示評論與回覆的原始樓層號；啟用後會產生額外請求
   adjust_comment_image_height: 調整評論區圖片高度
   adjust_comment_image_height_desc: 自動調整評論區圖片高度以匹配實際長寬比，避免圖片變形
   detect_comment_shadow_ban: 檢測留言僅自己可見

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -838,6 +838,8 @@ settings:
   show_sex_desc: Display user gender in the video/dynamic comment area
   show_comment_host_tag: Show OP tag
   show_comment_host_tag_desc: Show an OP tag on the root comment in reply detail view
+  show_comment_floor_number: Show comment floor numbers
+  show_comment_floor_number_desc: Read and display original comment and reply floor numbers from Bilibili; enabling this makes additional requests
   adjust_comment_image_height: Adjust comment image height
   adjust_comment_image_height_desc: Automatically adjust comment image height to match actual aspect ratio and prevent distortion
   detect_comment_shadow_ban: Detect comments visible only to you

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -759,6 +759,8 @@ settings:
   show_sex_desc: 喺影片/動向頁留言區顯示用戶性別。
   show_comment_host_tag: 顯示樓主標示
   show_comment_host_tag_desc: 喺留言回覆詳情頁標示樓主。
+  show_comment_floor_number: 顯示留言樓層號
+  show_comment_floor_number_desc: 由 Bilibili 介面讀取並顯示留言同回覆嘅原始樓層號；開啟後會產生額外請求。
   detect_comment_shadow_ban: 檢測留言係咪得自己睇到
   detect_comment_shadow_ban_desc: 發送留言大約 5 秒之後，分別用未登入同登入狀態檢查公開可見性；結果只供參考。
   video_player_scroll: 校好顯示模式後自動轆到合適嘅位置

--- a/src/components/Settings/BilibiliFeaturesEnhancement/Comments/Comments.vue
+++ b/src/components/Settings/BilibiliFeaturesEnhancement/Comments/Comments.vue
@@ -44,6 +44,15 @@ const commentToggleOptions = computed<CommentToggleOption[]>(() => [
     </div>
 
     <SettingsItem
+      :title="$t('settings.show_comment_floor_number')"
+      :desc="$t('settings.show_comment_floor_number_desc')"
+      :badge="`${$t('settings.experimental')} · ${$t('settings.badge_use_with_caution')}`"
+      right-width="auto"
+    >
+      <Radio v-model="settings.showCommentFloorNumber" />
+    </SettingsItem>
+
+    <SettingsItem
       :title="$t('settings.adjust_comment_image_height')"
       :desc="$t('settings.adjust_comment_image_height_desc')"
       right-width="auto"

--- a/src/inject/commentFloorNumber.ts
+++ b/src/inject/commentFloorNumber.ts
@@ -1,0 +1,203 @@
+const commentFloorByReplyKey = new Map<string, number>()
+const commentFloorRequests = new Map<string, Promise<void>>()
+const commentFloorRequestQueue: Array<() => void> = []
+const COMMENT_FLOOR_REQUEST_CONCURRENCY = 3
+let activeCommentFloorRequests = 0
+
+function toIdString(id: unknown): string | null {
+  if (id === null || id === undefined || id === '')
+    return null
+  return String(id)
+}
+
+function getReplyOid(replyItem: any): string | null {
+  return toIdString(replyItem?.oid_str ?? replyItem?.oid)
+}
+
+function getReplyRpid(replyItem: any): string | null {
+  return toIdString(replyItem?.rpid_str ?? replyItem?.rpid)
+}
+
+function getReplyRootRpid(replyItem: any): string | null {
+  return toIdString(replyItem?.root_str ?? replyItem?.root)
+}
+
+function getReplyType(replyItem: any): string | null {
+  return toIdString(replyItem?.type)
+}
+
+function getReplyDialogRpid(replyItem: any): string | null {
+  return toIdString(replyItem?.dialog_str ?? replyItem?.dialog)
+}
+
+function toFloorNumber(floor: unknown): number | null {
+  const floorNumber = Number(floor)
+  return Number.isSafeInteger(floorNumber) && floorNumber > 0
+    ? floorNumber
+    : null
+}
+
+function getCommentFloorCacheKey(type: string, oid: string, rpid: string) {
+  return `${type}:${oid}:${rpid}`
+}
+
+export function getCachedCommentFloor(replyItem: any): number | null {
+  const directFloor = toFloorNumber(replyItem?.floor)
+  if (directFloor)
+    return directFloor
+
+  const oid = getReplyOid(replyItem)
+  const rpid = getReplyRpid(replyItem)
+  if (!oid || !rpid)
+    return null
+
+  return commentFloorByReplyKey.get(
+    getCommentFloorCacheKey(getReplyType(replyItem) ?? '1', oid, rpid),
+  ) ?? null
+}
+
+function cacheCommentReplyFloors(
+  replyItem: any,
+  fallbackType: string,
+  fallbackOid: string,
+) {
+  if (!replyItem)
+    return
+
+  const type = getReplyType(replyItem) ?? fallbackType
+  const oid = getReplyOid(replyItem) ?? fallbackOid
+  const rpid = getReplyRpid(replyItem)
+  const floor = toFloorNumber(replyItem.floor)
+
+  if (oid && rpid && floor) {
+    commentFloorByReplyKey.set(
+      getCommentFloorCacheKey(type, oid, rpid),
+      floor,
+    )
+  }
+
+  if (Array.isArray(replyItem.replies)) {
+    replyItem.replies.forEach((reply: any) => {
+      cacheCommentReplyFloors(reply, type, oid)
+    })
+  }
+}
+
+function drainCommentFloorRequestQueue() {
+  while (
+    activeCommentFloorRequests < COMMENT_FLOOR_REQUEST_CONCURRENCY
+    && commentFloorRequestQueue.length > 0
+  ) {
+    const startRequest = commentFloorRequestQueue.shift()
+    if (!startRequest)
+      return
+    activeCommentFloorRequests += 1
+    startRequest()
+  }
+}
+
+function enqueueCommentFloorRequest<T>(request: () => Promise<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    commentFloorRequestQueue.push(() => {
+      void request()
+        .then(resolve, reject)
+        .finally(() => {
+          activeCommentFloorRequests -= 1
+          drainCommentFloorRequestQueue()
+        })
+    })
+    drainCommentFloorRequestQueue()
+  })
+}
+
+function requestCommentFloorData(
+  requestKey: string,
+  requestUrl: URL,
+  type: string,
+  oid: string,
+): Promise<void> {
+  const cachedRequest = commentFloorRequests.get(requestKey)
+  if (cachedRequest)
+    return cachedRequest
+
+  const request = enqueueCommentFloorRequest(async () => {
+    const response = await window.fetch(requestUrl, {
+      method: 'GET',
+      credentials: 'include',
+    })
+    if (!response.ok)
+      throw new Error(`HTTP ${response.status}`)
+
+    const responseData = await response.json()
+    if (responseData?.code !== 0 || !responseData.data)
+      throw new Error(`API ${responseData?.code ?? 'unknown'}: ${responseData?.message ?? 'unknown error'}`)
+
+    cacheCommentReplyFloors(responseData.data.root, type, oid)
+    if (Array.isArray(responseData.data.replies)) {
+      responseData.data.replies.forEach((reply: any) => {
+        cacheCommentReplyFloors(reply, type, oid)
+      })
+    }
+  }).catch((error) => {
+    console.warn(`[BewlyCat] Failed to fetch comment floor data (${requestUrl.pathname}).`, error)
+  })
+
+  commentFloorRequests.set(requestKey, request)
+  return request
+}
+
+export async function resolveCommentFloor(replyItem: any): Promise<number | null> {
+  const cachedFloor = getCachedCommentFloor(replyItem)
+  if (cachedFloor)
+    return cachedFloor
+
+  const oid = getReplyOid(replyItem)
+  const rpid = getReplyRpid(replyItem)
+  if (!oid || !rpid)
+    return null
+
+  const type = getReplyType(replyItem) ?? '1'
+  const root = getReplyRootRpid(replyItem)
+  const rootRpid = root && root !== '0' ? root : rpid
+  const detailUrl = new URL('https://api.bilibili.com/x/v2/reply/detail')
+  detailUrl.search = new URLSearchParams({
+    type,
+    oid,
+    root: rootRpid,
+    next: '0',
+    ps: '3',
+  }).toString()
+
+  await requestCommentFloorData(
+    `detail:${type}:${oid}:${rootRpid}`,
+    detailUrl,
+    type,
+    oid,
+  )
+
+  const detailFloor = getCachedCommentFloor(replyItem)
+  if (detailFloor)
+    return detailFloor
+
+  const dialogRpid = getReplyDialogRpid(replyItem)
+  if (!root || root === '0' || !dialogRpid || dialogRpid === '0')
+    return null
+
+  const dialogUrl = new URL('https://api.bilibili.com/x/v2/reply/dialog/cursor')
+  dialogUrl.search = new URLSearchParams({
+    type,
+    oid,
+    root: rootRpid,
+    dialog: dialogRpid,
+    size: '20',
+  }).toString()
+
+  await requestCommentFloorData(
+    `dialog:${type}:${oid}:${rootRpid}:${dialogRpid}`,
+    dialogUrl,
+    type,
+    oid,
+  )
+
+  return getCachedCommentFloor(replyItem)
+}

--- a/src/inject/index.ts
+++ b/src/inject/index.ts
@@ -4,6 +4,7 @@ import type { Settings } from '~/logic/storage'
 import { BILIBILI_DESKTOP_USER_AGENT, isBilibiliWwwUrl } from '~/utils/bilibiliDesktopNavigation'
 import { isElectron } from '~/utils/main'
 
+import { getCachedCommentFloor, resolveCommentFloor } from './commentFloorNumber'
 import { handleCommentAddResponse, isCommentAddRequest } from './commentShadowBanDetection'
 
 // 存储当前设置状态
@@ -333,6 +334,101 @@ else if (shouldInitializePageScript) {
     return rootAuthorMid === authorMid
   }
 
+  const pendingCommentFloorRpid = new WeakMap<Element, string>()
+
+  function getCommentFloorAnchor(root: ShadowRoot): Element | null {
+    return root.querySelector('#location')
+      ?? root.querySelector('#host-tag')
+      ?? root.querySelector('#sex')
+      ?? root.querySelector('#user-name')
+  }
+
+  async function resolveAndRenderCommentFloor(component: any, expectedRpid: string) {
+    if (
+      !currentSettings?.showCommentFloorNumber
+      || getReplyRpid(component.data) !== expectedRpid
+    ) {
+      return
+    }
+
+    const floor = await resolveCommentFloor(component.data)
+    if (
+      !floor
+      || !currentSettings?.showCommentFloorNumber
+      || getReplyRpid(component.data) !== expectedRpid
+    ) {
+      return
+    }
+
+    const root = component.shadowRoot as ShadowRoot | null
+    if (!root)
+      return
+
+    updateInfoElement(
+      root,
+      'floor-number',
+      true,
+      floor,
+      getCommentFloorAnchor(root),
+    )
+  }
+
+  const commentFloorObserver = typeof IntersectionObserver === 'undefined'
+    ? null
+    : new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (!entry.isIntersecting)
+          return
+
+        commentFloorObserver?.unobserve(entry.target)
+        const expectedRpid = pendingCommentFloorRpid.get(entry.target)
+        pendingCommentFloorRpid.delete(entry.target)
+        if (expectedRpid)
+          void resolveAndRenderCommentFloor(entry.target, expectedRpid)
+      })
+    }, {
+      rootMargin: '200px 0px',
+    })
+
+  function updateCommentFloor(component: any, root: ShadowRoot) {
+    const rpid = getReplyRpid(component.data)
+    const shouldShow = Boolean(currentSettings?.showCommentFloorNumber && rpid)
+
+    if (!shouldShow || !rpid) {
+      if (component instanceof Element) {
+        commentFloorObserver?.unobserve(component)
+        pendingCommentFloorRpid.delete(component)
+      }
+      updateInfoElement(root, 'floor-number', false, '', null)
+      return
+    }
+
+    const cachedFloor = getCachedCommentFloor(component.data)
+    if (cachedFloor) {
+      if (component instanceof Element) {
+        commentFloorObserver?.unobserve(component)
+        pendingCommentFloorRpid.delete(component)
+      }
+      updateInfoElement(
+        root,
+        'floor-number',
+        true,
+        cachedFloor,
+        getCommentFloorAnchor(root),
+      )
+      return
+    }
+
+    updateInfoElement(root, 'floor-number', false, '', null)
+    if (commentFloorObserver && component instanceof Element) {
+      pendingCommentFloorRpid.set(component, rpid)
+      commentFloorObserver.observe(component)
+      return
+    }
+
+    void resolveAndRenderCommentFloor(component, rpid)
+  }
+
   function updateInfoElement(
     root: ShadowRoot | null | undefined,
     id: string,
@@ -384,6 +480,10 @@ else if (shouldInitializePageScript) {
     else if (id === 'host-tag') {
       element.style.cssText = `display: inline-block; margin-left: 4px; padding: 1px 4px; font-size: 11px; font-weight: 500; color: var(--bew-theme-color); background-color: var(--bew-theme-color-10); border-radius: 3px; vertical-align: middle; line-height: 1.4;`
       element.textContent = String(text)
+    }
+    else if (id === 'floor-number') {
+      element.style.cssText = `display: inline-flex; align-items: center; margin-left: var(--bew-space-1, 4px); padding: 0 var(--bew-space-1, 4px); font-size: var(--bew-font-size-caption, 11px); line-height: var(--bew-line-height-caption, 16px); font-weight: var(--bew-font-weight-medium, 500); color: var(--bew-text-3, var(--text3, #9499a0)); background: var(--bew-fill-1, var(--bg2, #f1f2f3)); border-radius: var(--bew-radius-sm, 4px); vertical-align: middle; font-variant-numeric: tabular-nums;`
+      element.textContent = `#${String(text)}`
     }
     else {
       element.textContent = String(text)
@@ -517,6 +617,9 @@ else if (shouldInitializePageScript) {
               const shouldShowLocation = Boolean(currentSettings?.showIPLocation && locationString)
               const locationAnchor = hostEl ?? sexEl ?? userNameEl
               updateInfoElement(root, 'location', shouldShowLocation, locationString, locationAnchor)
+
+              // 真实楼层号已从主评论接口移除，按需从详情接口补取。
+              updateCommentFloor(component, root)
             })
           }
           catch (error) {

--- a/src/logic/storage.ts
+++ b/src/logic/storage.ts
@@ -200,6 +200,7 @@ export interface Settings {
   showIPLocation: boolean // 添加显示IP归属地设置项
   showSex: boolean // 添加显示性别设置项
   showCommentHostTag: boolean // 显示评论回复详情页楼主标识
+  showCommentFloorNumber: boolean // 显示评论与回复的原始楼层号
   adjustCommentImageHeight: boolean // 调整评论区图片高度以匹配实际比例
   detectCommentShadowBan: boolean // 发送评论后检测是否仅自己可见
   enlargeFavoriteDialog: boolean // 视频页收藏夹放大样式增强
@@ -467,6 +468,7 @@ export const originalSettings: Settings = {
   showIPLocation: true, // 默认启用IP归属地显示
   showSex: true, // 默认启用性别显示
   showCommentHostTag: true, // 默认启用楼主标识显示
+  showCommentFloorNumber: false, // 默认关闭，避免额外请求评论详情接口
   adjustCommentImageHeight: true, // 默认启用评论图片高度调整
   detectCommentShadowBan: false, // 默认关闭评论可见性检测
   enlargeFavoriteDialog: false, // 默认关闭收藏夹放大样式


### PR DESCRIPTION
## 背景

Closes #471。

Bilibili 当前 Web 评论主接口已不再向评论组件返回 `floor`，因此仅恢复旧 DOM 或直接读取 `component.data.floor` 无法显示楼层号。实测 `/x/v2/reply/detail` 仍能返回一级评论与预览回复的真实楼层，`/x/v2/reply/dialog/cursor` 可补取其余楼中楼回复。

## 改动

- 在新版评论 Web Component 的用户名信息旁显示 `#楼层号`
- 一级评论通过详情接口取值，缺失的楼中楼通过对话游标接口补取
- 按评论、线程和对话缓存结果，避免重复请求
- 仅在评论接近视口时请求，并将并发限制为 3
- 新增“显示评论楼层号”设置，默认关闭
- 在设置标题旁标记“实验性 · 谨慎开启”，并明确说明会产生额外请求
- 补齐简体中文、繁体中文、粤语和英文文案

## 用户影响与风险

启用路径：`设置 → Bilibili 功能 → 评论 → 显示评论楼层号`。

该功能依赖 Bilibili 未公开评论接口，接口变更时可能无法显示；请求失败时只跳过楼层号，不影响原生评论区。由于会增加只读请求，功能默认关闭，并通过视口懒加载、请求去重、缓存和并发限制降低影响。

## 验证

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- 使用真实公开评论验证一级评论与楼中楼解析路径均返回预期楼层
- 本地加载扩展后手动测试通过