### PR TITLE
fix: 修复已确认的设置、菜单与交互问题

### DIFF
--- a/src/components/Settings/Navigation/BewlyPages.vue
+++ b/src/components/Settings/Navigation/BewlyPages.vue
@@ -3,11 +3,13 @@ import SettingsCategoryLayout from '../components/SettingsCategoryLayout.vue'
 
 const storageKey = 'bewly-settings-bewly-pages-page'
 const legacyStorageKey = 'bewly-settings-navigation-page'
-const pageValues = ['home', 'moments', 'favorites', 'search']
+const pageValues = ['home', 'moments', 'search']
 const legacyPage = sessionStorage.getItem(legacyStorageKey)
 
 if (!sessionStorage.getItem(storageKey) && legacyPage && pageValues.includes(legacyPage))
   sessionStorage.setItem(storageKey, legacyPage)
+if (!pageValues.includes(sessionStorage.getItem(storageKey) ?? ''))
+  sessionStorage.setItem(storageKey, pageValues[0])
 
 const pages = [
   {
@@ -25,14 +27,6 @@ const pages = [
     icon: 'i-mingcute:moment-line',
     iconActivated: 'i-mingcute:moment-fill',
     component: defineAsyncComponent(() => import('../PluginComponentsAndPages/Moments/Moments.vue')),
-  },
-  {
-    value: 'favorites',
-    titleKey: 'settings.plugin.favorites',
-    descriptionKey: 'settings.category_browsing_favorites_desc',
-    icon: 'i-mingcute:bookmark-line',
-    iconActivated: 'i-mingcute:bookmark-fill',
-    component: defineAsyncComponent(() => import('../PluginComponentsAndPages/Favorites/Favorites.vue')),
   },
   {
     value: 'search',

--- a/src/components/Settings/Settings.vue
+++ b/src/components/Settings/Settings.vue
@@ -84,7 +84,7 @@ const legacyMenuAliases: Record<string, MenuType> = {
   Advanced: MenuType.General,
 }
 
-if (!sessionStorage.getItem(bewlyPagesStorageKey) && legacyNavigationPage && ['home', 'moments', 'favorites', 'search'].includes(legacyNavigationPage))
+if (!sessionStorage.getItem(bewlyPagesStorageKey) && legacyNavigationPage && ['home', 'moments', 'search'].includes(legacyNavigationPage))
   sessionStorage.setItem(bewlyPagesStorageKey, legacyNavigationPage)
 
 if (!sessionStorage.getItem(bewlyComponentsStorageKey) && legacyNavigationPage && legacyNavigationComponentPages.has(legacyNavigationPage))
@@ -615,6 +615,7 @@ function changeMenuItem(menuItem: MenuType) {
             WebkitMaskImage: settings.enableFrostedGlass ? 'linear-gradient(to bottom, transparent 0%, black 92px 30%)' : 'none',
             scrollbarGutter: 'stable',
             overflowAnchor: 'none',
+            overscrollBehavior: 'contain',
           }"
           h-inherit of-y-auto of-x-hidden
           style="padding-top: 92px;"

--- a/src/components/VideoCard/VideoCardContextMenu/VideoCardContextMenu.vue
+++ b/src/components/VideoCard/VideoCardContextMenu/VideoCardContextMenu.vue
@@ -455,7 +455,6 @@ async function unfollowUser() {
         style="backdrop-filter: var(--bew-filter-glass-1); box-shadow: var(--bew-shadow-edge-glow-1), var(--bew-shadow-1);"
         :style="contextMenuStyles"
         p-1 bg="$bew-elevated" rounded="$bew-radius"
-        min-w-200px m="t-4 l-[calc(-200px+1rem)]"
         border="1 $bew-border-color"
         class="context-menu-container"
       >
@@ -600,16 +599,17 @@ async function unfollowUser() {
 }
 
 .context-menu-container {
-  max-height: 80vh;
+  width: min(240px, calc(100vw - var(--bew-space-4)));
+  max-height: min(406px, calc(100vh - var(--bew-space-4)));
   overflow: hidden;
   z-index: 9999;
-  position: relative;
 }
 
 .context-menu-list {
-  max-height: calc(80vh - 40px); // 为指示器留出空间
+  max-height: inherit;
   overflow-y: auto;
-  padding: 4px 0;
+  overscroll-behavior: contain;
+  padding: var(--bew-space-1) 0;
 
   /* 完全隐藏滚动条 */
   -ms-overflow-style: none; /* IE 和 Edge */

--- a/src/components/VideoCard/composables/useVideoCardLogic.ts
+++ b/src/components/VideoCard/composables/useVideoCardLogic.ts
@@ -9,6 +9,7 @@ import { useTopBarStore } from '~/stores/topBarStore'
 import api from '~/utils/api'
 import { getTvSign, TVAppKey } from '~/utils/authProvider'
 import { calcCurrentTime, numFormatter, parseStatNumber } from '~/utils/dataFormatter'
+import { computeFloatingMenuPosition } from '~/utils/floatingMenu'
 import { getCSRF, removeHttpFromUrl } from '~/utils/main'
 import { resolvePgcEpisodeVideoIds } from '~/utils/pgcEpisode'
 import { openLinkInBackground } from '~/utils/tabs'
@@ -412,31 +413,19 @@ export function useVideoCardLogic(propsOrGetter: MaybeRefOrGetter<VideoCardProps
     }
   }
 
-  function handleMoreBtnClick(event: MouseEvent) {
+  function handleMoreBtnClick() {
     if (!moreBtnRef.value)
       return
-    const { height } = moreBtnRef.value.getBoundingClientRect()
-
-    /**
-     * 计算菜单位置，确保在视口内可见
-     * 如果底部空间不足，则向上偏移，但不超出顶部
-     */
-    const menuHeight = Math.min(406, window.innerHeight * 0.8) // 菜单最大高度为视口的80%或406px
-    const topSpace = event.y
-    const bottomSpace = window.innerHeight - event.y
-
-    // 如果底部空间足够，则向下展开；否则向上展开
-    const offsetTop = bottomSpace > menuHeight ? 0 : -menuHeight - height
-
-    // 确保不会超出顶部
-    const finalOffsetTop = Math.max(offsetTop, -topSpace + 10)
+    const anchor = moreBtnRef.value.getBoundingClientRect()
+    const position = computeFloatingMenuPosition(anchor, window.innerWidth, window.innerHeight)
 
     showVideoOptions.value = false
     videoOptionsFloatingStyles.value = {
-      position: 'absolute',
-      top: 0,
-      left: 0,
-      transform: `translate(${event.x}px, ${event.y + finalOffsetTop}px)`,
+      position: 'fixed',
+      top: `${position.top}px`,
+      left: `${position.left}px`,
+      width: `${position.width}px`,
+      maxHeight: `${position.maxHeight}px`,
     }
     showVideoOptions.value = true
   }

--- a/src/contentScripts/touchPlayerGestures.ts
+++ b/src/contentScripts/touchPlayerGestures.ts
@@ -2,6 +2,7 @@ import { watch } from 'vue'
 
 import { settings } from '~/logic'
 import { isVideoPlaybackPage } from '~/utils/main'
+import { calculateRelativeSeekTime } from '~/utils/touchGesture'
 
 const ROOT_CLASS = 'bewly-touch-player-gestures'
 const STYLE_ID = 'bewly-touch-player-gestures-style'
@@ -41,6 +42,7 @@ interface GestureSession extends PlayerContext {
   startX: number
   startY: number
   startTime: number
+  startPlaybackTime: number
   startVolume: number
   volumeGesture: boolean
   mode: GestureMode
@@ -248,6 +250,7 @@ function handlePointerDown(event: PointerEvent) {
     startX: event.clientX,
     startY: event.clientY,
     startTime: performance.now(),
+    startPlaybackTime: context.video.currentTime,
     startVolume: context.video.volume,
     volumeGesture,
     mode: null,
@@ -276,8 +279,12 @@ function handlePointerMove(event: PointerEvent) {
 
   if (gesture.mode === 'seek') {
     if (Number.isFinite(gesture.video.duration) && gesture.video.duration > 0) {
-      const progress = clamp((event.clientX - gesture.rect.left) / gesture.rect.width, 0, 1)
-      gesture.video.currentTime = progress * gesture.video.duration
+      gesture.video.currentTime = calculateRelativeSeekTime(
+        gesture.startPlaybackTime,
+        deltaX,
+        gesture.rect.width,
+        gesture.video.duration,
+      )
       showHud(
         gesture.area,
         `${formatTime(gesture.video.currentTime)} / ${formatTime(gesture.video.duration)}`,

--- a/src/contentScripts/views/SearchResults/composables/useSearchRequest.ts
+++ b/src/contentScripts/views/SearchResults/composables/useSearchRequest.ts
@@ -47,6 +47,9 @@ export function useSearchRequest<T = any>(category: SearchCategory) {
     options: SearchRequestOptions = {},
   ): Promise<boolean> {
     if (!keyword.trim()) {
+      activeRequestToken = null
+      isLoading.value = false
+      error.value = ''
       results.value = null
       return false
     }
@@ -78,6 +81,8 @@ export function useSearchRequest<T = any>(category: SearchCategory) {
       return true
     }
     catch (err) {
+      if (activeRequestToken !== requestToken)
+        return false
       console.error(`Search error for ${category}:`, err)
       error.value = '搜索出错，请稍后重试'
       return false
@@ -92,6 +97,7 @@ export function useSearchRequest<T = any>(category: SearchCategory) {
    * 重置搜索状态
    */
   function reset() {
+    isLoading.value = false
     results.value = null
     totalResults.value = 0
     totalPages.value = 0

--- a/src/inject/index.ts
+++ b/src/inject/index.ts
@@ -356,6 +356,10 @@ else if (shouldInitializePageScript) {
           --bili-comment-tag-color: var(--bew-comment-tag-color, var(--bili-comment-tag-color-dark)) !important;
           --bili-comment-tag-bg: var(--bew-comment-tag-bg, var(--bili-comment-tag-bg-dark)) !important;
         }
+
+        #body .tag:empty {
+          display: none !important;
+        }
       `,
     },
     'bili-comment-box': {

--- a/src/stores/topBarStore.ts
+++ b/src/stores/topBarStore.ts
@@ -405,24 +405,20 @@ export const useTopBarStore = defineStore('topBar', () => {
     if (!isCurrentAccount(accountId) || userInfo.vip?.status !== 1 || !settings.value.showBCoinReceiveReminder)
       return
 
-    // 如果已经记录为已领取，则不再请求
-    if (bCoinAlreadyReceived.value) {
-      return
-    }
-
     try {
       const res = await api.user.getPrivilegeInfo()
       if (res.code === 0 && isCurrentAccount(accountId)) {
         Object.assign(privilegeInfo, res.data)
         if (privilegeInfo.vip_type < 2) {
+          bCoinAlreadyReceived.value = false
+          hasBCoinToReceive.value = false
           return
         }
         // 检查B币兑换状态 (type: 1)
         const bCoinItem = privilegeInfo.list?.find(item => item.type === 1)
         if (bCoinItem) {
-          if (bCoinItem.state === 1) {
-            // 如果已经领取，记录状态并设置为false
-            bCoinAlreadyReceived.value = true
+          bCoinAlreadyReceived.value = bCoinItem.state === 1
+          if (bCoinAlreadyReceived.value) {
             hasBCoinToReceive.value = false
           }
           else {
@@ -436,6 +432,7 @@ export const useTopBarStore = defineStore('topBar', () => {
           }
         }
         else {
+          bCoinAlreadyReceived.value = false
           hasBCoinToReceive.value = false
         }
       }
@@ -885,6 +882,7 @@ export const useTopBarStore = defineStore('topBar', () => {
               authorFace: item.face,
               cover: item.pic,
               link: item.link,
+              authorJumpUrl: item.link,
             }),
             ),
           )

--- a/src/utils/floatingMenu.ts
+++ b/src/utils/floatingMenu.ts
@@ -1,0 +1,25 @@
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max)
+}
+
+export function computeFloatingMenuPosition(
+  anchor: { top: number, right: number, bottom: number },
+  viewportWidth: number,
+  viewportHeight: number,
+) {
+  const inset = 8
+  const gap = 8
+  const availableWidth = Math.max(0, viewportWidth - inset * 2)
+  const availableHeight = Math.max(0, viewportHeight - inset * 2)
+  const width = Math.min(240, availableWidth)
+  const maxHeight = Math.min(406, availableHeight)
+  const left = clamp(anchor.right - width, inset, Math.max(inset, viewportWidth - width - inset))
+
+  const belowTop = anchor.bottom + gap
+  const hasEnoughSpaceBelow = viewportHeight - inset - belowTop >= maxHeight
+  const top = hasEnoughSpaceBelow
+    ? belowTop
+    : Math.max(inset, anchor.top - gap - maxHeight)
+
+  return { left, top, width, maxHeight }
+}

--- a/src/utils/shortcuts.ts
+++ b/src/utils/shortcuts.ts
@@ -141,7 +141,7 @@ export function setupShortcutHandlers() {
 
     // 检查是否事件来自插件容器
     const target = e.target as HTMLElement
-    if (target && target.id === 'bewly') {
+    if ((target && target.id === 'bewly') || document.getElementById('bewly')?.classList.contains('settings-open')) {
       return
     }
     // 更新快捷键配置缓存

--- a/src/utils/touchGesture.ts
+++ b/src/utils/touchGesture.ts
@@ -1,0 +1,8 @@
+export function calculateRelativeSeekTime(
+  startPlaybackTime: number,
+  deltaX: number,
+  gestureWidth: number,
+  duration: number,
+): number {
+  return Math.min(duration, Math.max(0, startPlaybackTime + deltaX / gestureWidth * duration))
+}


### PR DESCRIPTION
## 修复内容
- Fixes #869：设置打开时屏蔽全局快捷键。
- Fixes #926：隐藏空白的收藏设置入口并处理旧 session 选择。
- Fixes #927：隐藏评论区空标签产生的方块。
- Fixes #944：重新计算大会员 B 币领取状态，避免旧状态跨周期阻塞。
- Fixes #948：阻止设置页滚动穿透。
- Fixes #958：隐藏暗色模式下评论空标签产生的异色方块。
- Fixes #966：直播动态作者名称跳转到正确直播间。
- Fixes #968：触摸拖动进度以 pointerdown 时播放时间为基准。

另外修复了视频卡片更多菜单在窄视口下越界/无法滚动的问题（#959 的 Bug 部分）

搜索请求竞态也修复了