### PR TITLE
feat: 树状显示评论回复

### DIFF
--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -769,7 +769,7 @@ settings:
   show_comment_host_tag: 显示楼主标识
   show_comment_host_tag_desc: 在评论回复详情页中标注楼主
   enable_comment_reply_tree: 树状显示评论回复
-  enable_comment_reply_tree_desc: 根据回复关系逐层缩进楼中楼，方便辨认评论的前后关系
+  enable_comment_reply_tree_desc: 根据回复关系和发布时间整理楼中楼，并按层级逐层缩进
   adjust_comment_image_height: 调整评论区图片高度
   adjust_comment_image_height_desc: 自动调整评论区图片高度以匹配实际长宽比，避免图片变形
   detect_comment_shadow_ban: 检测评论仅自己可见

--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -768,6 +768,8 @@ settings:
   show_sex_desc: 在视频/动态评论区显示用户性别
   show_comment_host_tag: 显示楼主标识
   show_comment_host_tag_desc: 在评论回复详情页中标注楼主
+  enable_comment_reply_tree: 树状显示评论回复
+  enable_comment_reply_tree_desc: 根据回复关系逐层缩进楼中楼，方便辨认评论的前后关系
   adjust_comment_image_height: 调整评论区图片高度
   adjust_comment_image_height_desc: 自动调整评论区图片高度以匹配实际长宽比，避免图片变形
   detect_comment_shadow_ban: 检测评论仅自己可见

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -759,7 +759,7 @@ settings:
   show_comment_host_tag: 顯示樓主標示
   show_comment_host_tag_desc: 在評論回覆詳情頁標示樓主
   enable_comment_reply_tree: 樹狀顯示評論回覆
-  enable_comment_reply_tree_desc: 根據回覆關係逐層縮進樓中樓，方便辨識評論的前後關係
+  enable_comment_reply_tree_desc: 根據回覆關係和發佈時間整理樓中樓，並按層級逐層縮進
   adjust_comment_image_height: 調整評論區圖片高度
   adjust_comment_image_height_desc: 自動調整評論區圖片高度以匹配實際長寬比，避免圖片變形
   detect_comment_shadow_ban: 檢測留言僅自己可見

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -758,6 +758,8 @@ settings:
   show_sex_desc: 在影片/動態評論區顯示使用者性別
   show_comment_host_tag: 顯示樓主標示
   show_comment_host_tag_desc: 在評論回覆詳情頁標示樓主
+  enable_comment_reply_tree: 樹狀顯示評論回覆
+  enable_comment_reply_tree_desc: 根據回覆關係逐層縮進樓中樓，方便辨識評論的前後關係
   adjust_comment_image_height: 調整評論區圖片高度
   adjust_comment_image_height_desc: 自動調整評論區圖片高度以匹配實際長寬比，避免圖片變形
   detect_comment_shadow_ban: 檢測留言僅自己可見

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -838,6 +838,8 @@ settings:
   show_sex_desc: Display user gender in the video/dynamic comment area
   show_comment_host_tag: Show OP tag
   show_comment_host_tag_desc: Show an OP tag on the root comment in reply detail view
+  enable_comment_reply_tree: Show comment replies as a tree
+  enable_comment_reply_tree_desc: Indent nested replies by their parent relationship to make comment threads easier to follow
   adjust_comment_image_height: Adjust comment image height
   adjust_comment_image_height_desc: Automatically adjust comment image height to match actual aspect ratio and prevent distortion
   detect_comment_shadow_ban: Detect comments visible only to you

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -839,7 +839,7 @@ settings:
   show_comment_host_tag: Show OP tag
   show_comment_host_tag_desc: Show an OP tag on the root comment in reply detail view
   enable_comment_reply_tree: Show comment replies as a tree
-  enable_comment_reply_tree_desc: Indent nested replies by their parent relationship to make comment threads easier to follow
+  enable_comment_reply_tree_desc: Group replies by parent and posting time, then indent each nested level
   adjust_comment_image_height: Adjust comment image height
   adjust_comment_image_height_desc: Automatically adjust comment image height to match actual aspect ratio and prevent distortion
   detect_comment_shadow_ban: Detect comments visible only to you

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -760,7 +760,7 @@ settings:
   show_comment_host_tag: 顯示樓主標示
   show_comment_host_tag_desc: 喺留言回覆詳情頁標示樓主。
   enable_comment_reply_tree: 樹狀顯示留言回覆
-  enable_comment_reply_tree_desc: 根據回覆關係逐層縮入樓中樓，方便分辨留言嘅前後關係。
+  enable_comment_reply_tree_desc: 根據回覆關係同發佈時間整理樓中樓，再按層級逐層縮入。
   detect_comment_shadow_ban: 檢測留言係咪得自己睇到
   detect_comment_shadow_ban_desc: 發送留言大約 5 秒之後，分別用未登入同登入狀態檢查公開可見性；結果只供參考。
   video_player_scroll: 校好顯示模式後自動轆到合適嘅位置

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -759,6 +759,8 @@ settings:
   show_sex_desc: 喺影片/動向頁留言區顯示用戶性別。
   show_comment_host_tag: 顯示樓主標示
   show_comment_host_tag_desc: 喺留言回覆詳情頁標示樓主。
+  enable_comment_reply_tree: 樹狀顯示留言回覆
+  enable_comment_reply_tree_desc: 根據回覆關係逐層縮入樓中樓，方便分辨留言嘅前後關係。
   detect_comment_shadow_ban: 檢測留言係咪得自己睇到
   detect_comment_shadow_ban_desc: 發送留言大約 5 秒之後，分別用未登入同登入狀態檢查公開可見性；結果只供參考。
   video_player_scroll: 校好顯示模式後自動轆到合適嘅位置

--- a/src/components/Settings/BilibiliFeaturesEnhancement/Comments/Comments.vue
+++ b/src/components/Settings/BilibiliFeaturesEnhancement/Comments/Comments.vue
@@ -44,6 +44,14 @@ const commentToggleOptions = computed<CommentToggleOption[]>(() => [
     </div>
 
     <SettingsItem
+      :title="$t('settings.enable_comment_reply_tree')"
+      :desc="$t('settings.enable_comment_reply_tree_desc')"
+      right-width="auto"
+    >
+      <Radio v-model="settings.enableCommentReplyTree" />
+    </SettingsItem>
+
+    <SettingsItem
       :title="$t('settings.adjust_comment_image_height')"
       :desc="$t('settings.adjust_comment_image_height_desc')"
       right-width="auto"

--- a/src/components/Settings/searchCatalog.ts
+++ b/src/components/Settings/searchCatalog.ts
@@ -429,6 +429,7 @@ export const settingsSearchEntries: SettingsSearchEntry[] = [
     'settings.show_ip_location',
     'settings.show_sex',
     'settings.show_comment_host_tag',
+    'settings.enable_comment_reply_tree',
     'settings.adjust_comment_image_height',
     'settings.detect_comment_shadow_ban',
     'settings.bilibili_features.vip_features',

--- a/src/inject/index.ts
+++ b/src/inject/index.ts
@@ -122,6 +122,8 @@ else if (shouldInitializePageScript) {
 
   const COMMENT_COMPONENT_PATCHED = Symbol('bewly-comment-component-patched')
   const pendingCommentEnhancements = new WeakSet<object>()
+  const commentRepliesRenderers = new Set<any>()
+  const MAX_COMMENT_REPLY_TREE_DEPTH = 4
 
   const COMMENT_SHADOW_STYLE_PATCHES: Record<string, { id: string, css: string }> = {
     'bili-comment-replies-renderer': {
@@ -130,6 +132,31 @@ else if (shouldInitializePageScript) {
         #spinner {
           background: var(--bew-comment-replies-mask-bg, rgba(var(--bg1_rgb), 0.85)) !important;
         }
+
+        :host([data-bewly-comment-reply-tree]) #expander-contents > :is(bili-comment-reply-renderer, bili-comment-renderer)[data-bewly-comment-reply-depth] {
+          --bew-comment-reply-indent: 0px;
+          box-sizing: border-box;
+          display: block;
+          margin-inline-start: var(--bew-comment-reply-indent);
+          width: calc(100% - var(--bew-comment-reply-indent));
+        }
+
+        :host([data-bewly-comment-reply-tree]) #expander-contents > :is(bili-comment-reply-renderer, bili-comment-renderer)[data-bewly-comment-reply-depth="1"] {
+          --bew-comment-reply-indent: var(--bew-space-6, 24px);
+        }
+
+        :host([data-bewly-comment-reply-tree]) #expander-contents > :is(bili-comment-reply-renderer, bili-comment-renderer)[data-bewly-comment-reply-depth="2"] {
+          --bew-comment-reply-indent: var(--bew-space-12, 48px);
+        }
+
+        :host([data-bewly-comment-reply-tree]) #expander-contents > :is(bili-comment-reply-renderer, bili-comment-renderer)[data-bewly-comment-reply-depth="3"] {
+          --bew-comment-reply-indent: calc(var(--bew-space-12, 48px) + var(--bew-space-6, 24px));
+        }
+
+        :host([data-bewly-comment-reply-tree]) #expander-contents > :is(bili-comment-reply-renderer, bili-comment-renderer)[data-bewly-comment-reply-depth="4"] {
+          --bew-comment-reply-indent: calc(var(--bew-space-12, 48px) + var(--bew-space-12, 48px));
+        }
+
       `,
     },
     'bili-comment-renderer': {
@@ -269,6 +296,10 @@ else if (shouldInitializePageScript) {
     return toIdString(replyItem?.root_str ?? replyItem?.root)
   }
 
+  function getReplyParentRpid(replyItem: any): string | null {
+    return toIdString(replyItem?.parent_str ?? replyItem?.parent)
+  }
+
   function getReplyMemberMid(replyItem: any): string | null {
     return toIdString(replyItem?.member?.mid)
   }
@@ -276,6 +307,109 @@ else if (shouldInitializePageScript) {
   function getThreadRootKey(replyItem: any, rootRpid: string): string {
     const oid = getReplyOid(replyItem)
     return oid ? `${oid}:${rootRpid}` : rootRpid
+  }
+
+  function getCommentReplyData(component: any): any | null {
+    const userInfoData = component?.shadowRoot
+      ?.querySelector('bili-comment-user-info')
+      ?.data
+    const candidates = [component?.data, component?.reply, component?.replyItem, userInfoData]
+    return candidates.find(candidate => candidate && typeof candidate === 'object') ?? null
+  }
+
+  function getCommentReplyDepth(
+    replyItem: any,
+    repliesByRpid: Map<string, any>,
+    depthByRpid: Map<string, number>,
+    resolvingRpids: Set<string>,
+  ): number {
+    const rpid = getReplyRpid(replyItem)
+    if (!rpid)
+      return 0
+
+    const cachedDepth = depthByRpid.get(rpid)
+    if (cachedDepth !== undefined)
+      return cachedDepth
+
+    const parentRpid = getReplyParentRpid(replyItem)
+    const rootRpid = getReplyRootRpid(replyItem)
+    if (
+      !parentRpid
+      || parentRpid === '0'
+      || parentRpid === rootRpid
+      || parentRpid === rpid
+      || resolvingRpids.has(rpid)
+    ) {
+      depthByRpid.set(rpid, 0)
+      return 0
+    }
+
+    const parentReply = repliesByRpid.get(parentRpid)
+    if (!parentReply) {
+      depthByRpid.set(rpid, 0)
+      return 0
+    }
+
+    resolvingRpids.add(rpid)
+    const depth = Math.min(
+      getCommentReplyDepth(parentReply, repliesByRpid, depthByRpid, resolvingRpids) + 1,
+      MAX_COMMENT_REPLY_TREE_DEPTH,
+    )
+    resolvingRpids.delete(rpid)
+    depthByRpid.set(rpid, depth)
+    return depth
+  }
+
+  function updateCommentReplyTree(component: any) {
+    const root = component?.shadowRoot as ShadowRoot | null | undefined
+    if (!root)
+      return
+
+    commentRepliesRenderers.add(component)
+
+    const replyRenderers = Array.from(root.querySelectorAll<HTMLElement>(
+      '#expander-contents > bili-comment-reply-renderer, #expander-contents > bili-comment-renderer',
+    ))
+    const enabled = currentSettings?.enableCommentReplyTree === true
+    component.toggleAttribute('data-bewly-comment-reply-tree', enabled)
+
+    if (!enabled) {
+      replyRenderers.forEach((replyRenderer) => {
+        delete replyRenderer.dataset.bewlyCommentReplyDepth
+      })
+      return
+    }
+
+    const repliesByRpid = new Map<string, any>()
+    replyRenderers.forEach((replyRenderer) => {
+      const replyItem = getCommentReplyData(replyRenderer)
+      const rpid = getReplyRpid(replyItem)
+      if (rpid)
+        repliesByRpid.set(rpid, replyItem)
+    })
+
+    const depthByRpid = new Map<string, number>()
+    replyRenderers.forEach((replyRenderer) => {
+      const replyItem = getCommentReplyData(replyRenderer)
+      if (!replyItem) {
+        delete replyRenderer.dataset.bewlyCommentReplyDepth
+        return
+      }
+
+      const depth = getCommentReplyDepth(replyItem, repliesByRpid, depthByRpid, new Set())
+      replyRenderer.dataset.bewlyCommentReplyDepth = String(depth)
+    })
+  }
+
+  function refreshCommentReplyTrees() {
+    commentRepliesRenderers.forEach((component) => {
+      if (!component?.isConnected) {
+        commentRepliesRenderers.delete(component)
+        return
+      }
+
+      updateCommentReplyTree(component)
+    })
   }
 
   function cacheRootReplyAuthor(replyItem: any) {
@@ -447,6 +581,23 @@ else if (shouldInitializePageScript) {
                 return
 
               ensureCommentShadowStyle(root, shadowStylePatch.id, shadowStylePatch.css)
+              if (name === 'bili-comment-replies-renderer')
+                updateCommentReplyTree(component)
+            })
+          }
+          catch (error) {
+            console.warn(`[BewlyCat] Failed to patch ${name}.`, error)
+          }
+          return Reflect.apply(target, thisArg, args)
+        }
+
+        if (name === 'bili-comment-reply-renderer') {
+          try {
+            patchCommentComponentUpdate(name, classConstructor, (component) => {
+              const rootNode = component.getRootNode?.()
+              const repliesRenderer = rootNode instanceof ShadowRoot ? rootNode.host : null
+              if (repliesRenderer?.localName === 'bili-comment-replies-renderer')
+                updateCommentReplyTree(repliesRenderer)
             })
           }
           catch (error) {
@@ -546,6 +697,7 @@ else if (shouldInitializePageScript) {
         currentSettings = data
         preventMobileRedirectEnabled = data.preventMobileRedirect === true
         settingsReady = true
+        refreshCommentReplyTrees()
         resolveSettingsReady?.()
         resolveSettingsReady = null
 

--- a/src/inject/index.ts
+++ b/src/inject/index.ts
@@ -123,7 +123,24 @@ else if (shouldInitializePageScript) {
   const COMMENT_COMPONENT_PATCHED = Symbol('bewly-comment-component-patched')
   const pendingCommentEnhancements = new WeakSet<object>()
   const commentRepliesRenderers = new Set<any>()
-  const MAX_COMMENT_REPLY_TREE_DEPTH = 4
+  const commentReplyTreeStates = new WeakMap<object, CommentReplyTreeState>()
+  const MAX_COMMENT_REPLY_TREE_DEPTH = 10
+  const COMMENT_REPLY_TREE_INDENT_STEP = 'var(--bew-comment-reply-indent-step, var(--bew-space-8, 32px))'
+
+  interface CommentReplyTreeState {
+    enabled: boolean
+    nextOriginalOrder: number
+    originalOrderByRenderer: WeakMap<HTMLElement, number>
+  }
+
+  interface CommentReplyTreeNode {
+    renderer: HTMLElement
+    rpid: string | null
+    parentRpid: string | null
+    ctime: number | null
+    originalOrder: number
+    children: CommentReplyTreeNode[]
+  }
 
   const COMMENT_SHADOW_STYLE_PATCHES: Record<string, { id: string, css: string }> = {
     'bili-comment-replies-renderer': {
@@ -133,30 +150,22 @@ else if (shouldInitializePageScript) {
           background: var(--bew-comment-replies-mask-bg, rgba(var(--bg1_rgb), 0.85)) !important;
         }
 
+        :host([data-bewly-comment-reply-tree]) {
+          --bew-comment-reply-indent-step: var(--bew-space-8, 32px);
+        }
+
         :host([data-bewly-comment-reply-tree]) #expander-contents > :is(bili-comment-reply-renderer, bili-comment-renderer)[data-bewly-comment-reply-depth] {
-          --bew-comment-reply-indent: 0px;
           box-sizing: border-box;
           display: block;
-          margin-inline-start: var(--bew-comment-reply-indent);
-          width: calc(100% - var(--bew-comment-reply-indent));
+          margin-inline-start: var(--bew-comment-reply-indent, 0px);
+          width: calc(100% - var(--bew-comment-reply-indent, 0px));
         }
 
-        :host([data-bewly-comment-reply-tree]) #expander-contents > :is(bili-comment-reply-renderer, bili-comment-renderer)[data-bewly-comment-reply-depth="1"] {
-          --bew-comment-reply-indent: var(--bew-space-6, 24px);
+        @media (max-width: 640px) {
+          :host([data-bewly-comment-reply-tree]) {
+            --bew-comment-reply-indent-step: var(--bew-space-6, 24px);
+          }
         }
-
-        :host([data-bewly-comment-reply-tree]) #expander-contents > :is(bili-comment-reply-renderer, bili-comment-renderer)[data-bewly-comment-reply-depth="2"] {
-          --bew-comment-reply-indent: var(--bew-space-12, 48px);
-        }
-
-        :host([data-bewly-comment-reply-tree]) #expander-contents > :is(bili-comment-reply-renderer, bili-comment-renderer)[data-bewly-comment-reply-depth="3"] {
-          --bew-comment-reply-indent: calc(var(--bew-space-12, 48px) + var(--bew-space-6, 24px));
-        }
-
-        :host([data-bewly-comment-reply-tree]) #expander-contents > :is(bili-comment-reply-renderer, bili-comment-renderer)[data-bewly-comment-reply-depth="4"] {
-          --bew-comment-reply-indent: calc(var(--bew-space-12, 48px) + var(--bew-space-12, 48px));
-        }
-
       `,
     },
     'bili-comment-renderer': {
@@ -317,47 +326,128 @@ else if (shouldInitializePageScript) {
     return candidates.find(candidate => candidate && typeof candidate === 'object') ?? null
   }
 
-  function getCommentReplyDepth(
-    replyItem: any,
-    repliesByRpid: Map<string, any>,
-    depthByRpid: Map<string, number>,
-    resolvingRpids: Set<string>,
-  ): number {
-    const rpid = getReplyRpid(replyItem)
-    if (!rpid)
-      return 0
+  function getCommentReplyTreeState(component: object): CommentReplyTreeState {
+    let state = commentReplyTreeStates.get(component)
+    if (!state) {
+      state = {
+        enabled: false,
+        nextOriginalOrder: 0,
+        originalOrderByRenderer: new WeakMap(),
+      }
+      commentReplyTreeStates.set(component, state)
+    }
+    return state
+  }
 
-    const cachedDepth = depthByRpid.get(rpid)
-    if (cachedDepth !== undefined)
-      return cachedDepth
+  function getCommentReplyOriginalOrder(state: CommentReplyTreeState, renderer: HTMLElement): number {
+    let originalOrder = state.originalOrderByRenderer.get(renderer)
+    if (originalOrder === undefined) {
+      originalOrder = state.nextOriginalOrder
+      state.nextOriginalOrder += 1
+      state.originalOrderByRenderer.set(renderer, originalOrder)
+    }
+    return originalOrder
+  }
 
-    const parentRpid = getReplyParentRpid(replyItem)
-    const rootRpid = getReplyRootRpid(replyItem)
-    if (
-      !parentRpid
-      || parentRpid === '0'
-      || parentRpid === rootRpid
-      || parentRpid === rpid
-      || resolvingRpids.has(rpid)
-    ) {
-      depthByRpid.set(rpid, 0)
-      return 0
+  function getCommentReplyCtime(replyItem: any): number | null {
+    const ctime = replyItem?.ctime
+    if (ctime === null || ctime === undefined || ctime === '')
+      return null
+
+    const numericCtime = Number(ctime)
+    return Number.isFinite(numericCtime) ? numericCtime : null
+  }
+
+  function compareCommentReplyTreeNodes(a: CommentReplyTreeNode, b: CommentReplyTreeNode): number {
+    if (a.ctime !== null && b.ctime !== null && a.ctime !== b.ctime)
+      return a.ctime - b.ctime
+    if (a.ctime !== null && b.ctime === null)
+      return -1
+    if (a.ctime === null && b.ctime !== null)
+      return 1
+    return a.originalOrder - b.originalOrder
+  }
+
+  function getCommentReplyIndent(depth: number): string {
+    if (depth <= 0)
+      return '0px'
+    if (depth === 1)
+      return COMMENT_REPLY_TREE_INDENT_STEP
+
+    return `calc(${Array.from({ length: depth }, () => COMMENT_REPLY_TREE_INDENT_STEP).join(' + ')})`
+  }
+
+  function isCommentReplyRenderer(element: Element): element is HTMLElement {
+    return element.localName === 'bili-comment-reply-renderer'
+      || element.localName === 'bili-comment-renderer'
+  }
+
+  function reorderCommentReplyRenderers(
+    container: HTMLElement,
+    currentRenderers: HTMLElement[],
+    orderedRenderers: HTMLElement[],
+  ) {
+    if (orderedRenderers.every((renderer, index) => renderer === currentRenderers[index]))
+      return
+
+    const replyRendererSet = new Set(currentRenderers)
+    const findNextReplyRenderer = (renderer: HTMLElement): ChildNode | null => {
+      let sibling = renderer.nextSibling
+      while (sibling && !(sibling instanceof HTMLElement && replyRendererSet.has(sibling)))
+        sibling = sibling.nextSibling
+      return sibling
     }
 
-    const parentReply = repliesByRpid.get(parentRpid)
-    if (!parentReply) {
-      depthByRpid.set(rpid, 0)
-      return 0
+    let insertionPoint: ChildNode | null = currentRenderers[0] ?? null
+    orderedRenderers.forEach((renderer) => {
+      if (renderer === insertionPoint)
+        insertionPoint = findNextReplyRenderer(renderer)
+      else
+        container.insertBefore(renderer, insertionPoint)
+    })
+  }
+
+  function buildCommentReplyTreeOrder(nodes: CommentReplyTreeNode[]): Array<{
+    depth: number
+    node: CommentReplyTreeNode
+  }> {
+    const nodeByRpid = new Map<string, CommentReplyTreeNode>()
+    nodes.forEach((node) => {
+      if (node.rpid && !nodeByRpid.has(node.rpid))
+        nodeByRpid.set(node.rpid, node)
+    })
+
+    const rootNodes: CommentReplyTreeNode[] = []
+    nodes.forEach((node) => {
+      const parentNode = node.parentRpid ? nodeByRpid.get(node.parentRpid) : undefined
+      if (parentNode && parentNode !== node)
+        parentNode.children.push(node)
+      else
+        rootNodes.push(node)
+    })
+
+    rootNodes.sort(compareCommentReplyTreeNodes)
+    nodes.forEach(node => node.children.sort(compareCommentReplyTreeNodes))
+
+    // Keep every branch contiguous: parent first, then its time-ordered children.
+    const orderedNodes: Array<{ depth: number, node: CommentReplyTreeNode }> = []
+    const visitedRenderers = new Set<HTMLElement>()
+    const visitNode = (node: CommentReplyTreeNode, depth: number) => {
+      if (visitedRenderers.has(node.renderer))
+        return
+
+      visitedRenderers.add(node.renderer)
+      orderedNodes.push({ node, depth: Math.min(depth, MAX_COMMENT_REPLY_TREE_DEPTH) })
+      node.children.forEach(child => visitNode(child, depth + 1))
     }
 
-    resolvingRpids.add(rpid)
-    const depth = Math.min(
-      getCommentReplyDepth(parentReply, repliesByRpid, depthByRpid, resolvingRpids) + 1,
-      MAX_COMMENT_REPLY_TREE_DEPTH,
-    )
-    resolvingRpids.delete(rpid)
-    depthByRpid.set(rpid, depth)
-    return depth
+    rootNodes.forEach(node => visitNode(node, 0))
+    nodes
+      .filter(node => !visitedRenderers.has(node.renderer))
+      .sort(compareCommentReplyTreeNodes)
+      .forEach(node => visitNode(node, 0))
+
+    return orderedNodes
   }
 
   function updateCommentReplyTree(component: any) {
@@ -367,38 +457,57 @@ else if (shouldInitializePageScript) {
 
     commentRepliesRenderers.add(component)
 
-    const replyRenderers = Array.from(root.querySelectorAll<HTMLElement>(
-      '#expander-contents > bili-comment-reply-renderer, #expander-contents > bili-comment-renderer',
-    ))
+    const replyContainer = root.querySelector<HTMLElement>('#expander-contents')
+    if (!replyContainer)
+      return
+
+    const replyRenderers = Array.from(replyContainer.children)
+      .filter(isCommentReplyRenderer)
+    const state = getCommentReplyTreeState(component)
+    replyRenderers.forEach(renderer => getCommentReplyOriginalOrder(state, renderer))
+
     const enabled = currentSettings?.enableCommentReplyTree === true
     component.toggleAttribute('data-bewly-comment-reply-tree', enabled)
 
     if (!enabled) {
+      if (state.enabled) {
+        const originalOrder = [...replyRenderers].sort((a, b) => (
+          getCommentReplyOriginalOrder(state, a) - getCommentReplyOriginalOrder(state, b)
+        ))
+        reorderCommentReplyRenderers(replyContainer, replyRenderers, originalOrder)
+      }
+
       replyRenderers.forEach((replyRenderer) => {
         delete replyRenderer.dataset.bewlyCommentReplyDepth
+        replyRenderer.style.removeProperty('--bew-comment-reply-indent')
       })
+      state.enabled = false
       return
     }
 
-    const repliesByRpid = new Map<string, any>()
-    replyRenderers.forEach((replyRenderer) => {
+    const nodes: CommentReplyTreeNode[] = replyRenderers.map((replyRenderer) => {
       const replyItem = getCommentReplyData(replyRenderer)
-      const rpid = getReplyRpid(replyItem)
-      if (rpid)
-        repliesByRpid.set(rpid, replyItem)
-    })
-
-    const depthByRpid = new Map<string, number>()
-    replyRenderers.forEach((replyRenderer) => {
-      const replyItem = getCommentReplyData(replyRenderer)
-      if (!replyItem) {
-        delete replyRenderer.dataset.bewlyCommentReplyDepth
-        return
+      return {
+        renderer: replyRenderer,
+        rpid: getReplyRpid(replyItem),
+        parentRpid: getReplyParentRpid(replyItem),
+        ctime: getCommentReplyCtime(replyItem),
+        originalOrder: getCommentReplyOriginalOrder(state, replyRenderer),
+        children: [],
       }
-
-      const depth = getCommentReplyDepth(replyItem, repliesByRpid, depthByRpid, new Set())
-      replyRenderer.dataset.bewlyCommentReplyDepth = String(depth)
     })
+
+    const orderedNodes = buildCommentReplyTreeOrder(nodes)
+    orderedNodes.forEach(({ depth, node }) => {
+      node.renderer.dataset.bewlyCommentReplyDepth = String(depth)
+      node.renderer.style.setProperty('--bew-comment-reply-indent', getCommentReplyIndent(depth))
+    })
+    reorderCommentReplyRenderers(
+      replyContainer,
+      replyRenderers,
+      orderedNodes.map(({ node }) => node.renderer),
+    )
+    state.enabled = true
   }
 
   function refreshCommentReplyTrees() {

--- a/src/logic/storage.ts
+++ b/src/logic/storage.ts
@@ -200,6 +200,7 @@ export interface Settings {
   showIPLocation: boolean // 添加显示IP归属地设置项
   showSex: boolean // 添加显示性别设置项
   showCommentHostTag: boolean // 显示评论回复详情页楼主标识
+  enableCommentReplyTree: boolean // 根据回复关系逐层缩进楼中楼
   adjustCommentImageHeight: boolean // 调整评论区图片高度以匹配实际比例
   detectCommentShadowBan: boolean // 发送评论后检测是否仅自己可见
   enlargeFavoriteDialog: boolean // 视频页收藏夹放大样式增强
@@ -467,6 +468,7 @@ export const originalSettings: Settings = {
   showIPLocation: true, // 默认启用IP归属地显示
   showSex: true, // 默认启用性别显示
   showCommentHostTag: true, // 默认启用楼主标识显示
+  enableCommentReplyTree: true, // 默认启用评论回复树状缩进
   adjustCommentImageHeight: true, // 默认启用评论图片高度调整
   detectCommentShadowBan: false, // 默认关闭评论可见性检测
   enlargeFavoriteDialog: false, // 默认关闭收藏夹放大样式


### PR DESCRIPTION
## 关联 Issue

Closes #349

是 https://github.com/keleus/BewlyCat/issues/471 问题的部分实现，可以考虑评论后关闭

## 背景

Bilibili 当前将楼中楼回复渲染为同一容器下的平级节点。回复内容虽然会显示被回复用户，但较长对话中的父子关系不够直观；仅对平级节点增加缩进，也无法让同一父回复下的后续讨论保持连续。

本 PR 根据每条回复的 `rpid`、`root`、`parent` 和 `ctime` 恢复当前已加载回复之间的树关系，并把同一父回复下的子回复按发布时间整理到一起。

## 改动内容

- 新增“树状显示评论回复”设置，默认开启，并支持在设置页实时开关。
- 在 `bili-comment-replies-renderer` 的 Shadow DOM 中注入树状缩进样式。
- 收集当前楼中楼内已渲染回复，以 `rpid` 建立索引，并通过 `parent` 连接可见的父子节点。
- 每个父回复后紧跟其完整子树；同一直接父回复下的子回复按 `ctime` 从早到晚排列。
- 使用深度优先顺序展示回复树，使同一讨论分支连续显示，行为接近多级菜单。
- 常规窗口每深入一级缩进 `32px`；小于 `640px` 的窄窗口降为 `24px`，避免正文区域被过度压缩。
- 视觉缩进最多保留 10 级；更深的回复仍参与树形排序，但沿用第 10 级位置。
- 不绘制层级竖线，仅通过稳定的水平位置表达层级。
- 只移动当前容器内已有的评论节点，不克隆或删除节点；顺序未变化时不会执行 DOM 移动。
- 关闭功能时恢复首次观察到的 Bilibili 原始节点顺序，并移除深度属性与缩进变量。
- 监听回复组件更新，兼容展开更多、分页和懒加载产生的新回复。
- 设置变更时刷新已经挂载的评论回复组件，并清理已卸载组件引用。
- 回复数据优先从渲染器自身读取，同时以内部 `bili-comment-user-info.data` 作为兼容兜底。
- 补充简体中文、繁体中文、粤语和英文文案，并加入设置搜索目录。

## 排序与层级规则

对于当前回复容器中的每个节点：

1. 读取回复 ID、直接父回复 ID 和发布时间。
2. 如果直接父回复也在当前容器中，将节点挂到该父回复下。
3. 如果父回复尚未加载、位于其他分页、字段缺失或指向自身，则将节点作为当前可见树的根节点处理。
4. 根节点以及同一父节点的直接子节点均按发布时间升序排列；时间缺失或相同时使用首次观察到的原始顺序保持稳定。
5. 以“父节点优先，然后递归处理子节点”的深度优先顺序生成最终列表。
6. 使用已访问节点集合防止异常父链循环导致重复或无限递归。
7. 将真实深度限制为最多 10 级视觉缩进，再按最终顺序移动现有节点。

例如原平级顺序为 `A, B, D→A, C→A, E→D`，且 `D` 比 `C` 更早发布，整理后会显示为 `A, D, E, C, B`：`D/C` 作为 `A` 的同级子回复按时间排列，`E` 紧跟在其父回复 `D` 下。

## 用户可见行为

- 功能默认开启，可在“设置 > Bilibili 功能增强 > 评论”中关闭。
- 根评论下的直接回复保持第一级位置。
- 回复楼中楼时，常规窗口每深入一级增加 `32px` 缩进，最高显示十级。
- 同一父回复收到的多条回复会按发布时间排列并连续显示。
- 一个父回复的后续分支会在下一个同级回复之前完整显示。
- 不显示层级竖线。
- 设置开关无需刷新页面即可作用于已经加载的评论。

## 验证

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build:inject -- --mode development`
- `pnpm build:js -- --mode development`
- `git diff --check`
- chrome下测试无异常

以上检查均已通过。

## 兼容性与风险

该功能依赖 Bilibili 新评论 Web Components 的开放 Shadow DOM、组件名称和评论数据字段。实现沿用了项目现有的评论组件补丁机制，并为回复数据读取提供内部用户信息组件兜底。树形排序仅在计算后的顺序发生变化时移动同一容器中的现有节点；若 Bilibili 后续调整组件结构或字段，无法识别的数据会作为当前层根节点保留，不会主动删除评论。