### PR TITLE
fix: 修复搜索框圆角从胶囊到方形的过渡动画丢失

### DIFF
--- a/src/components/SearchBar/SearchBar.vue
+++ b/src/components/SearchBar/SearchBar.vue
@@ -612,13 +612,11 @@ function handleClearKeyword() {
         class="group"
         enterkeyhint="search"
         name="search"
-        rounded="$bew-top-bar-primary-control-radius"
         p="l-6 r-18 y-3"
         h-inherit
         spellcheck="false"
         text="$b-search-bar-normal-text-color group-focus-within:$b-search-bar-focus-text-color group-hover:$b-search-bar-hover-text-color"
         un-border="1 solid $bew-border-color"
-        transition="background-color duration-200, color duration-200, opacity duration-200, box-shadow duration-200"
         @focus="isFocus = true"
         @input="handleNativeInput"
         @keydown.enter.stop="handleKeyEnter"
@@ -849,6 +847,12 @@ function handleClearKeyword() {
       position: relative;
       z-index: 1;
       border-radius: var(--b-search-bar-radius, 60px);
+      transition:
+        background-color var(--bew-duration-normal) var(--bew-ease-standard),
+        color var(--bew-duration-normal) var(--bew-ease-standard),
+        opacity var(--bew-duration-normal) var(--bew-ease-standard),
+        box-shadow var(--bew-duration-normal) var(--bew-ease-standard),
+        border-radius var(--bew-duration-moderate) var(--bew-ease-standard);
 
       &::placeholder {
         color: inherit;
@@ -861,7 +865,8 @@ function handleClearKeyword() {
     }
 
     &.focus input {
-      --uno: "border-$bew-theme-color rounded-$bew-radius";
+      --uno: "border-$bew-theme-color";
+      border-radius: var(--bew-radius);
       box-shadow:
         0 0 0 2px var(--bew-theme-color),
         0 6px 16px var(--bew-theme-color-40),

--- a/src/components/TopBar/components/TopBarSearch.vue
+++ b/src/components/TopBar/components/TopBarSearch.vue
@@ -19,7 +19,7 @@ const useLightText = computed(() => forceWhiteIcon.value && settings.value.enabl
 const searchBarStyles = computed(() => ({
   '--b-search-bar-max-width': '100%',
   '--b-search-bar-height': 'var(--bew-top-bar-primary-control-height)',
-  '--b-search-bar-radius': 'var(--bew-top-bar-primary-control-radius)',
+  '--b-search-bar-radius': 'calc(var(--bew-top-bar-primary-control-height) / 2 - 3px)',
   '--b-search-bar-normal-color': settings.value.enableFrostedGlass ? 'color-mix(in oklab, var(--bew-elevated-solid), transparent 60%)' : 'var(--bew-elevated)',
   '--b-search-bar-focus-color': 'var(--bew-elevated)',
   '--b-search-bar-normal-icon-color': useLightText.value ? 'white' : 'var(--bew-text-1)',


### PR DESCRIPTION
## 问题

搜索框聚焦时，圆角从胶囊形到方形的过渡动画丢失

## 根因

`9eea21e5`（统一动效过渡与圆角样式 token）将 `transition="all duration-300"` 改为显式属性列表以避免布局跳动
## 修复

- 移除 UnoCSS `transition` 属性，改用 scoped CSS 的 `transition` 声明
- 补回 `border-radius` 过渡
- 正常态圆角从 9999px 改为几何半径（20px）

## 验证
- `pnpm typecheck` 通过
- `pnpm lint` 通过
- 外观正常