### PR TITLE
fix: 修复页面切换器选中项不可见、ClientOnly 解析失败与 iframe 早期注入抛错

### DIFF
--- a/src/components/Settings/Settings.vue
+++ b/src/components/Settings/Settings.vue
@@ -602,44 +602,42 @@ function changeMenuItem(menuItem: MenuType) {
       </div>
     </div>
 
-    <ClientOnly>
-      <Teleport :to="mainAppRef" :disabled="!mainAppRef">
-        <Transition name="settings-search-popover">
-          <div
-            v-if="searchQuery && isSearchFocused"
-            id="settings-search-results"
-            ref="searchResultsRef"
-            class="settings-search-results bew-popover-surface"
-            role="listbox"
-            :style="[
-              searchPopoverStyle,
-              {
-                backgroundColor: settings.enableFrostedGlass ? 'var(--bew-elevated-alt)' : 'var(--bew-elevated-alt-solid)',
-                zIndex: 10010,
-              },
-            ]"
+    <Teleport :to="mainAppRef" :disabled="!mainAppRef">
+      <Transition name="settings-search-popover">
+        <div
+          v-if="searchQuery && isSearchFocused"
+          id="settings-search-results"
+          ref="searchResultsRef"
+          class="settings-search-results bew-popover-surface"
+          role="listbox"
+          :style="[
+            searchPopoverStyle,
+            {
+              backgroundColor: settings.enableFrostedGlass ? 'var(--bew-elevated-alt)' : 'var(--bew-elevated-alt-solid)',
+              zIndex: 10010,
+            },
+          ]"
+        >
+          <button
+            v-for="(entry, index) in searchResults"
+            :id="`settings-search-result-${index}`"
+            :key="`${entry.menu}-${entry.secondaryTitleKey ?? ''}-${entry.titleKey ?? entry.title}-${index}`"
+            type="button"
+            role="option"
+            :aria-selected="index === activeSearchResultIndex"
+            :class="{ active: index === activeSearchResultIndex }"
+            @mouseenter="activeSearchResultIndex = index"
+            @click="navigateToSearchResult(entry)"
           >
-            <button
-              v-for="(entry, index) in searchResults"
-              :id="`settings-search-result-${index}`"
-              :key="`${entry.menu}-${entry.secondaryTitleKey ?? ''}-${entry.titleKey ?? entry.title}-${index}`"
-              type="button"
-              role="option"
-              :aria-selected="index === activeSearchResultIndex"
-              :class="{ active: index === activeSearchResultIndex }"
-              @mouseenter="activeSearchResultIndex = index"
-              @click="navigateToSearchResult(entry)"
-            >
-              <strong>{{ getSearchEntryTitle(entry) }}</strong>
-              <span>{{ getSearchEntryLocation(entry) }}</span>
-            </button>
-            <p v-if="searchResults.length === 0">
-              {{ $t('settings.search.no_results') }}
-            </p>
-          </div>
-        </Transition>
-      </Teleport>
-    </ClientOnly>
+            <strong>{{ getSearchEntryTitle(entry) }}</strong>
+            <span>{{ getSearchEntryLocation(entry) }}</span>
+          </button>
+          <p v-if="searchResults.length === 0">
+            {{ $t('settings.search.no_results') }}
+          </p>
+        </div>
+      </Transition>
+    </Teleport>
   </div>
 </template>
 

--- a/src/components/TopBar/components/BewlyOrBiliPageSwitcher.vue
+++ b/src/components/TopBar/components/BewlyOrBiliPageSwitcher.vue
@@ -135,8 +135,10 @@ function switchPage(nextUseOriginalBiliPage: boolean) {
     --bew-segment-item-current-color: white;
   }
 
-  // 无液态指示器时，静态选中态也要沿用白色主题底色
-  &--white.bew-segment-control--static {
+  // 无液态指示器时，静态选中态也要沿用白色主题底色。
+  // 关闭磨砂玻璃时 surface 是不透明浅底，白色变体会让选中项彻底消失，
+  // 因此与上面的白色文字规则一样排除 solid。
+  &--white.bew-segment-control--static:not(.bew-segment-control--solid) {
     --bew-segment-item-active-bg: var(--bew-segment-item-active-bg-white);
     --bew-segment-item-active-shadow: var(--bew-segment-item-active-shadow-white);
     --bew-segment-item-current-color: white;

--- a/src/utils/bilibiliTopBar.ts
+++ b/src/utils/bilibiliTopBar.ts
@@ -578,8 +578,14 @@ export function setupLoginButtonClickHandlers(doc: Document) {
     })
   })
 
-  // Observe the entire document for popup elements
-  observer.observe(doc.body, {
+  // Observe the entire document for popup elements.
+  // 内容脚本在 document_start 注入，iframe 刚创建时 doc.body 仍为 null；
+  // 回落到 documentElement 既能避免抛错，又能靠 subtree 覆盖随后插入的 body。
+  const observeTarget = doc.body ?? doc.documentElement
+  if (!observeTarget)
+    return () => {}
+
+  observer.observe(observeTarget, {
     childList: true,
     subtree: true,
   })


### PR DESCRIPTION
## 概述

Fixes #980

修复三个 bug。第一个是用户可见的样式问题（#980），后两个是排查它时顺带发现的控制台报错。

三处改动互不相干，也可以拆开合并，我放在一个 PR 里只是因为它们是同一次排查中连锁发现的。

**我不熟悉这个项目，后两处修改请重点帮我判断是否妥当** —— 尤其是 `ClientOnly` 那处，我不确定当初引入它是否有我没看到的用意。

## 1. 页面切换器选中项不可见

`src/components/TopBar/components/BewlyOrBiliPageSwitcher.vue`

复现条件：**亮色主题 + 设置了首页壁纸 + 磨砂玻璃关闭（默认）**。默认无壁纸时不会出现。

这两个 class 是各自独立判定的：

```vue
'bewly-bili-switcher--white': props.forceWhiteIcon,          // L83
'bew-segment-control--solid': !settings.enableFrostedGlass,  // L84
```

设置壁纸让 `forceWhiteIcon = true`，关闭磨砂玻璃让 `--solid` 成立，两者可以同时为真。而白色变体的静态选中态规则漏了 `:not(.bew-segment-control--solid)` 守卫，此时仍会设 `--bew-segment-item-current-color: white` 和半透明白底；`--solid` 只移除 `backdrop-filter`，容器背景回落到不透明的 `--bew-control-background`（= `--bew-elevated`），亮色主题下是一块浅色胶囊，白字压上去就消失了。暗色下 `--bew-elevated` 是深色，白字可见，所以只在亮色出现。

补上守卫后 solid 模式回落到主题色。两处旁证说明这只是漏写：

1. 紧挨着的上一条规则 `&--white:not(.bew-segment-control--solid)` 设置的正是**同一个变量** `--bew-segment-item-current-color: white`，但它带了守卫
2. `LiquidSegmentIndicator` 的 `:white` prop 传的是 `props.forceWhiteIcon && settings.enableFrostedGlass`（L94），说明白色变体的设计意图本就要求磨砂玻璃开启，而容器的 `--white` class 只看 `forceWhiteIcon`，没跟上这个约束

## 2. `Failed to resolve component: ClientOnly`

`src/components/Settings/Settings.vue`

打开设置面板时控制台稳定输出：

```
[Vue warn]: Failed to resolve component: ClientOnly
  at <Settings key=0 z-10002="" onClose=fn > at <KeepAlive> at <App>
```

`<ClientOnly>` 由 `c093e2ff`（refactor: 美味地优化设置搜索弹窗）引入，但项目没有安装 `unplugin-vue-components`，`src/components/index.ts` 的 glob 也扫不到这个名字，运行时 `resolveComponent` 必定失败。

浏览器扩展没有 SSR 场景，这层包装应该是多余的；内层 `<Teleport>` 已经有 `:disabled="!mainAppRef"` 守卫，删掉外层包装后渲染结构与行为不变。改动的 35 行里绝大部分只是内层收回一级缩进。

> 如果当初加它是为了别的目的（比如规避某个时序问题），请告诉我，我换成别的写法。

## 3. iframe 早期注入时 `observe` 空 body 抛错

`src/utils/bilibiliTopBar.ts`

控制台报：

```
Uncaught TypeError: Failed to execute 'observe' on 'MutationObserver':
parameter 1 is not of type 'Node'.
```

`setupLoginButtonClickHandlers` 直接 `observer.observe(doc.body, ...)`，而内容脚本以 `run_at: document_start` + `all_frames: true` 注入，iframe 刚创建时 `doc.body` 还没生成。

稳定触发路径：点击页面样式切换器会向 iframe 发送 `IFRAME_TOP_BAR_CHANGE`，在该消息的回调里必现。

改为回落到 `documentElement`，`subtree: true` 仍能覆盖随后插入的 body，登录按钮的绑定行为不降级。

---

## 顺带发现，但这个 PR 没有处理

以下两项我没有动，因为不确定实际是否可达，需要熟悉项目的人判断：

### a. `bilibiliTopBar.ts` 里其余的 `doc.body` 操作也没有守卫

和第 3 点同源。如果 `doc.body` 为 null，这些位置同样会抛错：

| 行号 | 代码 |
|---|---|
| 169 / 172 | `doc.body.firstElementChild` / `doc.body.prepend(cachedOriginalTopBar)` |
| 196 | `doc.body.prepend(header)` |
| 336 | `doc.body.appendChild(icons)` |
| 472 / 473 | 同 169 / 172 的模式 |
| 489 | `doc.body.prepend(header)` |

另外 168 行和 470 行的 `cachedOriginalTopBar.parentElement === doc.body`，在 `doc.body` 为 null 且节点游离时会变成 `null === null` 而意外成立，接着访问 `doc.body.firstElementChild` 抛错。

我没有复现出这几条路径，所以没动。如果它们确实只在 body 已就绪后才会被调用，那就不用管。

### b. `pe.ctx.deactivate is not a function`（未解决）

打开设置面板前后会出现，压缩后的调用点是：

```text
if (Ce & 256) { pe.ctx.deactivate(te); return }
```

`256` 是 `ShapeFlags.COMPONENT_SHOULD_KEEP_ALIVE`，说明某个被 `<KeepAlive>` 标记的组件在卸载时，其 `ctx` 上没有 `deactivate` 方法，怀疑与 `KeepAlive` × `Transition` / `Teleport` 的组合有关。

我没能稳定复现出触发操作，所以这个 PR 没有涉及。想请问这个报错是否是已知问题？如果能给出复现步骤我可以继续跟进。