### PR TITLE
fix: 恢复正文字体大小

### DIFF
--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -6,8 +6,8 @@
   // Use semantic roles instead of one-off size/weight pairs. Keep interface text
   // to this compact five-step scale; reserve bold for branding or rare emphasis.
   --bew-font-size-caption: 11px;
-  --bew-font-size-control: 12px;
-  --bew-font-size-body: 14px;
+  --bew-font-size-control: 13px;
+  --bew-font-size-body: 15px;
   --bew-font-size-title: 16px;
   --bew-font-size-heading: 18px;
   // Rare display text and large numerals are not part of the interface text scale.


### PR DESCRIPTION
## 问题

1.7.0 引入字体 token 时修改了正文和控件字号，导致部分内容可读性较差

## 更改

```scss
--bew-font-size-body: 14px → 15px;
--bew-font-size-control: 12px → 13px;
```


## 验证
- `pnpm typecheck` 通过
- `pnpm lint` 通过