### PR TITLE
fix: 修复窄屏下 Dock 遮挡视频卡片

### DIFF
--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -437,10 +437,10 @@ settings:
 
   # Video Card Grid Settings
   group_video_card_grid: 视频卡片网格
-  auto_switch_list_layout: 根据屏幕宽度自动切换单双列
-  auto_switch_list_layout_desc: 开启后，双列模式会在屏幕宽度小于 640px 时自动切换为单列。
+  auto_switch_list_layout: 根据视频卡片区域宽度自动切换单双列
+  auto_switch_list_layout_desc: 开启后，双列模式会在视频卡片区域宽度小于 640px 时自动切换为单列。
   grid_breakpoints: 网格断点配置
-  grid_breakpoints_desc: 设置不同屏幕宽度下显示的列数。当屏幕宽度大于等于设定值时，使用对应的列数。
+  grid_breakpoints_desc: 设置不同视频卡片区域宽度下显示的列数。当区域宽度大于等于设定值时，使用对应的列数。
   grid_min_width: 宽度 ≥
   grid_columns: 显示
   grid_columns_unit: 列

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -293,10 +293,10 @@ settings:
 
   # Video Card Grid Settings
   group_video_card_grid: 影片卡片網格
-  auto_switch_list_layout: 根據螢幕寬度自動切換單雙列
-  auto_switch_list_layout_desc: 開啟後，雙列模式會在螢幕寬度小於 640px 時自動切換為單列。
+  auto_switch_list_layout: 根據影片卡片區域寬度自動切換單雙列
+  auto_switch_list_layout_desc: 開啟後，雙列模式會在影片卡片區域寬度小於 640px 時自動切換為單列。
   grid_breakpoints: 網格斷點配置
-  grid_breakpoints_desc: 設定不同螢幕寬度下顯示的列數。當螢幕寬度大於等於設定值時，使用對應的列數。
+  grid_breakpoints_desc: 設定不同影片卡片區域寬度下顯示的列數。當區域寬度大於等於設定值時，使用對應的列數。
   grid_min_width: 寬度 ≥
   grid_columns: 顯示
   grid_columns_unit: 列

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -388,10 +388,10 @@ settings:
 
   # Video Card Grid Settings
   group_video_card_grid: Video Card Grid
-  auto_switch_list_layout: Automatically switch list columns based on screen width
-  auto_switch_list_layout_desc: When enabled, two-column mode switches to one column when the screen is narrower than 640px.
+  auto_switch_list_layout: Automatically switch list columns based on video grid width
+  auto_switch_list_layout_desc: When enabled, two-column mode switches to one column when the video grid is narrower than 640px.
   grid_breakpoints: Grid Breakpoints
-  grid_breakpoints_desc: Set the number of columns at different screen widths. When screen width is greater than or equal to the set value, use the corresponding columns.
+  grid_breakpoints_desc: Set the number of columns at different video grid widths. The matching column count is used when the grid reaches each breakpoint.
   grid_min_width: Width ≥
   grid_columns: Show
   grid_columns_unit: cols

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -317,10 +317,10 @@ settings:
 
   # Video Card Grid Settings
   group_video_card_grid: 影片卡片網格
-  auto_switch_list_layout: 根據屏幕闊度自動切換單雙列
-  auto_switch_list_layout_desc: 開啟之後，雙列模式會喺屏幕闊度細過 640px 時自動切換做單列。
+  auto_switch_list_layout: 根據影片卡片區域闊度自動切換單雙列
+  auto_switch_list_layout_desc: 開啟之後，雙列模式會喺影片卡片區域闊度細過 640px 時自動切換做單列。
   grid_breakpoints: 網格斷點設定
-  grid_breakpoints_desc: 設定唔同屏幕闊度時顯示嘅列數。當屏幕闊度大過或者等於設定值時，用對應嘅列數。
+  grid_breakpoints_desc: 設定唔同影片卡片區域闊度時顯示嘅列數。當區域闊度大過或者等於設定值時，用對應嘅列數。
   grid_min_width: 闊度 ≥
   grid_columns: 顯示
   grid_columns_unit: 列

--- a/src/components/Dock/Dock.vue
+++ b/src/components/Dock/Dock.vue
@@ -798,12 +798,13 @@ onUnmounted(() => {
 
   .back-to-top-or-refresh-btn {
     --uno: "transform active:important-scale-90 hover:scale-110";
-    --uno: "lg:w-45px w-35px lg:h-45px h-35px";
     --uno: "grid place-items-center";
     --uno: "filter-$bew-filter-glass-1";
     --uno: "bg-$bew-elevated hover:bg-$bew-content-hover";
     --uno: "rounded-full shadow-$bew-shadow-2 border-1 border-$bew-border-color";
 
+    width: var(--bew-dock-item-size);
+    height: var(--bew-dock-item-size);
     backdrop-filter: var(--bew-filter-glass-1);
     transition:
       transform 300ms var(--bew-ease-emphasized, cubic-bezier(0.34, 1.3, 0.64, 1)),
@@ -871,12 +872,13 @@ onUnmounted(() => {
 
   .back-to-top-or-refresh-btn {
     --uno: "transform active:important-scale-90 hover:scale-110";
-    --uno: "lg:w-45px w-35px lg:h-45px h-35px";
     --uno: "grid place-items-center";
     --uno: "filter-$bew-filter-glass-1";
     --uno: "bg-$bew-elevated hover:bg-$bew-content-hover";
     --uno: "rounded-full shadow-$bew-shadow-2 border-1 border-$bew-border-color";
 
+    width: var(--bew-dock-item-size);
+    height: var(--bew-dock-item-size);
     backdrop-filter: var(--bew-filter-glass-1);
     transition:
       transform 300ms var(--bew-ease-emphasized, cubic-bezier(0.34, 1.3, 0.64, 1)),
@@ -909,8 +911,6 @@ onUnmounted(() => {
   --shadow-active-active: 0 4px 20px var(--bew-theme-color-80);
 
   --uno: "relative transform active:important-scale-90 hover:scale-110";
-  --uno: "lg:w-45px w-35px";
-  --uno: "lg:lh-45px lh-35px";
   --uno: "p-0 flex items-center justify-center";
   --uno: "aspect-square relative";
   --uno: "leading-0";
@@ -918,6 +918,8 @@ onUnmounted(() => {
   --uno: "bg-$bew-fill-alt hover:bg-$bew-fill-2 cursor-pointer";
   --uno: "dark:bg-$bew-fill-1 dark-hover:bg-$bew-fill-4";
 
+  width: var(--bew-dock-item-size);
+  height: var(--bew-dock-item-size);
   box-shadow: var(--bew-shadow-edge-glow-1), var(--bew-shadow-1);
   transition:
     transform 300ms var(--bew-ease-emphasized, cubic-bezier(0.34, 1.3, 0.64, 1)),

--- a/src/components/VideoCardGrid.vue
+++ b/src/components/VideoCardGrid.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts" generic="T = any">
-import { useDebounceFn } from '@vueuse/core'
+import { useDebounceFn, useElementSize } from '@vueuse/core'
 
 import type { Video } from '~/components/VideoCard/types'
 import type { BewlyAppProvider } from '~/composables/useAppProvider'
@@ -189,6 +189,7 @@ const emit = defineEmits<{
 
 // Grid 容器 ref
 const gridContainerRef = ref<HTMLElement | null>(null)
+const { width: gridContainerWidth } = useElementSize(gridContainerRef)
 const loadMoreSentinelRef = ref<HTMLElement | null>(null)
 const isLoadMoreSentinelIntersecting = ref(false)
 const reachedLoadMoreDuringLoading = ref(false)
@@ -748,13 +749,11 @@ function cleanupScrollListeners() {
 }
 
 function getRenderedColumnCount(): number {
-  const containerWidth = gridContainerRef.value?.clientWidth
+  const containerWidth = gridContainerWidth.value
+    || gridContainerRef.value?.clientWidth
     || (typeof window !== 'undefined' ? window.innerWidth : 0)
-  // CSS 响应式布局使用视口断点，这里让骨架屏和补位计算保持相同的宽度基准。
-  const responsiveWidth = (props.gridLayout === 'adaptive' || settings.value.autoSwitchListLayout) && typeof window !== 'undefined'
-    ? window.innerWidth
-    : containerWidth
-  return getCurrentColumnCount(props.gridLayout, responsiveWidth)
+  // CSS container queries and JS row calculations must use the same width basis.
+  return getCurrentColumnCount(props.gridLayout, containerWidth)
 }
 
 function clearContinuePreloadTimer() {
@@ -1245,10 +1244,11 @@ function getUniqueKey(item: T, index: number): string | number {
 
 <style lang="scss" scoped>
 .video-card-grid-root {
+  container-type: inline-size;
   overflow-anchor: none;
 }
 
-// Grid 布局 - 根据设置页声明的视口断点和 CSS 变量控制列数
+// Grid 布局 - 根据设置页声明的容器断点和 CSS 变量控制列数
 .grid-adaptive {
   display: grid;
   gap: 20px;
@@ -1257,31 +1257,31 @@ function getUniqueKey(item: T, index: number): string | number {
   align-items: stretch;
 }
 
-@media (min-width: 640px) {
+@container (min-width: 640px) {
   .grid-adaptive {
     grid-template-columns: repeat(var(--grid-cols-sm, 2), 1fr);
   }
 }
 
-@media (min-width: 768px) {
+@container (min-width: 768px) {
   .grid-adaptive {
     grid-template-columns: repeat(var(--grid-cols-md, 3), 1fr);
   }
 }
 
-@media (min-width: 1024px) {
+@container (min-width: 1024px) {
   .grid-adaptive {
     grid-template-columns: repeat(var(--grid-cols-lg, 4), 1fr);
   }
 }
 
-@media (min-width: 1280px) {
+@container (min-width: 1280px) {
   .grid-adaptive {
     grid-template-columns: repeat(var(--grid-cols-xl, 5), 1fr);
   }
 }
 
-@media (min-width: 1536px) {
+@container (min-width: 1536px) {
   .grid-adaptive {
     grid-template-columns: repeat(var(--grid-cols-xxl, 6), 1fr);
   }
@@ -1303,7 +1303,7 @@ function getUniqueKey(item: T, index: number): string | number {
   align-items: stretch;
 }
 
-@media (max-width: 639.98px) {
+@container (max-width: 639.98px) {
   .grid-two-columns.grid-list-auto-switch {
     grid-template-columns: repeat(1, minmax(0, 1fr));
   }

--- a/src/contentScripts/views/App.vue
+++ b/src/contentScripts/views/App.vue
@@ -1005,6 +1005,11 @@ if (settings.value.cleanUrlArgument) {
             <main m-auto max-w="$bew-page-max-width">
               <div
                 class="bewly-page-content"
+                :class="{
+                  'bewly-page-content--dock-left': activatedPage === AppPage.Home && settings.dockPosition === 'left',
+                  'bewly-page-content--dock-right': activatedPage === AppPage.Home && settings.dockPosition === 'right',
+                  'bewly-page-content--dock-bottom': activatedPage === AppPage.Home && settings.dockPosition === 'bottom',
+                }"
                 p="t-[calc(var(--bew-top-bar-height)+10px)]" m-auto
                 :style="settings.useOriginalBilibiliTopBar && !reachTop
                   ? { paddingTop: 'calc(var(--bew-top-bar-height) + 120px)' }
@@ -1078,8 +1083,22 @@ if (settings.value.cleanUrlArgument) {
 }
 
 .bewly-page-content {
+  --bew-page-inline-padding: clamp(16px, 4vw, 80px);
+
   box-sizing: border-box;
   width: 100%;
-  padding-inline: clamp(16px, 4vw, 80px);
+  padding-inline: var(--bew-page-inline-padding);
+}
+
+.bewly-page-content--dock-left {
+  padding-left: max(var(--bew-page-inline-padding), var(--bew-dock-safe-inset));
+}
+
+.bewly-page-content--dock-right {
+  padding-right: max(var(--bew-page-inline-padding), var(--bew-dock-safe-inset));
+}
+
+.bewly-page-content--dock-bottom {
+  padding-bottom: var(--bew-dock-safe-inset);
 }
 </style>

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -68,6 +68,12 @@
   --bew-space-12: 48px;
   // #endregion
 
+  // Keep fixed Dock controls visually separate from scrollable page content.
+  --bew-dock-item-size: 35px;
+  --bew-dock-content-gap: var(--bew-space-3);
+  // Item size + the Dock's edge offset, shell margin/padding, and content gap.
+  --bew-dock-safe-inset: calc(var(--bew-dock-item-size) + var(--bew-space-10) + var(--bew-dock-content-gap));
+
   // #region Motion
   // Prefer specific transition properties over `transition: all` to avoid layout jumps.
   --bew-duration-fast: 150ms;
@@ -1040,5 +1046,12 @@
   --Lb1_rgb: 11, 32, 42;
   --Lb5_rgb: 0, 135, 189;
   --Lb7_rgb: 88, 177, 212;
+}
+
+@media (min-width: 1024px) {
+  :host,
+  :root {
+    --bew-dock-item-size: 45px;
+  }
 }
 // #endregion


### PR DESCRIPTION
## 关联 Issue

Closes #858

## 问题背景

在首页使用左侧或右侧 Dock 时，页面变窄到四列及以下后，视频卡片会重新进入 Dock 的覆盖区域。原有修复只在响应式页面边距上额外增加少量间距，无法覆盖窄屏下 Dock 的完整外廓；同时卡片网格仍按浏览器总宽度选择列数，临界宽度下会在实际可用空间不足时继续保持四列，造成遮挡和卡片拥挤。

## 根因分析

1. 首页水平内边距使用 `clamp(16px, 4vw, 80px)`，会随视口缩窄持续下降；Dock 按钮、外层偏移、margin 和 padding 的合计占用不会同比缩小。
2. `VideoCardGrid` 的 CSS 媒体查询和 JS 补行计算均基于 `window.innerWidth`，没有扣除 Dock 安全区及页面内边距。
3. Dock 的 `35px / 45px` 响应式尺寸分别散落在组件样式和布局计算中，页面安全区缺少可复用的统一尺寸来源。

## 修改内容

### 首页 Dock 安全区

- 根据 `dockPosition` 为首页内容绑定左、右、底部方向 class。
- 左右布局使用响应式页面边距与 Dock 安全尺寸的较大值，确保页面变窄后安全区不会继续缩进 Dock 内部。
- 底部布局预留相同语义安全区，使最后一排内容可以完整滚动到 Dock 上方。
- 修改仅作用于 Bewly 首页，不影响普通页面 SideBar 或视频宽屏侧栏。

### 视频卡片响应式网格

- 将 adaptive 网格及双列自动切换从视口媒体查询改为容器查询。
- 使用 `useElementSize` 读取视频网格实际宽度，让 CSS 列数、骨架屏补位、整行揭示和预加载计算使用同一宽度基准。
- 扣除 Dock 占用后若内容区域不足 `1024px`，网格会自然保持三列，而不会因浏览器总宽度达到断点被强制挤成四列。
- 保留用户已有的 `base / sm / md / lg / xl / xxl` 自定义列数配置及 adaptive、双列、单列布局模式。

### Token 与文案

- 新增 `--bew-dock-item-size`、`--bew-dock-content-gap` 和 `--bew-dock-safe-inset`，统一 Dock 控件尺寸与页面安全区计算。
- Dock 主按钮和独立操作按钮复用相同尺寸 token，避免视觉尺寸与布局预留再次漂移。
- 更新简体中文、繁体中文、英文和粤语设置文案，将断点语义从“屏幕宽度”明确为“视频卡片区域宽度”。

## 布局覆盖

- Dock 位置：左侧、右侧、底部
- 首页网格：adaptive、双列、单列
- adaptive 默认断点：1 至 6 列
- Dock 尺寸断点：小于 `1024px` 使用 `35px`，大于等于 `1024px` 使用 `45px`
- 自动隐藏和半隐藏 Dock 仍按完整展开外廓预留空间，避免悬停展开后覆盖卡片

## 验证

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `git diff --check`
- [x] CSS 与 JS 列数计算统一使用网格容器宽度
- [x] 提交内容不包含 tests 文件或 `AGENTS.md`

## 说明

PR 暂以 Draft 提交，便于进一步进行扩展内的多宽度视觉回归后再转为 Ready for review。