### PR TITLE
fix(topBar): 修复刷新后登录态被误判为未登录

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -4,6 +4,7 @@ import { BILIBILI_DESKTOP_USER_AGENT, isBilibiliWwwUrl, isPreventMobileRedirectE
 
 import { setupAppAuthScheduler } from './appAuthScheduler'
 import { setupContentScriptRefreshPrompt } from './contentScriptRefreshPrompt'
+import { setupLoginStateWatcher } from './loginStateWatcher'
 import { setupApiMsgListeners } from './messageListeners/api'
 import { setupTabMsgListeners } from './messageListeners/tabs'
 import { setupTopBarStateBroker } from './topBarStateBroker'
@@ -145,3 +146,4 @@ setupTabMsgListeners()
 setupTopBarStateBroker()
 setupAppAuthScheduler()
 setupContentScriptRefreshPrompt()
+setupLoginStateWatcher()

--- a/src/background/loginStateWatcher.ts
+++ b/src/background/loginStateWatcher.ts
@@ -1,0 +1,39 @@
+import browser from 'webextension-polyfill'
+
+import { CONTENT_SCRIPT_MATCHES } from '~/constants/contentScript'
+import { TOP_BAR_STATE_MESSAGE } from '~/constants/topBarState'
+
+// 登录态相关的会话 Cookie（见 bilibili-API-collect docs/login/exit.md：
+// 登出会清空它们，登录/扫码登录会写入）
+const WATCHED_COOKIE_NAMES = new Set(['DedeUserID', 'SESSDATA'])
+
+/**
+ * 监听会话 Cookie 变化并广播给所有内容脚本。
+ *
+ * 登录态变化（他处登录/登出/会话过期/切换账号）必然伴随这两个 Cookie 的
+ * 写入或清除，因此事件驱动可以替代轮询（见 issue #921）。广播不携带状态，
+ * 各标签页自行按本地 Cookie 事实校正（reconcileLocalLoginState），SESSDATA
+ * 例行轮换等值变化会被标签页侧的 mid 比对自然过滤。
+ */
+export function setupLoginStateWatcher() {
+  browser.cookies.onChanged.addListener(({ cookie }) => {
+    if (!WATCHED_COOKIE_NAMES.has(cookie.name) || !cookie.domain.endsWith('bilibili.com'))
+      return
+
+    void broadcastLoginStateChanged()
+  })
+}
+
+async function broadcastLoginStateChanged() {
+  try {
+    const tabs = await browser.tabs.query({ url: [...CONTENT_SCRIPT_MATCHES] })
+    await Promise.allSettled(
+      tabs
+        .filter(tab => tab.id !== undefined)
+        .map(tab => browser.tabs.sendMessage(tab.id!, { type: TOP_BAR_STATE_MESSAGE.LOGIN_STATE_CHANGED })),
+    )
+  }
+  catch {
+    // 没有匹配的标签页或查询失败时静默：下次变化会再次广播
+  }
+}

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -351,7 +351,8 @@ onMounted(() => {
     catch (error) {
       console.error('初始化顶栏数据失败:', error)
     }
-    // 无论登录与否都启动定时器：未登录时用于周期重查登录态
+    // 启动定时器：已登录时同步角标/补填 userInfo；未登录时为空转，
+    // 登录态由本地 Cookie 事实与事件驱动维护（见 issue #921）
     topBarStore.startUpdateTimer()
     setupScrollListeners()
 

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -374,8 +374,16 @@ onMounted(() => {
 
     // 添加全局点击事件监听器（用于触屏模式下点击外部关闭弹窗）
     document.addEventListener('click', handleClickOutsidePopup)
+    // 页面重新可见时按本地 Cookie 校正登录态：覆盖「他处登录/登出后
+    // 本标签处于后台」的场景，无需轮询（见 issue #921）
+    document.addEventListener('visibilitychange', handleVisibilityChange)
   })
 })
+
+function handleVisibilityChange() {
+  if (!document.hidden)
+    topBarStore.reconcileLocalLoginState()
+}
 
 onUnmounted(() => {
   if (hideTimer) {
@@ -396,6 +404,7 @@ onUnmounted(() => {
 
   // 移除全局点击事件监听器
   document.removeEventListener('click', handleClickOutsidePopup)
+  document.removeEventListener('visibilitychange', handleVisibilityChange)
 })
 
 // 快捷键

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -351,9 +351,8 @@ onMounted(() => {
     catch (error) {
       console.error('初始化顶栏数据失败:', error)
     }
-    // 只有在登录状态下才启动更新定时器
-    if (topBarStore.isLogin)
-      topBarStore.startUpdateTimer()
+    // 无论登录与否都启动定时器：未登录时用于周期重查登录态
+    topBarStore.startUpdateTimer()
     setupScrollListeners()
 
     updateConflictingHeaderVisibility()

--- a/src/components/TopBar/components/pops/UserPanelPop.vue
+++ b/src/components/TopBar/components/pops/UserPanelPop.vue
@@ -88,7 +88,8 @@ const otherLinks = computed((): { name: string, url: string, icon: string, code?
 })
 
 const levelProgressBarWidth = computed(() => {
-  const { next_exp: nextExp, current_exp: currentExp } = props.userInfo.level_info
+  // 登录态尚未初始化（瞬时故障后自动重查期间）时 userInfo 可能为空，兜底防止解引用崩溃
+  const { next_exp: nextExp = 1, current_exp: currentExp = 0 } = props.userInfo.level_info ?? {}
 
   const percentage = (currentExp / nextExp) * 100
   return `${percentage.toFixed(2)}%`

--- a/src/components/TopBar/components/pops/UserPanelPop.vue
+++ b/src/components/TopBar/components/pops/UserPanelPop.vue
@@ -88,7 +88,7 @@ const otherLinks = computed((): { name: string, url: string, icon: string, code?
 })
 
 const levelProgressBarWidth = computed(() => {
-  // 登录态尚未初始化（瞬时故障后自动重查期间）时 userInfo 可能为空，兜底防止解引用崩溃
+  // 登录态尚未初始化（瞬态故障后自动重查期间）时 userInfo 可能为空，兜底防止解引用崩溃
   const { next_exp: nextExp = 1, current_exp: currentExp = 0 } = props.userInfo.level_info ?? {}
 
   const percentage = (currentExp / nextExp) * 100

--- a/src/constants/topBarState.ts
+++ b/src/constants/topBarState.ts
@@ -44,4 +44,5 @@ export const TOP_BAR_STATE_MESSAGE = {
   INVALIDATE: 'topBarState:invalidate',
   INVALIDATED: 'topBarState:invalidated',
   UPDATED: 'topBarState:updated',
+  LOGIN_STATE_CHANGED: 'topBarState:loginStateChanged',
 } as const

--- a/src/logic/loginStatus.ts
+++ b/src/logic/loginStatus.ts
@@ -1,0 +1,36 @@
+export enum LoginStatus {
+  LoggedIn = 'logged-in',
+  LoggedOut = 'logged-out',
+  TransientError = 'transient-error',
+}
+
+export type LoginCheckResult<T>
+  = | { status: LoginStatus.LoggedIn, data: T }
+    | { status: LoginStatus.LoggedOut }
+    | { status: LoginStatus.TransientError }
+
+export type NavChecker<T> = () => Promise<{ code: number, data?: T }>
+
+/**
+ * 将一次登录态检查（nav 接口）分类为状态动作。
+ *
+ * 只有 code -101 才是真实登出；风控（HTML 页面、-412）、限流（-509）、
+ * 网络错误等瞬态失败统一归为 transient-error，调用方不得据此切换登录态，
+ * 否则刷新时的一次风控窗口会把已登录用户误判为未登录（见 issue #921）。
+ */
+export async function checkLoginStatus<T>(check: NavChecker<T>): Promise<LoginCheckResult<T>> {
+  try {
+    const res = await check()
+
+    if (res?.code === 0)
+      return { status: LoginStatus.LoggedIn, data: res.data as T }
+
+    if (res?.code === -101)
+      return { status: LoginStatus.LoggedOut }
+
+    return { status: LoginStatus.TransientError }
+  }
+  catch {
+    return { status: LoginStatus.TransientError }
+  }
+}

--- a/src/logic/loginStatus.ts
+++ b/src/logic/loginStatus.ts
@@ -12,6 +12,22 @@ export type LoginCheckResult<T>
 export type NavChecker<T> = () => Promise<{ code: number, data?: T }>
 
 /**
+ * 从 Cookie 字符串解析 DedeUserID（登录用户的 mid）。
+ *
+ * DedeUserID 非 HttpOnly，且「存在且不为 0」是 B 站多个接口的登录鉴权
+ * 依据；登出/会话过期时它随 SESSDATA 一起被清空（见 bilibili-API-collect
+ * docs/login/exit.md），因此可作为登录态的本地事实源，无需网络请求。
+ */
+export function parseDedeUserID(cookieString: string): number | undefined {
+  const match = cookieString.match(/(?:^|;\s*)DedeUserID=(\d+)/)
+  if (!match)
+    return undefined
+
+  const mid = Number(match[1])
+  return mid > 0 ? mid : undefined
+}
+
+/**
  * 将一次登录态检查（nav 接口）分类为状态动作。
  *
  * 只有 code -101 才是真实登出；风控（HTML 页面、-412）、限流（-509）、

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -39,9 +39,10 @@ export async function getManifest() {
     permissions: [
       'storage',
       'declarativeNetRequest',
+      'cookies',
       ...(!isFirefox && !isSafari ? ['scripting'] : []),
       ...isFirefox
-        ? ['webRequest', 'webRequestBlocking', 'cookies']
+        ? ['webRequest', 'webRequestBlocking']
         : [],
     ],
     host_permissions: [

--- a/src/stores/topBarStore.ts
+++ b/src/stores/topBarStore.ts
@@ -208,6 +208,29 @@ export const useTopBarStore = defineStore('topBar', () => {
     return result.status
   }
 
+  // 用本地事实校正登录态：页面重新可见或收到会话 Cookie 变化广播时调用。
+  // - 本地无 DedeUserID 且当前已登录：交由 nav 裁决（-101 才翻转，见 getUserInfo）
+  // - 本地有 DedeUserID 且当前未登录：立即置已登录并拉取 userInfo 填充
+  // - 已登录但 mid 不一致：他处切换了账号，重新拉取（会重置 B 币领取状态）
+  function reconcileLocalLoginState() {
+    const localMid = getLocalLoginMid()
+
+    if (localMid === undefined) {
+      if (isLogin.value)
+        void getUserInfo().catch(() => {})
+      return
+    }
+
+    if (!isLogin.value) {
+      isLogin.value = true
+      void getUserInfo().catch(() => {})
+      return
+    }
+
+    if (userInfo.mid && userInfo.mid !== localMid)
+      void getUserInfo().catch(() => {})
+  }
+
   // Notification Methods
   async function getUnreadMessageCount() {
     if (!isLogin.value)
@@ -1039,6 +1062,7 @@ export const useTopBarStore = defineStore('topBar', () => {
     showTopBar,
 
     getUserInfo,
+    reconcileLocalLoginState,
     getUnreadMessageCount,
     getTopBarNewMomentsCount,
     handleNotificationsItemClick,

--- a/src/stores/topBarStore.ts
+++ b/src/stores/topBarStore.ts
@@ -814,6 +814,9 @@ export const useTopBarStore = defineStore('topBar', () => {
     },
   )
 
+  // 他处登录/登出/会话过期导致会话 Cookie 变化时，后台广播此消息（见 issue #921）
+  onMessage(TOP_BAR_STATE_MESSAGE.LOGIN_STATE_CHANGED, reconcileLocalLoginState)
+
   async function refreshSharedData() {
     await Promise.all([
       getUnreadMessageCount(),

--- a/src/stores/topBarStore.ts
+++ b/src/stores/topBarStore.ts
@@ -33,7 +33,7 @@ import api from '~/utils/api'
 import { getCSRF, isHomePage } from '~/utils/main'
 import { isExtensionContextInvalidatedError, onMessage, sendMessage } from '~/utils/messaging'
 
-export const LOGIN_RECHECK_INTERVAL = 1000 * 60 // 未登录/未初始化时重查登录态的间隔
+export const LOGIN_RECHECK_INTERVAL = 1000 * 60 // 已登录但 userInfo 未填充时重查的间隔
 
 export const useTopBarStore = defineStore('topBar', () => {
   const toast = useToast()
@@ -1009,7 +1009,6 @@ export const useTopBarStore = defineStore('topBar', () => {
       }, delay)
     }
 
-    // 未登录时不启动轮询，等待事件唤醒
     if (!isLogin.value)
       return
 

--- a/src/stores/topBarStore.ts
+++ b/src/stores/topBarStore.ts
@@ -27,7 +27,7 @@ import {
   TOP_BAR_STATE_MESSAGE,
 } from '~/constants/topBarState'
 import { settings } from '~/logic'
-import { checkLoginStatus, LoginStatus } from '~/logic/loginStatus'
+import { checkLoginStatus, LoginStatus, parseDedeUserID } from '~/logic/loginStatus'
 import type { List as VideoItem } from '~/models/video/watchLater'
 import api from '~/utils/api'
 import { getCSRF, isHomePage } from '~/utils/main'
@@ -37,7 +37,10 @@ export const LOGIN_RECHECK_INTERVAL = 1000 * 60 // 未登录/未初始化时重�
 
 export const useTopBarStore = defineStore('topBar', () => {
   const toast = useToast()
-  const isLogin = ref<boolean>(true)
+  // 登录态是本地事实而非网络推导：初始值取 DedeUserID 存在性（同步、零请求），
+  // 之后只有 -101 或本地 Cookie 清除才能翻转为未登录，瞬态失败永不翻转。
+  // 否则刷新时的一次风控窗口会把已登录用户误判为未登录（见 issue #921）。
+  const isLogin = ref<boolean>(getLocalLoginMid() !== undefined)
   const userInfo = reactive<UserInfo>({} as UserInfo)
 
   const unReadMessage = reactive<UnReadMessage>({} as UnReadMessage)
@@ -163,6 +166,11 @@ export const useTopBarStore = defineStore('topBar', () => {
     bCoinAlreadyReceived.value = false
     hasBCoinToReceive.value = false
     vipExpAlreadyReceived.value = false
+  }
+
+  // 登录态的本地事实源：读取 DedeUserID（非 HttpOnly，content script 可读）
+  function getLocalLoginMid(): number | undefined {
+    return parseDedeUserID(document.cookie)
   }
 
   // User Methods

--- a/src/stores/topBarStore.ts
+++ b/src/stores/topBarStore.ts
@@ -175,6 +175,10 @@ export const useTopBarStore = defineStore('topBar', () => {
 
   // User Methods
   async function getUserInfo(retryCount = 0): Promise<LoginStatus> {
+    // 本地无会话 Cookie 且已知未登录时，nav 只会返回 -101，跳过无意义的请求
+    if (!isLogin.value && getLocalLoginMid() === undefined)
+      return LoginStatus.LoggedOut
+
     const maxRetries = 2 // 最多重试2次
     const retryDelay = (retryCount + 1) * 1000 // 递增延迟: 1s, 2s
 

--- a/src/stores/topBarStore.ts
+++ b/src/stores/topBarStore.ts
@@ -27,10 +27,13 @@ import {
   TOP_BAR_STATE_MESSAGE,
 } from '~/constants/topBarState'
 import { settings } from '~/logic'
+import { checkLoginStatus, LoginStatus } from '~/logic/loginStatus'
 import type { List as VideoItem } from '~/models/video/watchLater'
 import api from '~/utils/api'
 import { getCSRF, isHomePage } from '~/utils/main'
 import { isExtensionContextInvalidatedError, onMessage, sendMessage } from '~/utils/messaging'
+
+export const LOGIN_RECHECK_INTERVAL = 1000 * 60 // 未登录/未初始化时重查登录态的间隔
 
 export const useTopBarStore = defineStore('topBar', () => {
   const toast = useToast()
@@ -156,62 +159,45 @@ export const useTopBarStore = defineStore('topBar', () => {
     return false
   })
 
+  function resetReceiveStates() {
+    bCoinAlreadyReceived.value = false
+    hasBCoinToReceive.value = false
+    vipExpAlreadyReceived.value = false
+  }
+
   // User Methods
-  async function getUserInfo(retryCount = 0) {
+  async function getUserInfo(retryCount = 0): Promise<LoginStatus> {
     const maxRetries = 2 // 最多重试2次
     const retryDelay = (retryCount + 1) * 1000 // 递增延迟: 1s, 2s
 
-    try {
-      const res = await api.user.getUserInfo()
+    const result = await checkLoginStatus<UserInfo>(() => api.user.getUserInfo())
 
-      if (res.code === 0) {
-        const wasLoggedIn = isLogin.value
-        const previousMid = userInfo.mid
+    if (result.status === LoginStatus.LoggedIn) {
+      const wasLoggedIn = isLogin.value
+      const previousMid = userInfo.mid
 
-        isLogin.value = true
-        Object.assign(userInfo, res.data)
+      isLogin.value = true
+      Object.assign(userInfo, result.data)
 
-        // 如果是新登录或者切换了账号，重置B币领取状态
-        if (!wasLoggedIn || previousMid !== userInfo.mid) {
-          bCoinAlreadyReceived.value = false
-          hasBCoinToReceive.value = false
-          vipExpAlreadyReceived.value = false
-        }
-      }
-      else if (res.code === -101) {
-        isLogin.value = false
-        // 登出时重置状态
-        bCoinAlreadyReceived.value = false
-        hasBCoinToReceive.value = false
-        vipExpAlreadyReceived.value = false
-      }
-      else {
-        // 其他错误码
-        // 对于非未登录的错误，如果还有重试机会，则重试
-        if (retryCount < maxRetries) {
-          await new Promise(resolve => setTimeout(resolve, retryDelay))
-          return getUserInfo(retryCount + 1)
-        }
-
-        isLogin.value = false
-        bCoinAlreadyReceived.value = false
-        hasBCoinToReceive.value = false
-        vipExpAlreadyReceived.value = false
-      }
+      // 如果是新登录或者切换了账号，重置B币领取状态
+      if (!wasLoggedIn || previousMid !== userInfo.mid)
+        resetReceiveStates()
+      return result.status
     }
-    catch {
-      // 如果还有重试机会，则重试
-      if (retryCount < maxRetries) {
-        await new Promise(resolve => setTimeout(resolve, retryDelay))
-        return getUserInfo(retryCount + 1)
-      }
 
-      // 重试次数用尽，标记为未登录
+    if (result.status === LoginStatus.LoggedOut) {
       isLogin.value = false
-      bCoinAlreadyReceived.value = false
-      hasBCoinToReceive.value = false
-      vipExpAlreadyReceived.value = false
+      // 登出时重置状态
+      resetReceiveStates()
+      return result.status
     }
+
+    // 瞬态失败（风控/限流/网络错误）：不切换登录态，稍后重试
+    if (retryCount < maxRetries) {
+      await new Promise(resolve => setTimeout(resolve, retryDelay))
+      return getUserInfo(retryCount + 1)
+    }
+    return result.status
   }
 
   // Notification Methods
@@ -746,7 +732,7 @@ export const useTopBarStore = defineStore('topBar', () => {
     })
   }
 
-  let updateTimer: ReturnType<typeof setInterval> | null = null
+  let updateTimer: ReturnType<typeof setTimeout> | null = null
   let sharedStateMessagingUnavailable = false
 
   function disableSharedStateMessaging() {
@@ -926,22 +912,62 @@ export const useTopBarStore = defineStore('topBar', () => {
   }
 
   function startUpdateTimer() {
-    if (updateTimer) {
-      clearInterval(updateTimer)
-      updateTimer = null
-    }
-    updateTimer = setInterval(() => {
-      if (!isLogin.value)
-        return
+    if (updateTimer)
+      return
 
-      syncSharedData().catch((error) => {
-        console.error('同步顶栏共享状态失败:', error)
-      })
-    }, updateInterval)
+    // 已登录且已拿到用户信息时按 updateInterval 同步角标状态；
+    // 未登录或用户信息尚未初始化（瞬态失败后的空状态）时按较短间隔重查登录态，
+    // 风控/临时故障窗口过后可自动恢复登录显示，无需刷新页面（见 issue #921）。
+    // 只有瞬态失败才指数退避（60s → 120s → 240s → 300s 封顶），避免多个标签页在
+    // 故障窗口内高频请求 nav；真实登出（-101）是一次成功的检查，保持 60s 重查
+    // 节奏，以便用户在他处重新登录后能被及时发现。
+    // 已知限制：本标签 isLogin=true 且 mid 已填充时不会周期性重查，跨标签页登出
+    // 依赖 INVALIDATED 消息刷新（既有行为，改动前一致）。
+    const maxRecheckInterval = 5 * 60 * 1000
+    let recheckInterval = LOGIN_RECHECK_INTERVAL
+    const needsRecheck = () => !isLogin.value || !userInfo.mid
+    const scheduleNext = (delay: number) => {
+      updateTimer = setTimeout(() => {
+        // 扩展重载后旧 content script 的 runtime 已失效：停止轮询，等待刷新
+        if (sharedStateMessagingUnavailable) {
+          updateTimer = null
+          return
+        }
+
+        if (needsRecheck()) {
+          getUserInfo()
+            .catch(() => LoginStatus.TransientError)
+            .then((status) => {
+              // 只有瞬态失败才退避；登录恢复或真实登出都复位到基准间隔
+              if (status === LoginStatus.TransientError)
+                recheckInterval = Math.min(recheckInterval * 2, maxRecheckInterval)
+              else
+                recheckInterval = LOGIN_RECHECK_INTERVAL
+
+              // 重查成功（登录恢复）后立即同步一次角标状态，不用等下一个 tick
+              if (!needsRecheck()) {
+                void syncSharedData().catch((error) => {
+                  console.error('同步顶栏共享状态失败:', error)
+                })
+              }
+              scheduleNext(needsRecheck() ? recheckInterval : updateInterval)
+            })
+          return
+        }
+
+        recheckInterval = LOGIN_RECHECK_INTERVAL
+        syncSharedData().catch((error) => {
+          console.error('同步顶栏共享状态失败:', error)
+        })
+        scheduleNext(updateInterval)
+      }, delay)
+    }
+
+    scheduleNext(needsRecheck() ? LOGIN_RECHECK_INTERVAL : updateInterval)
   }
   function stopUpdateTimer() {
     if (updateTimer) {
-      clearInterval(updateTimer)
+      clearTimeout(updateTimer)
       updateTimer = null
     }
   }
@@ -960,9 +986,7 @@ export const useTopBarStore = defineStore('topBar', () => {
 
     closeAllPopups()
     drawerVisible.notifications = false
-    hasBCoinToReceive.value = false
-    bCoinAlreadyReceived.value = false
-    vipExpAlreadyReceived.value = false
+    resetReceiveStates()
   }
 
   // 添加鼠标状态跟踪
@@ -1046,6 +1070,7 @@ export const useTopBarStore = defineStore('topBar', () => {
     privilegeInfo,
     hasBCoinToReceive,
     bCoinAlreadyReceived,
+    vipExpAlreadyReceived,
 
     topBarVisible,
     searchKeyword,

--- a/src/stores/topBarStore.ts
+++ b/src/stores/topBarStore.ts
@@ -215,7 +215,7 @@ export const useTopBarStore = defineStore('topBar', () => {
   // 用本地事实校正登录态：页面重新可见或收到会话 Cookie 变化广播时调用。
   // - 本地无 DedeUserID 且当前已登录：交由 nav 裁决（-101 才翻转，见 getUserInfo）
   // - 本地有 DedeUserID 且当前未登录：立即置已登录并拉取 userInfo 填充
-  // - 已登录但 mid 不一致：他处切换了账号，重新拉取（会重置 B 币领取状态）
+  // - 已登录但 userInfo 未填充，或 mid 不一致：补拉或换号重拉（会重置 B 币领取状态）
   function reconcileLocalLoginState() {
     const localMid = getLocalLoginMid()
 
@@ -232,7 +232,9 @@ export const useTopBarStore = defineStore('topBar', () => {
       return
     }
 
-    if (userInfo.mid && userInfo.mid !== localMid)
+    // 已登录但 userInfo 未填充（初始化时撞风控），或本地 mid 变化
+    // （他处切换账号）：重新拉取（会重置 B 币领取状态）
+    if (!userInfo.mid || userInfo.mid !== localMid)
       void getUserInfo().catch(() => {})
   }
 

--- a/src/stores/topBarStore.ts
+++ b/src/stores/topBarStore.ts
@@ -223,7 +223,8 @@ export const useTopBarStore = defineStore('topBar', () => {
 
     if (!isLogin.value) {
       isLogin.value = true
-      void getUserInfo().catch(() => {})
+      // 拉取 userInfo 填充，并重启定时器（未登录时定时器处于停止状态）
+      void getUserInfo().catch(() => {}).then(() => startUpdateTimer())
       return
     }
 
@@ -946,17 +947,16 @@ export const useTopBarStore = defineStore('topBar', () => {
     if (updateTimer)
       return
 
-    // 已登录且已拿到用户信息时按 updateInterval 同步角标状态；
-    // 未登录或用户信息尚未初始化（瞬态失败后的空状态）时按较短间隔重查登录态，
-    // 风控/临时故障窗口过后可自动恢复登录显示，无需刷新页面（见 issue #921）。
-    // 只有瞬态失败才指数退避（60s → 120s → 240s → 300s 封顶），避免多个标签页在
-    // 故障窗口内高频请求 nav；真实登出（-101）是一次成功的检查，保持 60s 重查
-    // 节奏，以便用户在他处重新登录后能被及时发现。
-    // 已知限制：本标签 isLogin=true 且 mid 已填充时不会周期性重查，跨标签页登出
-    // 依赖 INVALIDATED 消息刷新（既有行为，改动前一致）。
+    // 登录态由本地事实与事件驱动维护（见 reconcileLocalLoginState），定时器
+    // 不再承担登录态轮询，只负责两件事：
+    // 1. 已登录但 userInfo 尚未填充（初始化时撞风控/限流）：按
+    //    LOGIN_RECHECK_INTERVAL 重查，瞬态失败指数退避（60s → 120s → 240s →
+    //    300s 封顶），填充成功即转 2；
+    // 2. userInfo 已填充：按 updateInterval 同步角标状态。
+    // 未登录时不启动任何轮询，等待事件唤醒（见 issue #921）。
     const maxRecheckInterval = 5 * 60 * 1000
     let recheckInterval = LOGIN_RECHECK_INTERVAL
-    const needsRecheck = () => !isLogin.value || !userInfo.mid
+    const needsRecheck = () => isLogin.value && !userInfo.mid
     const scheduleNext = (delay: number) => {
       updateTimer = setTimeout(() => {
         // 扩展重载后旧 content script 的 runtime 已失效：停止轮询，等待刷新
@@ -969,13 +969,19 @@ export const useTopBarStore = defineStore('topBar', () => {
           getUserInfo()
             .catch(() => LoginStatus.TransientError)
             .then((status) => {
-              // 只有瞬态失败才退避；登录恢复或真实登出都复位到基准间隔
+              // 重查判定真实登出（-101）：停止轮询，等待事件唤醒
+              if (!isLogin.value) {
+                updateTimer = null
+                return
+              }
+
+              // 只有瞬态失败才退避；填充成功即复位到基准间隔
               if (status === LoginStatus.TransientError)
                 recheckInterval = Math.min(recheckInterval * 2, maxRecheckInterval)
               else
                 recheckInterval = LOGIN_RECHECK_INTERVAL
 
-              // 重查成功（登录恢复）后立即同步一次角标状态，不用等下一个 tick
+              // userInfo 填充成功后立即同步一次角标状态，不用等下一个 tick
               if (!needsRecheck()) {
                 void syncSharedData().catch((error) => {
                   console.error('同步顶栏共享状态失败:', error)
@@ -986,6 +992,12 @@ export const useTopBarStore = defineStore('topBar', () => {
           return
         }
 
+        if (!isLogin.value) {
+          // 未登录：停止轮询，等待 Cookie 事件或可见性校正唤醒
+          updateTimer = null
+          return
+        }
+
         recheckInterval = LOGIN_RECHECK_INTERVAL
         syncSharedData().catch((error) => {
           console.error('同步顶栏共享状态失败:', error)
@@ -993,6 +1005,10 @@ export const useTopBarStore = defineStore('topBar', () => {
         scheduleNext(updateInterval)
       }, delay)
     }
+
+    // 未登录时不启动轮询，等待事件唤醒
+    if (!isLogin.value)
+      return
 
     scheduleNext(needsRecheck() ? LOGIN_RECHECK_INTERVAL : updateInterval)
   }

--- a/src/stores/topBarStore.ts
+++ b/src/stores/topBarStore.ts
@@ -212,6 +212,16 @@ export const useTopBarStore = defineStore('topBar', () => {
     return result.status
   }
 
+  // 登录/登出会先后触发多个 Cookie 事件，reconcile 会被密集调用；
+  // 拉取进行中时复用同一 Promise，避免重复请求 nav
+  let fetchUserInfoPromise: Promise<LoginStatus> | null = null
+  function fetchUserInfoOnce(): Promise<LoginStatus> {
+    fetchUserInfoPromise ??= getUserInfo()
+      .catch(() => LoginStatus.TransientError)
+      .finally(() => { fetchUserInfoPromise = null })
+    return fetchUserInfoPromise
+  }
+
   // 用本地事实校正登录态：页面重新可见或收到会话 Cookie 变化广播时调用。
   // - 本地无 DedeUserID 且当前已登录：交由 nav 裁决（-101 才翻转，见 getUserInfo）
   // - 本地有 DedeUserID 且当前未登录：立即置已登录并拉取 userInfo 填充
@@ -221,21 +231,21 @@ export const useTopBarStore = defineStore('topBar', () => {
 
     if (localMid === undefined) {
       if (isLogin.value)
-        void getUserInfo().catch(() => {})
+        void fetchUserInfoOnce()
       return
     }
 
     if (!isLogin.value) {
       isLogin.value = true
       // 拉取 userInfo 填充，并重启定时器（未登录时定时器处于停止状态）
-      void getUserInfo().catch(() => {}).then(() => startUpdateTimer())
+      void fetchUserInfoOnce().then(() => startUpdateTimer())
       return
     }
 
     // 已登录但 userInfo 未填充（初始化时撞风控），或本地 mid 变化
     // （他处切换账号）：重新拉取（会重置 B 币领取状态）
     if (!userInfo.mid || userInfo.mid !== localMid)
-      void getUserInfo().catch(() => {})
+      void fetchUserInfoOnce()
   }
 
   // Notification Methods


### PR DESCRIPTION
Closes #921（#524/#625/#638 为同一问题）

登录自动刷新。刷新页面时如果正好撞上 B 站风控（-509 / -412 / 网络错误等），已登录的用户会被显示成未登录：先闪空白头像，然后变成登录按钮。原因是最初直接用 nav 接口的返回决定登录态，除了 0 和 -101 之外的错误重试两次后都会被当成未登录。这个 PR 修掉了误判，顺便把登录态的判定方式改了：不再靠请求接口判断，而是直接看本地 Cookie，未登录时的定时轮询也一起去掉了。

## Changes

- **`fix`** 刷新时风控窗口导致登录态误判为未登录 —— 只有 `-101` 才算登出，其他错误（风控 / 限流 / 断网）都不再动登录状态；重试退避只在瞬态失败时生效；UserPanelPop 在用户信息为空时兜底防崩溃；定时器改为递归 setTimeout
- **`refactor(topBar)`** 登录态初始值改为本地 Cookie 事实派生 —— 新增 `parseDedeUserID`，打开页面时同步读本地 Cookie 判断登录，不用等接口返回
- **`feat(topBar)`** 页面重新可见时按本地 Cookie 校正登录态 —— 切回标签页时核对一次；本地 Cookie 没了就调 nav 确认，有了直接显示已登录并补拉用户信息，账号换了会重新拉取（没换就不发请求）
- **`refactor(topBar)`** 未登录时停止 nav 轮询，定时器仅作数据恢复 —— 已登录但用户信息没拉到时按 60s 重试（失败退避），拉到后按 5 分钟同步角标；未登录时彻底不请求
- **`feat(background)`** 监听会话 Cookie 变化并广播登录态跳变 —— 后台监听 `DedeUserID` / `SESSDATA` 变化并通知所有标签页，在别的标签登录 / 登出 / 换号秒级生效
- **`style(topBar)`** 修正登录态相关注释的过时表述与措辞

## References

| 引用 | 用途 |
|------|------|
| [bilibili-API-collect — login_info.md](https://github.com/Goooler/bilibili-API-collect/blob/trunk/docs/login/login_info.md) | nav 接口 `-101 = 账号未登录` 的文档依据 |
| [bilibili-API-collect — exit.md](https://github.com/Goooler/bilibili-API-collect/blob/trunk/docs/login/exit.md) | 登出时 `DedeUserID` / `SESSDATA` 会被清空 |
| [bilibili-API-collect — cookie_refresh.md](https://github.com/rinnein/bilibili-API-collect/blob/master/docs/login/cookie_refresh.md) | SESSDATA 会定期换发，值变了不代表登出 |
| [bilibili-API-collect — member_center.md](https://github.com/Goooler/bilibili-API-collect/blob/trunk/docs/login/member_center.md) | `-101` 在多个接口中语义一致；`DedeUserID` 存在且非 0 即视为登录 |
| [BACNext (bilibili API Collect Next)](https://bacnext.apifox.cn/) | 核对全部接口，确认 B 站没有登录态推送 |
| [Bilibili-Evolved](https://github.com/the1812/Bilibili-Evolved) | 同样直接读 `document.cookie` 里的 `DedeUserID` |
| [bilibili-helper](https://github.com/bilibili-helper/bilibili-helper-o) | 同样用 `DedeUserID` Cookie 判断登录 |
| [PiliPlus](https://github.com/bggRGjQaUbCoE/PiliPlus) | 登录状态只存在本地，只有用户主动操作才改变 |
| [bilimiao2](https://github.com/10miaomiao/bilimiao2) | 同上，本地保存用户信息即视为登录 |
| [bilibili-api (Nemo2011)](https://github.com/Nemo2011/bilibili-api) | Cookie 本地持有、需要时才校验的做法参考 |