### PR TITLE
fix(adaptedStyles): 修复番剧/影视等 PGC 播放页网页全屏时顶栏遮挡播放器

### DIFF
--- a/src/styles/adaptedStyles/pages/animePlayback&MoviePage.scss
+++ b/src/styles/adaptedStyles/pages/animePlayback&MoviePage.scss
@@ -15,6 +15,11 @@
   }
 
   // #region new anime playback & movie page
+  // 网页全屏时播放器层级盖过顶栏（z-index: 999），与普通视频页表现一致
+  .plp-player:has([class*="video_playerFullScreen"]) {
+    z-index: 100000;
+  }
+
   [class*="numberListItem_number_list_item"][class*="numberListItem_select"],
   [class*="follow_btnFollow"],
   .squirtle-controller.squirtle-pgc .squirtle-progress-timeline,


### PR DESCRIPTION
Close #929

番剧、影视等 PGC 播放页点击网页全屏后，BewlyCat 顶栏仍浮在播放器上层，遮挡画面与弹幕；普通视频页无此问题。

原因是层级差异而非本扩展回归：顶栏 `z-index: 999` 自 db536809（2025-05-14，修 #26）沿用至今，期间无任何提交改动顶栏层级或 `#bewly` 容器堆叠。普通视频页网页全屏时 bpx 播放器容器 `data-screen='web'` 的 `z-index: 100000`，天然盖住顶栏；而 B 站新版 PGC 播放页（`ogv/video3` Next.js 重构页）网页全屏时，`#bilibili-player-wrap` 换上 `video_playerFullScreen__*` 类（`position: fixed; z-index: 130`），且被祖先 `.plp-player`（grid item，`z-index: 3`，形成堆叠上下文）压住，整体远低于顶栏的 999，顶栏因此外露。B 站原生顶栏在网页全屏时会自行隐藏，停用本扩展后问题不出现，问题随 B 站新页面改版灰度出现。

应用范围：所有 `bilibili.com/bangumi/play/*` PGC 官方内容播放页——番剧、电影/影视、电视剧、综艺、纪录片、国创等（共用同一新版播放页与播放器结构，`animePlaybackAndMoviePage` 样式按 URL 统一适配，均覆盖）。

## Changes

- **`fix`** PGC 播放页网页全屏顶栏遮挡播放器 —— 在 `animePlayback&MoviePage.scss` 新增 `.plp-player:has([class*="video_playerFullScreen"]) { z-index: 100000 }`：仅当播放器处于网页全屏时提升层级至与普通视频页 bpx 播放器一致的 100000，同时盖住顶栏（999）、顶部监听区（1000）与 App 浮层（1001/10002）；纯 CSS `:has()` 方案，进出网页全屏自动响应，无需 JS 监听，不影响正常/宽屏模式布局

## References

| 引用 | 用途 |
|---|---|
| B 站新版 PGC 播放页样式（`s1.hdslb.com/bfs/static/ogv/video3/_next/static/css`） | 确认 `video_playerFullScreen__*` 网页全屏容器为 `position: fixed; z-index: 130`，`.plp-player` 为 `z-index: 3` 的堆叠上下文 |
| B 站播放器内核（`s1.hdslb.com/bfs/static/player/main/core.*.js`） | 确认普通视频页 `.bpx-player-container[data-screen=web]` 网页全屏层级为 `z-index: 100000`，作为修复对齐的目标层级 |
| commit db536809（2025-05-14，#26） | 确认顶栏 `z-index: 999` 的引入时间，排除本扩展近期回归 |