### PR TITLE
fix: 修复设置搜索漏项与选项匹配

### DIFF
--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -233,6 +233,9 @@ settings:
   moments_card_open_mode_opt:
     dialog: 弹窗
     new_tab: 新建标签页
+  group_moments_wanted_users: 想看分组
+  group_moments_wanted_users_desc: 管理想看的 UP 主；支持输入 UID 或昵称，名单仅保存在本地。
+  moments_wanted_users: 想看的 UP 主
   btn:
     authorize: 授权
     revoke: 取消授权

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -232,6 +232,9 @@ settings:
   moments_card_open_mode_opt:
     dialog: 彈窗
     new_tab: 新分頁
+  group_moments_wanted_users: 想看分組
+  group_moments_wanted_users_desc: 管理想看的 UP 主；支援輸入 UID 或暱稱，名單僅儲存在本機。
+  moments_wanted_users: 想看的 UP 主
   btn:
     authorize: 授權
     revoke: 解除授權

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -236,6 +236,9 @@ settings:
   moments_card_open_mode_opt:
     dialog: Dialog
     new_tab: New tab
+  group_moments_wanted_users: Watchlist
+  group_moments_wanted_users_desc: Manage uploaders you want to watch by UID or name. The list is stored only on this device.
+  moments_wanted_users: Watchlisted uploaders
   btn:
     authorize: Authorize
     revoke: Revoke

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -256,6 +256,9 @@ settings:
   moments_card_open_mode_opt:
     dialog: 彈窗
     new_tab: 新分頁
+  group_moments_wanted_users: 想睇分組
+  group_moments_wanted_users_desc: 管理想睇嘅 UP 主；支援輸入 UID 或暱稱，名單只會儲存喺本機。
+  moments_wanted_users: 想睇嘅 UP 主
   btn:
     authorize: 授權
     revoke: 解除授權

--- a/src/components/Settings/PluginComponentsAndPages/Moments/Moments.vue
+++ b/src/components/Settings/PluginComponentsAndPages/Moments/Moments.vue
@@ -152,13 +152,13 @@ const openModeOptions = computed(() => [
     </SettingsItemGroup>
 
     <SettingsItemGroup
-      title="想看分组"
-      desc="管理想看的 UP 主；支持输入 UID 或昵称，名单仅保存在本地。"
+      :title="$t('settings.group_moments_wanted_users')"
+      :desc="$t('settings.group_moments_wanted_users_desc')"
       icon="i-tabler-heart-filled"
       collapsible
       default-collapsed
     >
-      <SettingsItem title="想看的 UP 主">
+      <SettingsItem :title="$t('settings.moments_wanted_users')">
         <template #bottom>
           <WantedUsersManager />
         </template>

--- a/src/components/Settings/Settings.vue
+++ b/src/components/Settings/Settings.vue
@@ -13,7 +13,7 @@ import { MenuType } from './types'
 
 const emit = defineEmits(['close'])
 
-const { t, te } = useI18n()
+const { t, tm, rt } = useI18n()
 const breadcrumbDetail = ref<string>()
 const searchQuery = ref('')
 const settingsContentKey = ref(0)
@@ -190,19 +190,30 @@ function getSearchEntryLocation(entry: SettingsSearchEntry) {
     : primaryTitle
 }
 
+function getTranslatedSearchTerms(key: string): string[] {
+  const collectTerms = (message: unknown): string[] => {
+    if (typeof message === 'string' || typeof message === 'function')
+      return [rt(message as Parameters<typeof rt>[0])]
+    if (Array.isArray(message))
+      return message.flatMap(collectTerms)
+    if (message && typeof message === 'object')
+      return Object.values(message).flatMap(collectTerms)
+    return []
+  }
+
+  return collectTerms(tm(key))
+}
+
 function getSearchEntryText(entry: SettingsSearchEntry) {
-  const inferredDescriptionKey = entry.titleKey ? `${entry.titleKey}_desc` : undefined
-  const translatedKeywords = entry.keywordKeys
-    ?.filter(key => te(key))
-    .map(key => t(key)) ?? []
-  const inferredDescription = inferredDescriptionKey && te(inferredDescriptionKey)
-    ? t(inferredDescriptionKey)
-    : ''
+  const inferredKeywordKeys = entry.titleKey
+    ? [`${entry.titleKey}_desc`, `${entry.titleKey}_opt`, `${entry.titleKey}_option`]
+    : []
+  const translatedKeywords = [...inferredKeywordKeys, ...(entry.keywordKeys ?? [])]
+    .flatMap(getTranslatedSearchTerms)
 
   return [
     getSearchEntryTitle(entry),
     getSearchEntryLocation(entry),
-    inferredDescription,
     ...translatedKeywords,
     ...(entry.keywords ?? []),
   ].join(' ').toLocaleLowerCase()

--- a/src/components/Settings/searchCatalog.ts
+++ b/src/components/Settings/searchCatalog.ts
@@ -119,6 +119,36 @@ const wallpaperTitleKeys = [
   'settings.wallpaper_blur_intensity',
 ]
 
+const linkOpeningOptionKeys = [
+  'settings.link_opening_behavior_opt.current_tab',
+  'settings.link_opening_behavior_opt.current_tab_if_not_homepage',
+  'settings.link_opening_behavior_opt.background',
+  'settings.link_opening_behavior_opt.new_tab',
+]
+const videoCardLinkOpeningOptionKeys = [
+  'settings.link_opening_behavior_opt.current_tab',
+  'settings.link_opening_behavior_opt.drawer',
+  'settings.link_opening_behavior_opt.background',
+  'settings.link_opening_behavior_opt.new_tab',
+]
+const playerModeOptionKeys = [
+  'settings.video_player_mode.default',
+  'settings.video_player_mode.web_fullscreen',
+  'settings.video_player_mode.widescreen',
+  'settings.video_player_mode.bewly_widescreen',
+]
+const autoPlayModeOptionKeys = [
+  'settings.auto_play_mode_auto_play',
+  'settings.auto_play_mode_auto_play_with_recommend',
+  'settings.auto_play_mode_pause_at_end',
+  'settings.auto_play_mode_loop',
+]
+const customAutoPlayModeOptionKeys = [
+  'settings.auto_play_mode_custom_sequential',
+  'settings.auto_play_mode_custom_reverse',
+  'settings.auto_play_mode_custom_random',
+]
+
 const topBarGlobalTitleKeys = [
   'settings.group_topbar',
   'settings.auto_hide_top_bar',
@@ -165,7 +195,6 @@ export const settingsSearchEntries: SettingsSearchEntry[] = [
     'settings.group_version_reminder',
     'settings.enable_version_reminder',
     'settings.group_recommendation_mode',
-    'settings.recommendation_mode',
     'settings.remember_no_cookie_recommendation_state',
     'settings.authorize_app',
     'settings.auto_switch_recommendation_mode',
@@ -188,13 +217,21 @@ export const settingsSearchEntries: SettingsSearchEntry[] = [
     'settings.following_filter_dynamic_videos',
     'settings.group_home_tabs',
     'settings.home_tabs_adjustment',
-    'settings.home_tabs_position',
     'settings.fixed_home_tabs_on_home_page',
     'settings.group_search_page_mode',
     'settings.use_search_page_mode',
     'settings.settings_shared_with_the_search_page',
     'settings.search_page_mode_wallpaper_fixed',
   ]),
+  ...createEntries(homeRoute, [
+    'settings.recommendation_mode',
+  ], {
+    keywordKeys: ['settings.recommendation_mode_web_no_cookie'],
+    keywords: ['Web', 'App'],
+  }),
+  ...createEntries(homeRoute, [
+    'settings.home_tabs_position',
+  ], { keywordKeys: ['common.position.center', 'common.position.left'] }),
 
   ...createEntries(momentsRoute, [
     'settings.plugin.moments',
@@ -212,14 +249,20 @@ export const settingsSearchEntries: SettingsSearchEntry[] = [
     'settings.moments_show_live',
     'settings.moments_enable_live_preview',
     'settings.moments_enable_video_preview',
-    'settings.moments_filter_up_recommendation',
     'settings.moments_filter_charge_dynamic',
     'settings.moments_filter_video_reservation',
     'settings.moments_filter_live_reservation',
     'settings.moments_filter_live_dynamic',
-    'settings.moments_hide_charge_exclusive',
     'settings.moments_card_open_mode',
+    'settings.group_moments_wanted_users',
+    'settings.moments_wanted_users',
   ]),
+  ...createEntries(momentsRoute, [
+    'settings.moments_filter_up_recommendation',
+  ], { targetTitleKey: 'settings.moments_filter_up_recommendation_short' }),
+  ...createEntries(momentsRoute, [
+    'settings.moments_hide_charge_exclusive',
+  ], { targetTitleKey: 'settings.moments_filter_charge_dynamic' }),
 
   ...createEntries(videoCardRoute, [
     'settings.plugin.video_card',
@@ -246,20 +289,26 @@ export const settingsSearchEntries: SettingsSearchEntry[] = [
     'settings.show_video_card_duration',
     'settings.show_video_watched_badge',
     'settings.show_video_card_watch_later',
-    'settings.video_card_title_font_size',
-    'settings.video_card_author_font_size',
-    'settings.video_card_meta_font_size',
     'settings.video_card_shadow_curve',
     'settings.video_card_shadow_height',
   ]),
+  ...createEntries(videoCardRoute, [
+    'settings.video_card_title_font_size',
+    'settings.video_card_author_font_size',
+    'settings.video_card_meta_font_size',
+  ], { keywordKeys: ['settings.font_size_option'] }),
 
   ...createEntries(linkOpeningRoute, [
     'settings.group_link_opening_behavior',
-    'settings.top_bar_link_opening_behavior',
-    'settings.video_card_link_opening_behavior',
-    'settings.search_bar_link_opening_behavior',
     'settings.close_drawer_without_pressing_esc_again',
   ]),
+  ...createEntries(linkOpeningRoute, [
+    'settings.top_bar_link_opening_behavior',
+    'settings.search_bar_link_opening_behavior',
+  ], { keywordKeys: linkOpeningOptionKeys }),
+  ...createEntries(linkOpeningRoute, [
+    'settings.video_card_link_opening_behavior',
+  ], { keywordKeys: videoCardLinkOpeningOptionKeys }),
 
   ...createEntries(topBarRoute, [
     'settings.plugin.topbar',
@@ -299,7 +348,7 @@ export const settingsSearchEntries: SettingsSearchEntry[] = [
     ['notifications', 'topbar.notifications'],
   ].flatMap(([element, titleKey]) => createTopBarElementEntries(element!, [titleKey!], {
     targetTitleKey: 'settings.visibility',
-    keywordKeys: ['settings.visibility', 'settings.badge_type'],
+    keywordKeys: ['settings.visibility', 'settings.badge_type', 'settings.top_bar_icon_badges_opt'],
   })),
 
   ...createEntries(dockRoute, [
@@ -308,7 +357,6 @@ export const settingsSearchEntries: SettingsSearchEntry[] = [
     'settings.always_use_dock',
     'settings.auto_hide_dock',
     'settings.half_hide_dock',
-    'settings.dock_position',
     'settings.dock_content_adjustment',
     'settings.disable_dock_glowing_effect',
     'settings.disable_light_dark_mode_switcher',
@@ -316,9 +364,14 @@ export const settingsSearchEntries: SettingsSearchEntry[] = [
     'settings.always_show_dock_actions_when_auto_hide',
     'settings.enable_undo_refresh_button',
     'settings.group_sidebar',
-    'settings.sidebar_position',
     'settings.auto_hide_sidebar',
   ]),
+  ...createEntries(dockRoute, [
+    'settings.dock_position',
+  ], { keywordKeys: ['common.position.left', 'common.position.right', 'common.position.bottom'] }),
+  ...createEntries(dockRoute, [
+    'settings.sidebar_position',
+  ], { keywordKeys: ['common.position.left', 'common.position.right'] }),
 
   ...createEntries(searchPageRoute, [
     'settings.plugin.search',
@@ -345,20 +398,12 @@ export const settingsSearchEntries: SettingsSearchEntry[] = [
   ...createEntries(playerRoute, [
     'settings.bilibili_features.video_playback',
     'settings.group_player_display_mode',
-    'settings.video_default_player_mode',
     'settings.video_player_mode.bewly_widescreen_sidebar_position',
     'settings.video_player_mode.enable_overrides',
     'settings.video_player_mode.overrides',
-    'settings.video_player_mode.context_multipart',
-    'settings.video_player_mode.context_collection',
-    'settings.video_player_mode.context_bangumi',
-    'settings.video_player_mode.context_watch_later',
-    'settings.video_player_mode.context_playlist',
     'settings.video_player_scroll',
     'settings.auto_exit_fullscreen_on_end',
     'settings.group_player_components',
-    'settings.video_danmaku_default_state',
-    'settings.video_caption_default_state',
     'settings.group_playback_memory',
     'settings.remember_playback_rate',
     'settings.remember_video_aspect_ratio',
@@ -367,28 +412,63 @@ export const settingsSearchEntries: SettingsSearchEntry[] = [
     'settings.external_watch_later_button',
     'settings.show_video_screenshot_button',
   ]),
+  ...createEntries(playerRoute, [
+    'settings.video_default_player_mode',
+  ], { keywordKeys: playerModeOptionKeys }),
+  ...createEntries(playerRoute, [
+    'settings.video_player_mode.context_multipart',
+    'settings.video_player_mode.context_collection',
+    'settings.video_player_mode.context_bangumi',
+    'settings.video_player_mode.context_watch_later',
+    'settings.video_player_mode.context_playlist',
+  ], { keywordKeys: [...playerModeOptionKeys, 'settings.video_player_mode.inherit'] }),
+  ...createEntries(playerRoute, [
+    'settings.video_danmaku_default_state',
+    'settings.video_caption_default_state',
+  ], { keywordKeys: ['settings.video_default_state_opt'] }),
 
   ...createEntries(autoPlayRoute, [
     'settings.bilibili_features.auto_play',
     'settings.group_random_play',
     'settings.enable_random_play',
-    'settings.default_custom_play_order',
     'settings.group_random_play_settings',
-    'settings.random_play_mode',
     'settings.min_videos_for_random',
     'settings.group_playback_end_behavior',
     'settings.use_bilibili_default_auto_play',
     'settings.group_video_type_end_behavior',
+    'settings.group_playlist_start_behavior',
+  ]),
+  ...createEntries(autoPlayRoute, [
     'settings.auto_play_multipart',
     'settings.auto_play_collection',
-    'settings.auto_play_recommend',
     'settings.auto_play_playlist',
-    'settings.auto_play_mode_custom_sequential',
-    'settings.auto_play_mode_custom_reverse',
-    'settings.auto_play_mode_custom_random',
-    'settings.group_playlist_start_behavior',
+  ], { keywordKeys: [...autoPlayModeOptionKeys, ...customAutoPlayModeOptionKeys] }),
+  ...createEntries(autoPlayRoute, [
+    'settings.auto_play_recommend',
+  ], { keywordKeys: autoPlayModeOptionKeys }),
+  ...createEntries(autoPlayRoute, [
+    'settings.default_custom_play_order',
+  ], {
+    keywordKeys: [
+      'settings.random_play_order_sequential',
+      'settings.random_play_order_reverse',
+      'settings.random_play_order_random',
+    ],
+  }),
+  ...createEntries(autoPlayRoute, [
+    'settings.random_play_mode',
+  ], {
+    keywordKeys: ['settings.random_play_mode_manual', 'settings.random_play_mode_auto'],
+  }),
+  ...createEntries(autoPlayRoute, [
     'settings.collected_season_play_all_mode',
-  ]),
+  ], {
+    keywordKeys: [
+      'settings.collected_season_play_all_mode_beginning',
+      'settings.collected_season_play_all_mode_latest',
+      'settings.collected_season_play_all_mode_last_watched',
+    ],
+  }),
 
   ...createEntries(volumeBalanceRoute, [
     'settings.plugin.volume_balance',


### PR DESCRIPTION
补齐设置搜索目录中遗漏的想看分组，并完善四种语言文案。设置搜索现在会索引描述、选项组和显式关联的动态选项，同时修正动态标签的定位目标，避免搜得到但无法跳转。验证：pnpm lint、pnpm typecheck、locale YAML 解析及代表性中文查询模拟均通过。