### PR TITLE
fix: 恢复设置页左侧导航的浮起缩放动画

### DIFF
--- a/src/components/Settings/Settings.vue
+++ b/src/components/Settings/Settings.vue
@@ -607,7 +607,8 @@ function changeMenuItem(menuItem: MenuType) {
   transition:
     width var(--bew-duration-moderate) var(--bew-ease-standard),
     border-radius var(--bew-duration-moderate) var(--bew-ease-standard),
-    background-color var(--bew-duration-moderate) var(--bew-ease-standard);
+    background-color var(--bew-duration-moderate) var(--bew-ease-standard),
+    transform var(--bew-duration-moderate) var(--bew-ease-standard);
 
   > li {
     width: 100%;
@@ -653,10 +654,7 @@ function changeMenuItem(menuItem: MenuType) {
         var(--settings-primary-nav-inset)
     );
     border-radius: var(--bew-radius-2xl);
-  }
-
-  .settings-primary-navigation__item {
-    border-radius: var(--bew-radius-xl);
+    transform: scale(1.05);
   }
 }
 


### PR DESCRIPTION
## 问题

1.7.0 重写设置页 aside 后，hover 时不再有浮起效果

## 根因

`73f51ce1`（重新编写 v1.6.9 浮动 aside）将上游的 UnoCSS 原子类重写为 scoped SCSS 时，遗漏了 `scale="group-hover:105"` + `transform-gpu` + `duration-300`

同时新增了上游本没有的 item 圆角 hover 动画（item 圆角原本是固定 30px）

## 修复

- 补回 `transform` transition 与 hover `scale(1.05)`
- 移除上游本没有的 item 圆角 hover 动画

## 验证
- `pnpm typecheck` 通过
- `pnpm lint` 通过
- 外观正常