### PR TITLE
refactor: 美味地优化设置搜索弹窗

### DIFF
--- a/src/components/Settings/Settings.vue
+++ b/src/components/Settings/Settings.vue
@@ -3,6 +3,7 @@ import { useEventListener } from '@vueuse/core'
 import type { CSSProperties } from 'vue'
 import { useI18n } from 'vue-i18n'
 
+import { useBewlyApp } from '~/composables/useAppProvider'
 import { settings } from '~/logic'
 import { createTransformer } from '~/utils/transformer'
 
@@ -61,6 +62,16 @@ const settingsWindow = ref<HTMLDivElement>()
 const settingsSearchRef = ref<HTMLElement>()
 const searchInputRef = ref<HTMLInputElement>()
 const searchPopoverStyle = ref<CSSProperties>({})
+const isSearchFocused = ref(false)
+const { mainAppRef } = useBewlyApp()
+
+function handleSearchBlur() {
+  isSearchFocused.value = false
+}
+
+function handleSearchFocus() {
+  isSearchFocused.value = true
+}
 
 function updateSearchPopoverBounds() {
   const searchElement = settingsSearchRef.value
@@ -71,16 +82,18 @@ function updateSearchPopoverBounds() {
   const searchRect = searchElement.getBoundingClientRect()
   const contentRect = contentElement.getBoundingClientRect()
   const edgeInset = 8
-  const popoverGap = 8
+  const popoverGap = 10
   const narrowLayout = window.innerWidth <= 760
   const bottomEdge = Math.min(window.innerHeight - edgeInset, contentRect.bottom - edgeInset)
 
-  // Match the top-bar search behavior: follow the trigger on wide layouts,
-  // then use the containing surface as a collision boundary on narrow ones.
+  // Fixed positioning so the popover can be teleported out of the settings
+  // window (which has its own backdrop-filter that would swallow ours).
   searchPopoverStyle.value = {
-    left: narrowLayout ? `${contentRect.left + edgeInset - searchRect.left}px` : 'auto',
-    right: narrowLayout ? 'auto' : '0',
-    width: narrowLayout ? `${Math.max(0, contentRect.width - edgeInset * 2)}px` : '100%',
+    position: 'fixed',
+    top: `${searchRect.bottom + popoverGap}px`,
+    right: narrowLayout ? 'auto' : `${window.innerWidth - searchRect.right}px`,
+    left: narrowLayout ? `${contentRect.left + edgeInset}px` : 'auto',
+    width: narrowLayout ? `${Math.max(0, contentRect.width - edgeInset * 2)}px` : `${searchRect.width}px`,
     maxHeight: `${Math.max(0, bottomEdge - searchRect.bottom - popoverGap)}px`,
   }
 }
@@ -107,6 +120,14 @@ useEventListener(window, 'resize', () => {
 })
 
 const scrollViewportRef = ref<HTMLElement>()
+
+// 滚动时关闭搜索弹窗（保留搜索词）
+useEventListener(() => scrollViewportRef.value, 'scroll', () => {
+  if (isSearchFocused.value) {
+    isSearchFocused.value = false
+    searchInputRef.value?.blur()
+  }
+}, { capture: true })
 
 provide('scrollSettingsContentToTop', () => {
   scrollViewportRef.value?.scrollTo({ top: 0 })
@@ -508,36 +529,9 @@ function changeMenuItem(menuItem: MenuType) {
               @keydown.down="moveSearchResultSelection($event, 1)"
               @keydown.up="moveSearchResultSelection($event, -1)"
               @keydown.enter="activateSearchResult"
-              @focus="updateSearchPopoverBounds"
+              @focus="() => { handleSearchFocus(); updateSearchPopoverBounds() }"
+              @blur="handleSearchBlur"
             >
-            <Transition name="settings-search-popover">
-              <div
-                v-if="searchQuery"
-                id="settings-search-results"
-                ref="searchResultsRef"
-                class="settings-search-results bew-popover-surface"
-                role="listbox"
-                :style="searchPopoverStyle"
-              >
-                <button
-                  v-for="(entry, index) in searchResults"
-                  :id="`settings-search-result-${index}`"
-                  :key="`${entry.menu}-${entry.secondaryTitleKey ?? ''}-${entry.titleKey ?? entry.title}-${index}`"
-                  type="button"
-                  role="option"
-                  :aria-selected="index === activeSearchResultIndex"
-                  :class="{ active: index === activeSearchResultIndex }"
-                  @mouseenter="activeSearchResultIndex = index"
-                  @click="navigateToSearchResult(entry)"
-                >
-                  <strong>{{ getSearchEntryTitle(entry) }}</strong>
-                  <span>{{ getSearchEntryLocation(entry) }}</span>
-                </button>
-                <p v-if="searchResults.length === 0">
-                  {{ $t('settings.search.no_results') }}
-                </p>
-              </div>
-            </Transition>
           </div>
           <div
             style="
@@ -578,6 +572,45 @@ function changeMenuItem(menuItem: MenuType) {
         </div>
       </div>
     </div>
+
+    <ClientOnly>
+      <Teleport :to="mainAppRef" :disabled="!mainAppRef">
+        <Transition name="settings-search-popover">
+          <div
+            v-if="searchQuery && isSearchFocused"
+            id="settings-search-results"
+            ref="searchResultsRef"
+            class="settings-search-results bew-popover-surface"
+            role="listbox"
+            :style="[
+              searchPopoverStyle,
+              {
+                backgroundColor: settings.enableFrostedGlass ? 'var(--bew-elevated-alt)' : 'var(--bew-elevated-alt-solid)',
+                zIndex: 10010,
+              },
+            ]"
+          >
+            <button
+              v-for="(entry, index) in searchResults"
+              :id="`settings-search-result-${index}`"
+              :key="`${entry.menu}-${entry.secondaryTitleKey ?? ''}-${entry.titleKey ?? entry.title}-${index}`"
+              type="button"
+              role="option"
+              :aria-selected="index === activeSearchResultIndex"
+              :class="{ active: index === activeSearchResultIndex }"
+              @mouseenter="activeSearchResultIndex = index"
+              @click="navigateToSearchResult(entry)"
+            >
+              <strong>{{ getSearchEntryTitle(entry) }}</strong>
+              <span>{{ getSearchEntryLocation(entry) }}</span>
+            </button>
+            <p v-if="searchResults.length === 0">
+              {{ $t('settings.search.no_results') }}
+            </p>
+          </div>
+        </Transition>
+      </Teleport>
+    </ClientOnly>
   </div>
 </template>
 
@@ -708,7 +741,7 @@ function changeMenuItem(menuItem: MenuType) {
   color: var(--bew-text-1);
   background: var(--bew-content);
   border: 1px solid var(--bew-border-color);
-  border-radius: var(--bew-interactive-radius);
+  border-radius: calc(var(--bew-radius) + 4px);
   box-shadow: var(--bew-shadow-edge-glow-1);
   transition:
     width var(--bew-duration-moderate) var(--bew-ease-standard),
@@ -750,16 +783,12 @@ function changeMenuItem(menuItem: MenuType) {
 }
 
 .settings-search-results {
-  position: absolute;
-  top: calc(100% + 8px);
-  right: 0;
-  z-index: 10;
   box-sizing: border-box;
-  width: 100%;
   padding: var(--bew-space-2);
   overflow-x: hidden;
   overflow-y: auto;
   overscroll-behavior: contain;
+  border-radius: calc(var(--bew-radius) + 4px);
 
   button {
     display: flex;
@@ -770,7 +799,8 @@ function changeMenuItem(menuItem: MenuType) {
     min-height: var(--bew-control-height);
     padding: var(--bew-space-2) var(--bew-space-4);
     text-align: left;
-    border-radius: var(--bew-panel-radius);
+    border-radius: var(--bew-radius);
+    transition: background-color var(--bew-duration-normal) var(--bew-ease-standard);
 
     &:hover {
       background: var(--bew-fill-2);
@@ -778,11 +808,6 @@ function changeMenuItem(menuItem: MenuType) {
 
     &.active {
       background: var(--bew-fill-2);
-      box-shadow: var(--bew-shadow-1), var(--bew-shadow-edge-glow-1);
-
-      strong {
-        color: var(--bew-theme-color);
-      }
     }
   }
 
@@ -817,17 +842,21 @@ function changeMenuItem(menuItem: MenuType) {
   }
 }
 
+.settings-search-results {
+  transform-origin: top right;
+}
+
 .settings-search-popover-enter-active,
 .settings-search-popover-leave-active {
   transition:
-    opacity var(--bew-duration-moderate) var(--bew-ease-in-out),
-    transform var(--bew-duration-moderate) var(--bew-ease-in-out);
+    opacity 0.24s cubic-bezier(0.16, 1, 0.3, 1),
+    transform 0.24s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .settings-search-popover-enter-from,
 .settings-search-popover-leave-to {
   opacity: 0;
-  transform: translateY(var(--bew-space-1)) scale(0.95);
+  transform: translateY(-4px) scale(0.98);
 }
 
 :deep(.settings-search-target) {


### PR DESCRIPTION
## 改动概述

在 1.7.0 基础上重新优化设置页搜索结果弹窗

## 改动

### 毛玻璃修复
弹窗用 `<Teleport>` 传送到 Shadow DOM 根（`mainAppRef`），脱离 `.settings-content` 的 backdrop root
`<ClientOnly>` + `:disabled="!mainAppRef"` 保护避免 removeChild 错误
对齐 `Dialog.vue` 的做法
并且背景跟随用户设置

### 交互优化
| 项目 | Before | After |
|---|---|---|
| 圆角 | 搜索框 `--bew-interactive-radius`(8px)、弹窗 `--bew-popover-radius` | 统一 `calc(var(--bew-radius) + 4px)`(16px) |
| 动画 | `--bew-duration-moderate` + `scale(0.95)` | `0.24s cubic-bezier(0.16,1,0.3,1)` + `transform-origin: top right` |
| hover | 瞬间变色 + `box-shadow` | `transition` 过渡，取消阴影 |
| 失焦 | 永远显示 | 关闭弹窗但保留搜索词，再次 focus 恢复 |
| 滚动 | 无反应 | 自动关闭弹窗 |

### 清理
- 移除不再需要的 `blurTimer` / `clearBlurTimer` / `onBeforeUnmount`

## 验证
- `pnpm typecheck` 通过
- `pnpm lint` 通过
- `pnpm build` 通过