### PR TITLE
feat(topbar): 仿 iOS scroll edge effect 重做顶栏边缘雾化

### DIFF
--- a/src/components/TopBar/components/TopBarHeader.vue
+++ b/src/components/TopBar/components/TopBarHeader.vue
@@ -9,7 +9,7 @@ import TopBarLogo from './TopBarLogo.vue'
 import TopBarRight from './TopBarRight.vue'
 import TopBarSearch from './TopBarSearch.vue'
 
-defineProps<{
+const props = defineProps<{
   reachTop: boolean
   isDark: boolean
 }>()
@@ -17,7 +17,90 @@ defineProps<{
 const { forceWhiteIcon, handleNotificationsItemClick, showSearchBar } = useTopBarInteraction()
 const isNarrowLayout = useMediaQuery('(max-width: 767px)')
 
-const isArticlePage = /^https?:\/\/(?:www\.)?bilibili\.com\/(?:read|opus)\//.test(location.href)
+const OVERLAY_HEIGHT = 'calc(var(--bew-top-bar-height) * 1.35)'
+
+// 雾色沿高度从 peak 衰减到几乎透明。
+//
+// 曲线必须处处平滑：alpha 的斜率只要在中途跳一次，人眼就会在那个一阶导数断点
+// 上看到一条并不存在的亮带（马赫带）。手挑 stop 数值保证不了这件事 —— 曾经
+// 用「peak → mid@45% → 0」三段，末端斜率突变成 0 长出一条亮带；改成手调的
+// S 形后，为了迁就 mid 又在 45% 处压出 2 倍斜率跳变，亮带只是搬到了中间。
+//
+// 所以改为采样余弦衰减 cos 曲线：它两端斜率天然为 0、中间单调，不存在断点。
+// FOG_GAMMA < 1 让曲线上凸，中段留住足够浓度（0.7 时 45% 处约为 peak 的 69%）。
+const FOG_GAMMA = 0.7
+const FOG_STOP_COUNT = 10
+
+// 末端刻意不归零到 0，而是留一个远低于可见阈值的残量，由元素下边界把它硬切掉。
+// 8bit 色深下渐变必然在某处发生一次 1 色阶的跳变（浅色背景上约在 alpha 0.2% 处），
+// 归零到 0 时这个跳变点会停在下边界上方约 1px，在平坦背景上就是一条可见的细线；
+// 保留 0.05% 的残量能把跳变点推到边界那半个像素内，与边界本身重合从而看不见。
+// 而 0.05% 的硬切自身在 8bit 乃至 10bit 下都不足半个色阶，不会另生边界。
+const FOG_FLOOR = 0.05
+
+function fogStops(peak: number): [number, number][] {
+  return Array.from({ length: FOG_STOP_COUNT }, (_, index) => {
+    const t = index / (FOG_STOP_COUNT - 1)
+    const decay = ((1 + Math.cos(Math.PI * t)) / 2) ** FOG_GAMMA
+    return [+(t * 100).toFixed(1), Math.max(peak * decay, FOG_FLOOR)]
+  })
+}
+
+// 保留两位小数，末端那点残量不能被取整抹平
+const fogAlpha = (alpha: number) => +alpha.toFixed(2)
+
+function fogGradient(color: string, peak: number) {
+  const stops = fogStops(peak).map(([pos, alpha]) => `rgb(${color} / ${fogAlpha(alpha)}%) ${pos}%`)
+  return `linear-gradient(to bottom, ${stops.join(', ')})`
+}
+
+// 跟随页面背景色的变体，供关闭磨砂玻璃时使用
+function fogGradientOnBg(peak: number) {
+  const stops = fogStops(peak).map(([pos, alpha]) =>
+    `color-mix(in oklab, var(--bew-bg), transparent ${fogAlpha(100 - alpha)}%) ${pos}%`)
+  return `linear-gradient(to bottom, ${stops.join(', ')})`
+}
+
+// 仿 iOS 的 scroll edge effect：让模糊半径本身自顶向下衰减，内容像穿过一层雾
+// 那样逐渐变清晰。单层 backdrop-filter 配 mask 做不到这件事 —— 那只是把清晰
+// 图像和固定强度的模糊图像按比例混合，两份内容同时可见，会留下重影和边界感。
+//
+// 真正的渐进模糊要靠堆叠：每层 blur 半径翻倍，mask 窗口逐层向顶部收缩，
+// 后一层的 backdrop 是前一层绘制后的结果，于是模糊沿高度累积衰减。
+// 顶部五层叠满约等于 blur(18px)，到底部只剩不足 1px，自然归零。
+const BLUR_LAYER_COUNT = 5
+
+const blurLayers = Array.from({ length: BLUR_LAYER_COUNT }, (_, index) => {
+  const solid = ((BLUR_LAYER_COUNT - 1 - index) / BLUR_LAYER_COUNT) * 100
+  const fade = ((BLUR_LAYER_COUNT - index) / BLUR_LAYER_COUNT) * 100
+  const mask = `linear-gradient(to bottom, rgb(0 0 0 / 100%) 0, rgb(0 0 0 / 100%) ${solid}%, rgb(0 0 0 / 0%) ${fade}%)`
+  // 饱和度只加在覆盖最广的最底层，避免逐层累积把颜色推过头
+  const filter = index === 0 ? `blur(${2 ** index}px) saturate(180%)` : `blur(${2 ** index}px)`
+  return {
+    backdropFilter: filter,
+    WebkitBackdropFilter: filter,
+    maskImage: mask,
+    WebkitMaskImage: mask,
+  }
+})
+
+// 雾化层只改清晰度，还需要一层雾色叠上去才有"雾"的质感。
+const tintBackground = computed(() => {
+  // 壁纸模式下方是图片，压黑雾才压得住
+  if (forceWhiteIcon.value)
+    return fogGradient('0 0 0', 42)
+
+  // 关掉磨砂玻璃时雾化层不渲染，遮挡全压在这一层上，
+  // 语义上也不再是雾而是顶栏底色，所以跟着页面背景走。
+  if (!settings.value.enableFrostedGlass)
+    return fogGradientOnBg(92)
+
+  // 亮色白雾、暗色黑雾。这里不能图省事用 --bew-bg：
+  // 它在暗色下是深灰，跟深色页面几乎同色，压上去看不出任何变化。
+  return props.isDark
+    ? fogGradient('0 0 0', 75)
+    : fogGradient('255 255 255', 80)
+})
 
 const leftSection = ref<HTMLElement | null>(null)
 const rightSection = ref<HTMLElement | null>(null)
@@ -125,37 +208,24 @@ function refreshSearchContent() {
     p="x-12" m-auto
     h="$bew-top-bar-height"
   >
-    <!-- Top bar mask -->
-    <Transition name="fade">
-      <div
-        v-if="!reachTop"
-        style="
-          mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 1), rgba(0, 0, 0, 1) 24px, rgba(0, 0, 0, 0.9) 44px, transparent);
-          -webkit-mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 1), rgba(0, 0, 0, 1) 24px, rgba(0, 0, 0, 0.9) 44px, transparent);
-        "
-        pos="absolute top-0 left-0" w-full h="$bew-top-bar-height"
-        pointer-events-none
-        :style="{
-          backgroundColor: settings.enableFrostedGlass ? 'transparent' : 'var(--bew-bg)',
-          opacity: settings.enableFrostedGlass ? 1 : 0.9,
-          backdropFilter: settings.enableFrostedGlass ? 'var(--bew-filter-glass-1)' : 'none',
-        }"
-      />
-    </Transition>
+    <!-- 顶栏边缘雾化：渐进模糊 + 雾色 -->
+    <div class="top-bar-header__scroll-edge" :style="{ height: OVERLAY_HEIGHT }">
+      <Transition name="fade">
+        <div v-if="!reachTop && settings.enableFrostedGlass" class="top-bar-header__blur-stack">
+          <div
+            v-for="(layer, index) in blurLayers"
+            :key="index"
+            class="top-bar-header__blur-layer"
+            :style="layer"
+          />
+        </div>
+      </Transition>
 
-    <div
-      pos="absolute top-0 left-0" w-full
-      pointer-events-none opacity-100 duration-300
-      :style="{
-        background: `linear-gradient(to bottom, ${
-          forceWhiteIcon
-            ? 'rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.4) calc(var(--bew-top-bar-height) / 2)'
-            : 'color-mix(in oklab, var(--bew-bg), transparent 20%), color-mix(in oklab, var(--bew-bg), transparent 40%) calc(var(--bew-top-bar-height) / 2)'
-        }, transparent)`,
-        opacity: reachTop ? 0.8 : 1,
-        height: 'var(--bew-top-bar-height)',
-      }"
-    />
+      <div
+        class="top-bar-header__tint"
+        :style="{ background: tintBackground, opacity: reachTop ? 0.8 : 1 }"
+      />
+    </div>
 
     <!-- Top bar theme color gradient -->
     <Transition name="fade">
@@ -195,14 +265,6 @@ function refreshSearchContent() {
         @notifications-click="handleNotificationsItemClick"
       />
     </div>
-
-    <div
-      class="top-bar-header__divider"
-      :class="{
-        'top-bar-header__divider--visible': !reachTop && !isArticlePage,
-        'top-bar-header__divider--white': forceWhiteIcon,
-      }"
-    />
   </main>
 </template>
 
@@ -214,28 +276,23 @@ function refreshSearchContent() {
   min-height: var(--bew-top-bar-height);
 }
 
-.top-bar-header__divider {
+.top-bar-header__scroll-edge {
   position: absolute;
-  right: 0;
-  bottom: 0;
+  top: 0;
   left: 0;
-  height: 1px;
+  width: 100%;
   pointer-events: none;
-  background: color-mix(in oklab, var(--bew-border-color), transparent 35%);
-  opacity: 0;
-  transform: scaleX(0.96);
-  transition:
-    opacity 0.3s ease,
-    transform 0.3s ease;
+}
 
-  &--visible {
-    opacity: 0.65;
-    transform: scaleX(1);
-  }
+.top-bar-header__blur-stack,
+.top-bar-header__blur-layer,
+.top-bar-header__tint {
+  position: absolute;
+  inset: 0;
+}
 
-  &--white {
-    background: rgba(255, 255, 255, 0.16);
-  }
+.top-bar-header__tint {
+  transition: opacity 0.3s ease;
 }
 
 .top-bar-header__side {


### PR DESCRIPTION
这是观感改动，会影响所有页面的顶栏外观，**想先听听你的意见**。方案和数值都可以调。只改了 `TopBarHeader.vue` 一个文件，详细原因写在代码注释里。

现版本有明显的两层：
<img width="768" height="266" alt="image" src="https://github.com/user-attachments/assets/5c99264b-0295-4c7b-b26b-a4f4bcead2d3" />
修改后：
<img width="796" height="250" alt="image" src="https://github.com/user-attachments/assets/10e0516e-1e99-4450-8d74-3009c1a8bac9" />

## 1. 渐变透明点落在顶栏底边，控件下缘几乎没遮挡

控件垂直居中于 64px 顶栏，底边位置 `(64 + 控件高) / 2`：

- 搜索框 `--bew-top-bar-primary-control-height` 46px → 底边 **55px**
- 切换器 / 右侧按钮 `--bew-control-height` 36px → 底边 **50px**

原渐变是 `80% @0 → 60% @32px → 0 @64px`，控件底边都落在第二段里，遮挡按线性插值：

```
55px → 60% × (64-55)/(64-32) = 16.9%
50px → 60% × (64-50)/(64-32) = 26.3%
```

滚动时页面内容基本是紧贴控件边缘划过的。

**改法**：区间从 64px 延长到 `64 × 1.35 = 86.4px`，配合下面第 4 条的余弦曲线，同位置变成：

```
55px → t = 55/86.4 = 0.637 → 80% × ((1+cos 0.637π)/2)^0.7 = 33.8%
50px → t = 50/86.4 = 0.579 → 80% × ((1+cos 0.579π)/2)^0.7 = 40.5%
```

## 2. 单层 `backdrop-filter` + mask 淡出不是渐进模糊

固定强度的 `blur(20px)` 靠 mask 在 44px→64px 淡出，效果是「清晰图像」和「模糊图像」按 mask 比例**混合**，过渡带里两份内容同时可见，所以有重影。真正的渐进模糊要让模糊半径本身衰减。

**改法**：CSS 没有原生可变模糊，堆叠 5 层 `backdrop-filter`，每层 blur 翻倍、mask 窗口逐层向顶部收缩（`[0,100%]`、`[0,80%]`…`[0,20%]`）。后一层的 backdrop 是前一层绘制后的结果，所以模糊沿高度累积。

高斯模糊叠加是方差相加，顶部五层叠满：

```
σ = √(1² + 2² + 4² + 8² + 16²) = √341 ≈ 18.5px
```

接近原先 `--bew-filter-glass-1` 的 `blur(20px)`。饱和度只加在覆盖最广的最底层，免得逐层累积推过头。

## 3. 暗色下颜色遮挡是恒等无效的（这条是功能问题）

`variables.scss` 里暗色的这两个变量是同一个表达式：

```scss
--bew-bg: color-mix(in oklab, var(--bew-dark-base-color), black 20%);
--bew-homepage-bg: color-mix(in oklab, var(--bew-dark-base-color), black 20%);
```

而原本两个分支都用 `--bew-bg` 当遮罩色。用某个颜色去叠加**与它同色**的背景：

```
result = bg × (1 - a) + bg × a = bg
```

与 alpha 无关、恒等于原色 —— 暗色下压在页面空白背景上完全没有遮挡效果，只有压在视频封面这类内容上才看得出来。

**改法**：亮色用纯白、暗色用纯黑，不再跟 `--bew-bg` 走。

## 4. 渐变会长出并不存在的亮带

**(a) 马赫带。** 线性渐变以恒定斜率归零时，alpha 的一阶导数在终点突变，人眼对亮度梯度的二阶导数敏感，会在断点上看到一条实际不存在的亮带。我先手挑 stop 拟了条 S 形，结果为了让曲线穿过手定的中点，又在那里压出 2 倍斜率跳变，亮带只是从末端搬到了中间。

**改法**：采样余弦衰减，不再手挑数值。

```
alpha(t) = peak × ((1 + cos πt) / 2) ^ 0.7        // 取 10 个 stop
```

导数含 `sin(πt)` 因子，而 `sin(0) = sin(π) = 0`，所以两端斜率天然为 0、中间单调，数学上不存在断点。指数 0.7 让曲线上凸，中段留住浓度。

**(b) 8bit 量化 banding。** 马赫带消除后还剩一条极淡的线，取色器量出来是真实的 1 色阶差：背景 `#F2F2F8`、线上 `#F1F1F7`。反推 `242 × (1-a) = 241` → `a ≈ 0.41%`，就是渐变末端的残量。

8bit 下渐变必然在某处发生一次色阶跳变，消不掉，只能控制它落在哪。浅色背景上半个色阶对应 `0.5/242 = 0.207%`，跳变就发生在 alpha 穿过这个值的位置。

**改法**：末端不归零，留 `0.05%` 残量交给元素边界硬切。末段斜率 `(6.9% - 0.05%) / 9.6px = 0.71%/px`，于是从 0.207% 降到 0.05% 只需 `0.157/0.71 = 0.22px` —— 不足一个 CSS 像素，跳变点被推进边界内与之重合。而 0.05% 残量本身在 242 上只有 0.12 色阶，8bit、10bit 下都不足半级，硬切不会另生边界。

## 参数

浓度只有 `peak` 一个旋钮，曲线形状由余弦函数保证：

| 场景 | 雾色 | `peak` |
|---|---|---|
| 亮色 | 纯白 | 80% |
| 暗色 | 纯黑 | 75% |
| 壁纸 | 纯黑 | 42% |
| 关闭磨砂玻璃 | `--bew-bg` | 92% |

关闭磨砂玻璃时不渲染模糊层，遮挡全压在这层上，语义上也不再是雾而是顶栏底色，所以仍跟着页面背景走。

顺带移除了 `top-bar-header__divider` —— 雾化已经承担分隔作用，两者叠加会显出一条硬边。想保留的话我单独留着。

## 没验证的部分

1. **滚动帧率** — 5 层 `backdrop-filter` 有真实代价，我没量测。担心就把 `BLUR_LAYER_COUNT` 降到 3（顶部模糊 18.5px → `√21 ≈ 4.6px`）。
2. **关闭磨砂玻璃**那条分支（`peak=92`）。
3. **壁纸模式下第 4(b) 条的修法**，我还没复量确认。
4. 这几个 `peak` 是按我自己屏幕调的，不合适请直接改。
