### PR TITLE
fix: improve search and settings interactions

### DIFF
--- a/src/components/Radio.vue
+++ b/src/components/Radio.vue
@@ -53,16 +53,16 @@ label {
     --b-switch-thumb-scale: 1;
 
     position: absolute;
-    // Absolute offsets start at the padding edge, so subtract the track border
-    // to retain an actual 2px visual inset on every side.
-    top: calc(var(--b-switch-edge-inset) - var(--b-switch-border-width));
+    top: 50%;
+    // Absolute horizontal offsets start at the padding edge, so subtract the
+    // track border to retain the intended outer-edge inset.
     left: calc(var(--b-switch-edge-inset) - var(--b-switch-border-width));
     width: var(--b-switch-thumb-size);
     height: var(--b-switch-thumb-size);
     background: white;
     border-radius: var(--bew-badge-radius);
     content: "";
-    transform: translateX(var(--b-switch-thumb-offset)) scale(var(--b-switch-thumb-scale));
+    transform: translate(var(--b-switch-thumb-offset), -50%) scale(var(--b-switch-thumb-scale));
   }
 }
 

--- a/src/components/SearchBar/SearchBar.vue
+++ b/src/components/SearchBar/SearchBar.vue
@@ -990,7 +990,7 @@ function handleClearKeyword() {
 
           &:hover,
           &:focus-visible {
-            background-color: var(--bew-fill-2);
+            background-color: var(--bew-fill-alt);
             box-shadow:
               inset 0 0 0 1px var(--bew-border-color),
               var(--bew-shadow-2),

--- a/src/components/SearchBar/SearchBar.vue
+++ b/src/components/SearchBar/SearchBar.vue
@@ -671,7 +671,7 @@ function handleClearKeyword() {
               type="searchBar"
               :custom-click-event="true"
               class="hot-search-item cursor-pointer duration-300"
-              flex items-center gap-2 p="x-2 y-1" hover="text-$bew-theme-color"
+              flex items-center gap-2 p="x-2 y-1"
               @click="handleKeywordLinkClick(item.keyword, $event)"
             >
               <span
@@ -942,7 +942,11 @@ function handleClearKeyword() {
       .hot-search-container {
         .hot-search-item {
           --uno: "relative cursor-pointer duration-300";
-          --uno: "hover:text-$bew-theme-color";
+          border-radius: var(--bew-interactive-radius);
+          transition:
+            background-color var(--bew-duration-normal) var(--bew-ease-standard),
+            box-shadow var(--bew-duration-normal) var(--bew-ease-standard),
+            transform var(--bew-duration-normal) var(--bew-ease-standard);
 
           .hot-search-icon {
             object-fit: contain;
@@ -982,6 +986,16 @@ function handleClearKeyword() {
 
           .keyword {
             --uno: "text-base truncate flex-1";
+          }
+
+          &:hover,
+          &:focus-visible {
+            background-color: var(--bew-fill-2);
+            box-shadow:
+              inset 0 0 0 1px var(--bew-border-color),
+              var(--bew-shadow-2),
+              0 0 16px var(--bew-theme-color-20);
+            transform: translateY(-1px);
           }
         }
       }

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -207,6 +207,14 @@ function onMouseEnter() {
 </template>
 
 <style lang="scss" scoped>
+.select-trigger {
+  transition: background-color var(--bew-duration-normal) var(--bew-ease-standard);
+}
+
+.select-trigger:hover {
+  background-color: var(--bew-fill-2);
+}
+
 // 向上弹出时的过渡：方向与全局 .dropdown（向下开）相反
 // 使用独立的 translate 属性而非 transform，避免覆盖定位用的 inline transform
 // 不要 transition: all，否则二次校正坐标时会带动 top/left 飞入

--- a/src/components/Settings/Appearance/Appearance.vue
+++ b/src/components/Settings/Appearance/Appearance.vue
@@ -212,6 +212,7 @@ function changeWallpaper(url: string) {
         <div class="theme-color-options" flex="~ gap-2 wrap" justify-end>
           <div
             v-for="color in themeColorOptions" :key="color"
+            class="color-option"
             w-20px h-20px rounded-8 cursor-pointer transition
             duration-300 box-border
             :style="{
@@ -223,6 +224,7 @@ function changeWallpaper(url: string) {
             @click="changeThemeColor(color)"
           />
           <div
+            class="color-option"
             w-20px h-20px rounded-8 overflow-hidden
             cursor-pointer transition duration-300
             flex="~ items-center justify-center"
@@ -251,6 +253,7 @@ function changeWallpaper(url: string) {
         <div class="dark-mode-base-color-options" flex="~ gap-2 wrap" justify-end>
           <div
             v-for="color in darkModeBaseColorOptions" :key="color"
+            class="color-option"
             w-20px h-20px rounded-8 cursor-pointer transition
             duration-300 box-border
             :style="{
@@ -262,6 +265,7 @@ function changeWallpaper(url: string) {
             @click="changeDarkModeBaseColor(color)"
           />
           <div
+            class="color-option"
             w-20px h-20px rounded-8 overflow-hidden
             cursor-pointer transition duration-300
             flex="~ items-center justify-center"
@@ -334,6 +338,18 @@ function changeWallpaper(url: string) {
 </template>
 
 <style lang="scss" scoped>
+.color-option {
+  transition:
+    filter var(--bew-duration-normal) var(--bew-ease-standard),
+    outline-color var(--bew-duration-normal) var(--bew-ease-standard);
+}
+
+.color-option:hover {
+  filter: brightness(1.12);
+  outline: 1px solid var(--bew-border-color);
+  outline-offset: 2px;
+}
+
 .theme-color-options {
   width: 312px;
 }

--- a/src/components/Settings/Compatibility/Compatibility.vue
+++ b/src/components/Settings/Compatibility/Compatibility.vue
@@ -50,6 +50,7 @@ function changeThemeColor(color: string) {
     <SettingsItemGroup title="Bilibili Evolved">
       <SettingsItem :title="$t('settings.follow_bilibili_evolved_color')" :desc="$t('settings.follow_bilibili_evolved_color_desc')" right-width="auto">
         <div
+          class="color-option"
           w-20px h-20px rounded-8 cursor-pointer transition
           duration-300 box-border
           :style="{
@@ -66,5 +67,15 @@ function changeThemeColor(color: string) {
 </template>
 
 <style lang="scss" scoped>
+.color-option {
+  transition:
+    filter var(--bew-duration-normal) var(--bew-ease-standard),
+    outline-color var(--bew-duration-normal) var(--bew-ease-standard);
+}
 
+.color-option:hover {
+  filter: brightness(1.12);
+  outline: 1px solid var(--bew-border-color);
+  outline-offset: 2px;
+}
 </style>

--- a/src/components/Settings/PluginComponentsAndPages/DockAndSidebar/DockAndSidebar.vue
+++ b/src/components/Settings/PluginComponentsAndPages/DockAndSidebar/DockAndSidebar.vue
@@ -132,6 +132,7 @@ function updateDockItemPageMode(dockItem: DockItem, useOriginalBiliPage: boolean
           >
             <template #item="{ element }">
               <div
+                class="bew-settings-option--lift"
                 flex="~ gap-2 justify-between items-center wrap" p="x-4 y-2" bg="$bew-fill-1" rounded="$bew-radius" cursor-all-scroll
                 duration-300
                 :style="{

--- a/src/components/Settings/PluginComponentsAndPages/Home/Home.vue
+++ b/src/components/Settings/PluginComponentsAndPages/Home/Home.vue
@@ -453,6 +453,7 @@ function handleToggleHomeTab(tab: any) {
           >
             <template #item="{ element }">
               <div
+                class="bew-settings-option--lift"
                 flex="~ gap-2 items-center" p="x-4 y-2" bg="$bew-fill-1" rounded="$bew-radius" cursor-all-scroll
                 duration-300
                 :style="{

--- a/src/components/Settings/PluginComponentsAndPages/Moments/WantedUsersManager.vue
+++ b/src/components/Settings/PluginComponentsAndPages/Moments/WantedUsersManager.vue
@@ -223,10 +223,14 @@ function removeUser(mid: string) {
   font-size: var(--bew-font-size-control);
   font-weight: var(--bew-font-weight-semibold);
   line-height: var(--bew-line-height-control);
+  transition: filter var(--bew-duration-normal) var(--bew-ease-standard);
 }
 .wanted-users-manager__form button:disabled {
   opacity: 0.55;
   cursor: not-allowed;
+}
+.wanted-users-manager__form button:hover:not(:disabled) {
+  filter: brightness(1.08);
 }
 .wanted-users-manager__error {
   display: flex;

--- a/src/components/Settings/PluginComponentsAndPages/SearchPage/SearchPage.vue
+++ b/src/components/Settings/PluginComponentsAndPages/SearchPage/SearchPage.vue
@@ -24,6 +24,7 @@ function changeSearchBarFocusCharacter(url: string) {
       <SettingsItem :title="$t('settings.logo_color')" right-width="auto">
         <div w="220px" flex rounded="$bew-radius" bg="$bew-fill-1" p-1>
           <div
+            class="search-page-choice-option"
             flex="1 ~" items-center justify-center py-1 cursor-pointer
             text-center rounded="$bew-radius"
             :style="{
@@ -35,6 +36,7 @@ function changeSearchBarFocusCharacter(url: string) {
             {{ $t('settings.logo_color_opt.theme_color') }}
           </div>
           <div
+            class="search-page-choice-option"
             flex="1 ~" items-center justify-center py-1 cursor-pointer
             text-center rounded="$bew-radius"
             :style="{
@@ -82,6 +84,7 @@ function changeSearchBarFocusCharacter(url: string) {
         <template #bottom>
           <div grid="~ xl:cols-8 lg:cols-6 cols-5 gap-4">
             <picture
+              class="bew-settings-option--lift"
               aspect-square bg="$bew-fill-1" rounded="$bew-radius" overflow-hidden
               un-border="4 transparent" cursor-pointer
               grid place-items-center
@@ -92,6 +95,7 @@ function changeSearchBarFocusCharacter(url: string) {
             </picture>
             <Tooltip v-for="item in SEARCH_BAR_CHARACTERS" :key="item.url" placement="top" :content="item.name" aspect-square>
               <picture
+                class="bew-settings-option--lift"
                 aspect-square bg="$bew-fill-1" rounded="$bew-radius" overflow-hidden
                 un-border="4 transparent" w-full
                 :class="{ 'selected-wallpaper': settings.searchPageSearchBarFocusCharacter === item.url }"
@@ -138,6 +142,7 @@ function changeSearchBarFocusCharacter(url: string) {
         </template>
         <div w="220px" flex rounded="$bew-radius" bg="$bew-fill-1" p-1>
           <div
+            class="search-page-choice-option"
             flex="1 ~" items-center justify-center py-1 cursor-pointer
             text-center rounded="$bew-radius"
             :style="{
@@ -149,6 +154,7 @@ function changeSearchBarFocusCharacter(url: string) {
             {{ $t('settings.search_results_pagination_mode_opt.scroll') }}
           </div>
           <div
+            class="search-page-choice-option"
             flex="1 ~" items-center justify-center py-1 cursor-pointer
             text-center rounded="$bew-radius"
             :style="{
@@ -168,6 +174,17 @@ function changeSearchBarFocusCharacter(url: string) {
 </template>
 
 <style scoped lang="scss">
+.search-page-choice-option {
+  transition:
+    filter var(--bew-duration-normal) var(--bew-ease-standard),
+    box-shadow var(--bew-duration-normal) var(--bew-ease-standard);
+}
+
+.search-page-choice-option:hover {
+  filter: brightness(1.08);
+  box-shadow: inset 0 0 0 1px var(--bew-border-color);
+}
+
 .selected-wallpaper {
   --uno: "border-$bew-theme-color-60";
 }

--- a/src/components/Settings/components/ChangeWallpaper.vue
+++ b/src/components/Settings/components/ChangeWallpaper.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
 import { WALLPAPERS } from '~/constants/imgs'
 import { localSettings, settings } from '~/logic'
 import { hasLocalWallpaper, isLocalWallpaperUrl, removeLocalWallpaper, resolveWallpaperUrl, storeLocalWallpaper } from '~/utils/localWallpaper'
@@ -6,18 +8,30 @@ import { compressAndResizeImage } from '~/utils/main'
 
 import SettingsItem from './SettingsItem.vue'
 import SettingsItemGroup from './SettingsItemGroup.vue'
+import SettingsSegmentedControl from './SettingsSegmentedControl.vue'
 
 const props = defineProps<Props>()
 
 interface Props {
   type: 'global' | 'searchPage'
 }
+type WallpaperMode = 'buildIn' | 'byUrl'
+
+const { t } = useI18n()
 const uploadWallpaperRef = ref(null)
 
 const isGlobal = computed(() => props.type === 'global')
 const isBuildInWallpaper = computed(() => {
   return isGlobal.value ? settings.value.wallpaperMode === 'buildIn' : settings.value.searchPageWallpaperMode === 'buildIn'
 })
+const wallpaperMode = computed<WallpaperMode>({
+  get: () => isBuildInWallpaper.value ? 'buildIn' : 'byUrl',
+  set: changeWallpaperType,
+})
+const wallpaperModeOptions = computed<{ label: string, value: WallpaperMode }[]>(() => [
+  { label: t('settings.wallpaper_mode_opt.build_in'), value: 'buildIn' },
+  { label: t('settings.wallpaper_mode_opt.by_url'), value: 'byUrl' },
+])
 
 // 计算本地壁纸的实际显示URL
 const localWallpaperDisplayUrl = computed(() => {
@@ -155,28 +169,11 @@ onMounted(() => {
 
     <template v-if="isGlobal || (settings.individuallySetSearchPageWallpaper && !isGlobal)">
       <SettingsItem :title="$t('settings.wallpaper_mode')" :desc="$t('settings.wallpaper_mode_desc')" right-width="auto">
-        <div w="220px" flex rounded="$bew-radius" bg="$bew-fill-1" p-1>
-          <div
-            flex-1 py-1 cursor-pointer text-center rounded="$bew-radius"
-            :style="{
-              background: isBuildInWallpaper ? 'var(--bew-theme-color)' : '',
-              color: isBuildInWallpaper ? 'white' : '',
-            }"
-            @click="changeWallpaperType('buildIn')"
-          >
-            {{ $t('settings.wallpaper_mode_opt.build_in') }}
-          </div>
-          <div
-            flex-1 py-1 cursor-pointer text-center rounded="$bew-radius"
-            :style="{
-              background: !isBuildInWallpaper ? 'var(--bew-theme-color)' : '',
-              color: !isBuildInWallpaper ? 'white' : '',
-            }"
-            @click="changeWallpaperType('byUrl')"
-          >
-            {{ $t('settings.wallpaper_mode_opt.by_url') }}
-          </div>
-        </div>
+        <SettingsSegmentedControl
+          v-model="wallpaperMode"
+          :label="$t('settings.wallpaper_mode')"
+          :options="wallpaperModeOptions"
+        />
       </SettingsItem>
 
       <!-- 缓存时间设置 - 对所有URL壁纸生效 -->
@@ -216,6 +213,7 @@ onMounted(() => {
         <template #bottom>
           <div grid="~ xl:cols-5 lg:cols-4 cols-3 gap-4">
             <picture
+              class="bew-settings-option--lift"
               aspect-video bg="$bew-fill-1" rounded="$bew-radius" overflow-hidden
               un-border="4 transparent" cursor-pointer
               grid place-items-center
@@ -227,6 +225,7 @@ onMounted(() => {
 
             <Tooltip v-for="item in WALLPAPERS" :key="item.url" placement="top" :content="item.name" aspect-video>
               <picture
+                class="bew-settings-option--lift"
                 aspect-video bg="$bew-fill-1" rounded="$bew-radius" overflow-hidden
                 un-border="4 transparent" w-full
                 :class="{ 'selected-wallpaper': isGlobal ? settings.wallpaper === item.url : settings.searchPageWallpaper === item.url }"
@@ -241,7 +240,7 @@ onMounted(() => {
               </picture>
             </Tooltip>
 
-            <Tooltip placement="top" :content="localSettings.locallyUploadedWallpaper?.name || ''" aspect-video>
+            <div aspect-video relative>
               <!-- Upload wallpaper input -->
               <input
                 ref="uploadWallpaperRef" type="file" accept="image/*"
@@ -250,7 +249,7 @@ onMounted(() => {
               >
 
               <picture
-                class="group"
+                class="group bew-settings-option--lift"
                 :class="{ 'selected-wallpaper': isGlobal
                   ? settings.wallpaper === (localWallpaperDisplayUrl || localSettings.locallyUploadedWallpaper?.url)
                   : settings.searchPageWallpaper === (localWallpaperDisplayUrl || localSettings.locallyUploadedWallpaper?.url) }"
@@ -298,7 +297,7 @@ onMounted(() => {
                   w-full h-full object-cover
                 >
               </picture>
-            </Tooltip>
+            </div>
           </div>
         </template>
       </SettingsItem>

--- a/src/components/Settings/components/SettingsItemGroup.vue
+++ b/src/components/Settings/components/SettingsItemGroup.vue
@@ -77,6 +77,19 @@ const collapsed = ref(props.defaultCollapsed)
   width: 100%;
   color: inherit;
   text-align: left;
+  cursor: pointer;
+
+  .group-title,
+  .collapse-icon {
+    transition: color var(--bew-duration-normal) var(--bew-ease-standard);
+  }
+
+  &:hover {
+    .group-title,
+    .collapse-icon {
+      color: var(--bew-theme-color);
+    }
+  }
 }
 
 .group-title {

--- a/src/components/Settings/components/SettingsSectionHeading.vue
+++ b/src/components/Settings/components/SettingsSectionHeading.vue
@@ -80,6 +80,13 @@ const collapsed = defineModel<boolean>('collapsed', {
   color: inherit;
   text-align: left;
   cursor: pointer;
+
+  &:hover {
+    .settings-section-heading__content h2,
+    .settings-section-heading__chevron {
+      color: var(--bew-theme-color);
+    }
+  }
 }
 
 .settings-section-heading__chevron {
@@ -89,7 +96,9 @@ const collapsed = defineModel<boolean>('collapsed', {
   margin-left: auto;
   color: var(--bew-text-2);
   font-size: var(--bew-icon-size-md);
-  transition: transform 0.2s ease;
+  transition:
+    color var(--bew-duration-normal) var(--bew-ease-standard),
+    transform 0.2s ease;
 
   &.collapsed {
     transform: rotate(-90deg);
@@ -101,6 +110,7 @@ h2 {
   font-size: var(--bew-font-size-title);
   font-weight: var(--bew-font-weight-semibold);
   line-height: var(--bew-line-height-title);
+  transition: color var(--bew-duration-normal) var(--bew-ease-standard);
 }
 
 .settings-risk-badge {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -207,3 +207,17 @@ img {
   box-shadow: var(--bew-shadow-2), var(--bew-shadow-edge-glow-1);
   backdrop-filter: var(--bew-filter-glass-1);
 }
+
+.bew-settings-option--lift {
+  cursor: pointer;
+  transition:
+    transform var(--bew-duration-normal) var(--bew-ease-standard),
+    filter var(--bew-duration-normal) var(--bew-ease-standard),
+    box-shadow var(--bew-duration-normal) var(--bew-ease-standard);
+
+  &:hover {
+    filter: brightness(1.08);
+    box-shadow: var(--bew-shadow-2);
+    transform: translateY(-2px);
+  }
+}


### PR DESCRIPTION
- Add a clear rounded hover state to hot-search items.
- Add consistent hover feedback to settings controls.
- Reuse the sliding wallpaper mode control and remove the empty upload tooltip.
- Keep switch thumbs vertically centered.

Closes #920

Checks: ESLint, vue-tsc, production build.
