### PR TITLE
fix: 修复防白屏样式重复移除导致的 NotFoundError

### DIFF
--- a/src/contentScripts/index.ts
+++ b/src/contentScripts/index.ts
@@ -287,13 +287,10 @@ else if (shouldInitializeContentScript) {
   }
 
   window.addEventListener(BEWLY_MOUNTED, () => {
-    if (beforeLoadedStyleEl) {
-      removeBeforeLoadedStyleEl()
-      if (isVideoPage()) {
-      // 根据设置应用默认播放器模式
-        applyDefaultPlayerMode()
-      }
-    }
+    removeBeforeLoadedStyleEl()
+    // 根据设置应用默认播放器模式
+    if (isVideoPage())
+      applyDefaultPlayerMode()
   })
 
   // 应用默认播放器模式

--- a/src/contentScripts/index.ts
+++ b/src/contentScripts/index.ts
@@ -180,6 +180,7 @@ else if (shouldInitializeContentScript) {
   }
 
   let beforeLoadedStyleEl: HTMLStyleElement | undefined
+  let beforeLoadedStyleFailsafeTimer: ReturnType<typeof setTimeout> | undefined
   let lastUrl = location.href
   let lastVideoNavigationKey = getVideoNavigationKey(location.href)
   let hasAppliedPlayerMode = false // 添加标志变量
@@ -256,6 +257,13 @@ else if (shouldInitializeContentScript) {
     }
   }
 
+  // 挂载完成与保险丝两条路径共用的清理，重复调用无副作用
+  function removeBeforeLoadedStyleEl() {
+    beforeLoadedStyleEl?.remove()
+    beforeLoadedStyleEl = undefined
+    clearTimeout(beforeLoadedStyleFailsafeTimer)
+  }
+
   if (settings.value.adaptToOtherPageStyles && isHomePage()) {
     beforeLoadedStyleEl = injectCSS(`
     html.bewly-design {
@@ -275,15 +283,12 @@ else if (shouldInitializeContentScript) {
     }
   `)
     // Failsafe: never keep the page hidden for too long.
-    setTimeout(() => {
-      if (beforeLoadedStyleEl?.isConnected)
-        document.documentElement.removeChild(beforeLoadedStyleEl)
-    }, 4000)
+    beforeLoadedStyleFailsafeTimer = setTimeout(removeBeforeLoadedStyleEl, 4000)
   }
 
   window.addEventListener(BEWLY_MOUNTED, () => {
     if (beforeLoadedStyleEl) {
-      document.documentElement.removeChild(beforeLoadedStyleEl)
+      removeBeforeLoadedStyleEl()
       if (isVideoPage()) {
       // 根据设置应用默认播放器模式
         applyDefaultPlayerMode()


### PR DESCRIPTION
页面加载慢的环境下，首页加载超过 4 秒时会抛 `NotFoundError`：4 秒保险丝先把防白屏样式 `beforeLoadedStyleEl` 移除，但变量仍指向已脱离 DOM 的节点；之后 `BEWLY_MOUNTED` 事件触发，对已移除节点再执行一次 `removeChild` 即抛错，还会中断监听器内的后续逻辑。正常浏览器挂载在 4 秒内完成，事件先跑、保险丝被 `isConnected` 挡住，所以平时不复现。

但是两条移除路径守卫不对称：保险丝判了 `isConnected`，事件路径只判变量非空，且移除后变量从不清空。本 PR 把两条路径收敛为一个幂等清理函数，并顺带解耦了同一监听器里一段从未生效的播放器模式调用（见 Changes 第二条）。

## Changes

- **`fix`** 防白屏样式重复移除导致 NotFoundError —— 新增 `removeBeforeLoadedStyleEl()`：用 `el.remove()` 替代 `removeChild`（对游离节点是无操作，不抛错），移除后清空引用，事件路径顺手 `clearTimeout` 取消保险丝；两条路径共用同一入口，无论谁先谁后都安全
- **`refactor`** 解耦 `BEWLY_MOUNTED` 中播放器模式与样式移除的耦合 —— `applyDefaultPlayerMode()` 自 76789b38（2025-02）引入起就嵌在 `if (beforeLoadedStyleEl)` 内，但该样式仅在 `adaptToOtherPageStyles && isHomePage()` 时赋值，视频页恒为 `undefined`，此调用从未实际执行。挪出后由 `isVideoPage()` 直接判断；函数有 `hasAppliedPlayerMode` 守卫，且已有 `load` / `pageshow` / `visibilitychange` / URL 轮询多个触发点，重复调用安全

## References

| 引用 | 用途 |
|---|---|
| [Bilibili-Evolved](https://github.com/the1812/Bilibili-Evolved) | `core/style.ts` 的 `removeStyle` 用 `?.remove()` 幂等移除；`styled-component.ts` 卸载时 `remove()` 后立即置 `null`，后续路径判空短路 |
| [bilibili-helper-o](https://github.com/bilibili-helper/bilibili-helper-o) | `UI.js` 中定时器与事件双路径的协调模式：共享句柄 + 标志位 + 触发前 `clearTimeout` |
