### PR TITLE
fix: 修复原版顶栏切换与搜索交互

### DIFF
--- a/src/components/SearchBar/SearchBar.vue
+++ b/src/components/SearchBar/SearchBar.vue
@@ -861,7 +861,7 @@ function handleClearKeyword() {
     }
 
     &.focus input {
-      --uno: "border-$bew-theme-color rounded-$bew-radius";
+      --uno: "border-$bew-theme-color";
       box-shadow:
         0 0 0 2px var(--bew-theme-color),
         0 6px 16px var(--bew-theme-color-40),

--- a/src/components/TopBar/BewlyOrBiliTopBarSwitcher.vue
+++ b/src/components/TopBar/BewlyOrBiliTopBarSwitcher.vue
@@ -31,42 +31,44 @@ const topMargin = computed(() => {
 </script>
 
 <template>
-  <div
-    v-show="topBarStore.topBarVisible || settings.useOriginalBilibiliTopBar"
-    class="group"
-    pos="fixed top-0 right-0"
-    z-10
-    w-full
-    flex="~ items-center justify-center"
-    :style="{ marginTop: topMargin }"
-    p="t-30px"
-    @mouseenter="isButtonVisible = true"
-    @mouseleave="isButtonVisible = false"
-  >
-    <button
-      style="backdrop-filter: var(--bew-filter-glass-1);"
-      pos="absolute"
-      :class="isButtonVisible ? 'opacity-100' : 'opacity-0'"
-      class="pointer-events-auto"
-      :style="{
-        transform: isButtonVisible ? 'translateY(0)' : 'translateY(-100%)',
-      }"
-      flex="~ items-center gap-2"
-      text="$bew-text-2 sm"
-      bg="$bew-elevated" p="x-2 y-1" mt-2
-      rounded="full" shadow="$bew-shadow-1"
-      duration-300
-      @click="toggleBewlyTopBar"
+  <Teleport to="body">
+    <div
+      v-show="topBarStore.topBarVisible || settings.useOriginalBilibiliTopBar"
+      class="group pointer-events-none"
+      pos="fixed top-0 right-0"
+      z-1002
+      w-full
+      flex="~ items-center justify-center"
+      :style="{ marginTop: topMargin }"
+      p="t-30px"
+      @mouseenter="isButtonVisible = true"
+      @mouseleave="isButtonVisible = false"
     >
-      <i i-mingcute:transfer-3-line text-xs />
-      <span>
-        <template v-if="settings.showTopBar">
-          {{ $t('topbar.switch_to_bili_top_bar') }}
-        </template>
-        <template v-else>
-          {{ $t('topbar.switch_to_bewly_top_bar') }}
-        </template>
-      </span>
-    </button>
-  </div>
+      <button
+        style="backdrop-filter: var(--bew-filter-glass-1);"
+        pos="absolute"
+        :class="isButtonVisible ? 'opacity-100' : 'opacity-0'"
+        class="pointer-events-auto"
+        :style="{
+          transform: isButtonVisible ? 'translateY(0)' : 'translateY(-100%)',
+        }"
+        flex="~ items-center gap-2"
+        text="$bew-text-2 sm"
+        bg="$bew-elevated" p="x-2 y-1" mt-2
+        rounded="full" shadow="$bew-shadow-1"
+        duration-300
+        @click="toggleBewlyTopBar"
+      >
+        <i i-mingcute:transfer-3-line text-xs />
+        <span>
+          <template v-if="settings.showTopBar">
+            {{ $t('topbar.switch_to_bili_top_bar') }}
+          </template>
+          <template v-else>
+            {{ $t('topbar.switch_to_bewly_top_bar') }}
+          </template>
+        </span>
+      </button>
+    </div>
+  </Teleport>
 </template>

--- a/src/contentScripts/index.ts
+++ b/src/contentScripts/index.ts
@@ -12,7 +12,7 @@ import { useTopBarStore } from '~/stores/topBarStore'
 import RESET_BEWLY_CSS from '~/styles/reset.css?raw'
 import { applyBewlyWidescreen, exitBewlyWidescreen } from '~/utils/bewlyWidescreen'
 import { cleanupBilibiliScripts } from '~/utils/bilibiliScriptCleanup'
-import { captureOriginalBilibiliTopBar, ensureOriginalBilibiliTopBarAppended, resetBilibiliTopBarInlineStyles, setupLoginButtonClickHandlers, setupOriginalBilibiliTopBarSearchHandlers } from '~/utils/bilibiliTopBar'
+import { captureOriginalBilibiliTopBar, ensureOriginalBilibiliTopBarAppended, resetBilibiliTopBarInlineStyles, setupLoginButtonClickHandlers } from '~/utils/bilibiliTopBar'
 import { initFavoriteDialogEnhancement } from '~/utils/favoriteDialog'
 import { runWhenIdle } from '~/utils/lazyLoad'
 import { getLocalWallpaper, hasLocalWallpaper, isLocalWallpaperUrl } from '~/utils/localWallpaper'
@@ -194,6 +194,9 @@ else if (shouldInitializeContentScript) {
         (target): target is HTMLAnchorElement => target instanceof HTMLAnchorElement && target.hasAttribute('href'),
       ) ?? (event.target instanceof Element ? event.target.closest('a[href]') : null)
       if (!(anchor instanceof HTMLAnchorElement))
+        return
+
+      if (anchor.closest('.bili-header, #biliMainHeader, #internationalHeader, #bili-header-container'))
         return
 
       const pluginSearchResultsUrl = getPluginSearchResultsUrl(anchor.href)
@@ -582,8 +585,6 @@ else if (shouldInitializeContentScript) {
     if (isHomePage())
       await settingsReady
 
-    setupOriginalBilibiliTopBarSearchHandlers(document, () => settings.value.usePluginSearchResultsPage)
-
     const changeHomePage = !isInIframe() && !settings.value.useOriginalBilibiliHomepage && isHomePage()
     document.documentElement.classList.toggle('bewly-custom-homepage', changeHomePage)
 
@@ -664,7 +665,8 @@ else if (shouldInitializeContentScript) {
       // 温和的脚本清理（可选，减少后台资源消耗）
       cleanupBilibiliScripts()
 
-      ensureOriginalBilibiliTopBarAppended(document)
+      if (settings.value.useOriginalBilibiliTopBar)
+        ensureOriginalBilibiliTopBarAppended(document)
 
       // Setup login button click handlers for the original Bilibili top bar
       setupLoginButtonClickHandlers(document)

--- a/src/contentScripts/views/necessarySettingsWatchers.ts
+++ b/src/contentScripts/views/necessarySettingsWatchers.ts
@@ -4,7 +4,7 @@ import { IFRAME_TOP_BAR_CHANGE } from '~/constants/globalEvents'
 import { setUselessFeedCardBlockerEnabled, shouldEnableUselessFeedCardBlocker } from '~/contentScripts/features/blockUselessFeedCards'
 import { LanguageType } from '~/enums/appEnums'
 import { appAuthTokens, FROSTED_GLASS_BLUR_MAX_PX, FROSTED_GLASS_BLUR_MIN_PX, localSettings, originalSettings, settings } from '~/logic'
-import { resetBilibiliTopBarInlineStyles, setOriginalBilibiliTopBarScrolled } from '~/utils/bilibiliTopBar'
+import { ensureOriginalBilibiliTopBarAppended, resetBilibiliTopBarInlineStyles, restoreOriginalBilibiliTopBarParent, setOriginalBilibiliTopBarScrolled } from '~/utils/bilibiliTopBar'
 import { cleanBilibiliShareText, getUserID, injectCSS, isHomePage, isInIframe, isVideoPlaybackPage } from '~/utils/main'
 
 function isFestivalPage(): boolean {
@@ -532,6 +532,11 @@ export function setupNecessarySettingsWatchers() {
       // When the homepage is showing an original Bilibili page inside our iframe (dock item "useOriginalBiliPage"),
       // we should keep the *outer* document's Bilibili top bar hidden to avoid double headers.
       const shouldHideOuterBiliTopBar = hasBiliIframePage()
+
+      if (settings.value.useOriginalBilibiliTopBar && !shouldHideOuterBiliTopBar)
+        ensureOriginalBilibiliTopBarAppended(document)
+      else
+        restoreOriginalBilibiliTopBarParent(document)
 
       const shouldApplyRemoveTopBar = !settings.value.useOriginalBilibiliTopBar || shouldHideOuterBiliTopBar
       document.documentElement.classList.toggle('remove-top-bar', shouldApplyRemoveTopBar)

--- a/src/utils/bilibiliTopBar.ts
+++ b/src/utils/bilibiliTopBar.ts
@@ -13,7 +13,7 @@ const BILIBILI_TOP_BAR_SELECTORS = [
 ]
 
 let cachedOriginalTopBar: HTMLElement | null = null
-const originalTopBarSearchCleanups = new WeakMap<Document, () => void>()
+let cachedOriginalTopBarParent: HTMLElement | null = null
 const initializedHoverHeaders = new WeakSet<HTMLElement>()
 const initializedScrollStateHeaders = new WeakSet<HTMLElement>()
 const initializedTopBarDocuments = new WeakSet<Document>()
@@ -79,6 +79,25 @@ function getDocumentTopBar(doc: Document): HTMLElement | null {
   return doc.querySelector<HTMLElement>('.bili-header')
 }
 
+function getNativeDocumentTopBar(doc: Document): HTMLElement | null {
+  return doc.querySelector<HTMLElement>('body > #app > .bili-feed4 > .bili-header')
+}
+
+function rememberOriginalTopBarParent(doc: Document, header: HTMLElement) {
+  if (header.parentElement && header.parentElement !== doc.body)
+    cachedOriginalTopBarParent = header.parentElement
+}
+
+function prepareOriginalTopBar(header: HTMLElement) {
+  const innerUselessContents = header.querySelectorAll<HTMLElement>(
+    ':scope > *:not(.bili-header__bar):not(.bili-header__channel)',
+  )
+  innerUselessContents.forEach(item => (item.style.display = 'none'))
+  header.querySelector<HTMLElement>(':scope > .bili-header__channel')?.style.removeProperty('display')
+  setupOriginalTopBarChannelHover(header)
+  ensureOriginalTopBarScrolledLayout(header)
+}
+
 export function captureOriginalBilibiliTopBar(doc: Document) {
   if (cachedOriginalTopBar?.isConnected && cachedOriginalTopBar.ownerDocument === doc)
     return cachedOriginalTopBar
@@ -88,9 +107,10 @@ export function captureOriginalBilibiliTopBar(doc: Document) {
     return null
 
   cachedOriginalTopBar = header
+  rememberOriginalTopBarParent(doc, header)
   keepOriginalTopBarAvailable(doc)
   setOriginalBilibiliTopBarScrolled(doc, false)
-  ensureOriginalTopBarScrolledLayout(header)
+  prepareOriginalTopBar(header)
   return cachedOriginalTopBar
 }
 
@@ -131,14 +151,20 @@ function keepOriginalTopBarAvailable(doc: Document) {
 
   initializedTopBarDocuments.add(doc)
   const observer = new MutationObserver(() => {
-    const header = getDocumentTopBar(doc)
+    const header = getNativeDocumentTopBar(doc) || getDocumentTopBar(doc)
     if (!header || header === cachedOriginalTopBar)
       return
 
+    const mountedInBody = cachedOriginalTopBar?.parentElement === doc.body
     const scrolled = cachedOriginalTopBar?.classList.contains('bewly-original-top-bar-scrolled') ?? false
+    if (mountedInBody)
+      cachedOriginalTopBar?.remove()
+
     cachedOriginalTopBar = header
-    setupOriginalTopBarChannelHover(header)
-    ensureOriginalTopBarScrolledLayout(header)
+    rememberOriginalTopBarParent(doc, header)
+    prepareOriginalTopBar(header)
+    if (mountedInBody)
+      doc.body.prepend(header)
     setOriginalBilibiliTopBarScrolled(doc, scrolled)
   })
   observer.observe(doc.documentElement, {
@@ -360,20 +386,53 @@ export function detachOriginalBilibiliTopBar(doc: Document) {
 }
 
 export function ensureOriginalBilibiliTopBarAppended(doc: Document): boolean {
-  const header = getDocumentTopBar(doc) || cachedOriginalTopBar
+  const nativeHeader = getNativeDocumentTopBar(doc)
+  const header = nativeHeader || cachedOriginalTopBar || getDocumentTopBar(doc)
   if (!header)
     return false
 
-  // 1. 隐藏 banner 等首页内容，分区面板由样式在下拉后悬浮“首页”时显示
-  const innerUselessContents = header.querySelectorAll<HTMLElement>(
-    ':scope > *:not(.bili-header__bar):not(.bili-header__channel)',
-  )
-  innerUselessContents.forEach(item => (item.style.display = 'none'))
-  header.querySelector<HTMLElement>(':scope > .bili-header__channel')?.style.removeProperty('display')
-  setupOriginalTopBarChannelHover(header)
-  ensureOriginalTopBarScrolledLayout(header)
+  if (nativeHeader && cachedOriginalTopBar && cachedOriginalTopBar !== nativeHeader && cachedOriginalTopBar.parentElement === doc.body)
+    cachedOriginalTopBar.remove()
 
-  // 原版顶栏继续留在 B 站 Vue 管理的父节点中，避免组件更新时节点丢失
+  cachedOriginalTopBar = header
+  rememberOriginalTopBarParent(doc, header)
+  prepareOriginalTopBar(header)
+
+  // Portal only the live header. The native channel row stays under Bilibili's Vue root.
+  if (header.parentElement !== doc.body || header !== doc.body.firstElementChild)
+    doc.body.prepend(header)
+
+  return true
+}
+
+export function restoreOriginalBilibiliTopBarParent(doc: Document): boolean {
+  const nativeHeader = getNativeDocumentTopBar(doc)
+  const mountedHeader = cachedOriginalTopBar?.parentElement === doc.body
+    ? cachedOriginalTopBar
+    : doc.querySelector<HTMLElement>('body > .bili-header')
+
+  if (nativeHeader && nativeHeader !== mountedHeader) {
+    mountedHeader?.remove()
+    cachedOriginalTopBar = nativeHeader
+    rememberOriginalTopBarParent(doc, nativeHeader)
+    prepareOriginalTopBar(nativeHeader)
+    return true
+  }
+
+  const header = mountedHeader || cachedOriginalTopBar || nativeHeader
+  if (!header)
+    return false
+
+  const parent = cachedOriginalTopBarParent?.isConnected
+    ? cachedOriginalTopBarParent
+    : doc.querySelector<HTMLElement>('body > #app > .bili-feed4')
+  if (!parent)
+    return false
+
+  // Return ownership before the outer header is hidden or replaced by the iframe homepage.
+  if (header.parentElement !== parent)
+    parent.prepend(header)
+
   cachedOriginalTopBar = header
   return true
 }
@@ -447,100 +506,4 @@ export function setupLoginButtonClickHandlers(doc: Document) {
   return () => {
     observer.disconnect()
   }
-}
-
-/**
- * 在启用插件搜索结果页时，接管原版 B 站顶栏的搜索提交。
- * 捕获阶段拦截可以避免 B 站自身的点击处理器先跳到 search.bilibili.com。
- */
-export function setupOriginalBilibiliTopBarSearchHandlers(
-  doc: Document,
-  shouldUsePluginSearchResultsPage: () => boolean,
-) {
-  originalTopBarSearchCleanups.get(doc)?.()
-
-  const SEARCH_FORM_SELECTOR = [
-    '#nav-searchform',
-    '.nav-search-form',
-    '.nav-search-content',
-  ].join(', ')
-  const SEARCH_INPUT_SELECTOR = [
-    '.nav-search-input',
-    'input[name="keyword"]',
-    'input[type="search"]',
-  ].join(', ')
-  const SEARCH_SUBMIT_SELECTOR = [
-    '.nav-search-btn',
-    '.nav-search-submit',
-    'button[type="submit"]',
-  ].join(', ')
-
-  function getOriginalTopBarSearchContext(target: EventTarget | null) {
-    if (!(target instanceof Element))
-      return null
-
-    const header = target.closest('.bili-header, #biliMainHeader, #internationalHeader')
-    if (!header)
-      return null
-
-    const form = target.closest(SEARCH_FORM_SELECTOR) || header.querySelector(SEARCH_FORM_SELECTOR)
-    const input = (form || header).querySelector<HTMLInputElement>(SEARCH_INPUT_SELECTOR)
-    return { form, input }
-  }
-
-  function navigateToPluginSearch(event: Event, input: HTMLInputElement | null | undefined) {
-    if (!shouldUsePluginSearchResultsPage())
-      return false
-
-    const keyword = input?.value.trim()
-    if (!keyword)
-      return false
-
-    event.preventDefault()
-    event.stopPropagation()
-    event.stopImmediatePropagation()
-
-    const params = new URLSearchParams()
-    params.set('page', 'SearchResults')
-    params.set('keyword', keyword)
-    window.location.assign(`https://www.bilibili.com/?${params.toString()}`)
-    return true
-  }
-
-  function handleSubmit(event: SubmitEvent) {
-    const context = getOriginalTopBarSearchContext(event.target)
-    if (context)
-      navigateToPluginSearch(event, context.input)
-  }
-
-  function handleClick(event: MouseEvent) {
-    if (!(event.target instanceof Element) || !event.target.closest(SEARCH_SUBMIT_SELECTOR))
-      return
-
-    const context = getOriginalTopBarSearchContext(event.target)
-    if (context)
-      navigateToPluginSearch(event, context.input)
-  }
-
-  function handleKeydown(event: KeyboardEvent) {
-    if (event.key !== 'Enter' || event.isComposing)
-      return
-
-    const context = getOriginalTopBarSearchContext(event.target)
-    if (context?.input === event.target)
-      navigateToPluginSearch(event, context.input)
-  }
-
-  doc.addEventListener('submit', handleSubmit, true)
-  doc.addEventListener('click', handleClick, true)
-  doc.addEventListener('keydown', handleKeydown, true)
-
-  const cleanup = () => {
-    doc.removeEventListener('submit', handleSubmit, true)
-    doc.removeEventListener('click', handleClick, true)
-    doc.removeEventListener('keydown', handleKeydown, true)
-    originalTopBarSearchCleanups.delete(doc)
-  }
-  originalTopBarSearchCleanups.set(doc, cleanup)
-  return cleanup
 }


### PR DESCRIPTION
## 背景

Bilibili 原版 `.bili-header` 留在隐藏的 `#app` 下时，会被宿主覆盖，导致从 BewlyCat 顶栏直接切换到原版顶栏后看起来透明或完全不可见；先切换到 Bilibili 首页模式再切回时，由于原页面状态被重新建立，顶栏又能显示。

同时，原版顶栏搜索曾由 BewlyCat 捕获并改写到插件搜索页。当前路由组合下该跳转可能落回首页导致搜索无法使用，且全局链接转换还会改写原版顶栏内的链接。顶栏搜索框聚焦时还会被通用 focus 样式从胶囊圆角覆盖为面板圆角。

## 修改内容

- 仅在启用原版顶栏且外层顶栏应显示时，将真实 `.bili-header` 临时挂载到 `body`。
- 记录原父节点，在切回 BewlyCat 顶栏或进入 Bilibili iframe 首页时归还 header。
- 处理 Bilibili 异步替换 header 的情况，并保留当前滚动态。
- 不移动 Vue 管理的 `.header-channel`，避免恢复 #811 中的 `removeChild` 异常。
- 将顶栏切换器 Teleport 到 `body`，保证原版 header 显示后仍可切回。
- 停止捕获原版顶栏搜索提交，并从全局搜索链接转换中排除原版顶栏。
- 聚焦搜索框时继续沿用控件自身的胶囊圆角，只保留主题色边框和焦点光环。

## 改动范围

- 5 个源文件，126 行增加、154 行删除，净减少 28 行。
- 约 96 行删除来自移除原版顶栏搜索捕获实现。
- 切换器的大部分行数变化来自增加 Teleport 后的模板缩进。
- 未修改首页内容布局、内部滚动系统、设置存储结构或搜索结果页主体实现。

## 关联与回归重点

- #390 / #804：原版顶栏下滑状态、悬浮“首页”分区面板及频道交互。
- #811：Bilibili Vue 管理节点不能被错误移动；本 PR 不移动 `.header-channel`。
- #803：本 PR 撤销了原版顶栏搜索捕获。原版顶栏现在遵循 Bilibili 原生搜索行为，即使“使用插件搜索结果页”已开启；是否需要在不返回首页的前提下重新支持该设置，需要维护者确认。
- Bilibili 页面控制台曾观察到 `Hydration completed but contains mismatches`。临时移动 `.bili-header` 与 Bilibili 自身 hydration/节点替换的关系仍需重点回归，因此先以 Draft 提交。

## 验证

- 用户手工确认：原版顶栏搜索不再返回首页。
- 用户手工确认：从 BewlyCat 顶栏直接切换到原版顶栏后可以正常显示。
- 浏览器检查确认：搜索框聚焦前圆角为 `9999px`，修复前 focus 状态会覆盖为 `12px`；构建后的 focus CSS 已不再覆盖圆角。
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`