### PR TITLE
fix(comment): 修复新评论组件深色模式下空tag占位显示为黑色方块

### DIFF
--- a/src/inject/index.ts
+++ b/src/inject/index.ts
@@ -356,10 +356,6 @@ else if (shouldInitializePageScript) {
           --bili-comment-tag-color: var(--bew-comment-tag-color, var(--bili-comment-tag-color-dark)) !important;
           --bili-comment-tag-bg: var(--bew-comment-tag-bg, var(--bili-comment-tag-bg-dark)) !important;
         }
-
-        #body .tag:empty {
-          display: none !important;
-        }
       `,
     },
     'bili-comment-box': {
@@ -2936,6 +2932,19 @@ else if (shouldInitializePageScript) {
                 return
 
               ensureCommentShadowStyle(root, shadowStylePatch.id, shadowStylePatch.css)
+              if (name === 'bili-comment-renderer') {
+                // 清理空 tag 占位元素。B 站评论新组件在 #tags 下为每种标签类型
+                // 预留了 .tag 占位，未激活的标签以空 div 形式残留。这些空 div
+                // 在深色模式下有背景色（#1E1E1E），显示为黑色方块。CSS 方案在
+                // Shadow DOM 中受 Lit 重渲染时序影响不可靠，改用 JS 直接移除。
+                const body = root.querySelector('#body')
+                if (body) {
+                  body.querySelectorAll('.tag').forEach((el) => {
+                    if (!(el as HTMLElement).style.cssText && !el.textContent?.trim())
+                      (el as HTMLElement).style.display = 'none'
+                  })
+                }
+              }
               if (name === 'bili-comment-thread-renderer') {
                 // 删除/屏蔽回复可能让楼层组件整体重绘，之前挂在其 shadow root
                 // 内的 SVG 线条会随渲染结果一并被移除；重绘完成后从当前回复容器恢复。


### PR DESCRIPTION
## 问题

深色模式下，评论标签旁出现黑色方块。

<img width="480" alt="修复前" src="https://github.com/user-attachments/assets/d67ed211-abd8-4ed6-881f-d057c3e7ab22" />

## 根因

B 站新评论组件 `bili-comment-renderer` 在 `#tags` 下为每种标签类型预留了固定的 `.tag` 占位元素。未激活的标签以空 div 残留，深色模式下背景 `#1E1E1E` 形成黑色方块。

## 修复

旧的 `:empty` CSS 规则在 Lit 渲染的 Shadow DOM 中受空白文本节点和重渲染时序影响不生效，改为 JS 方案：组件更新时扫描`.tag`，无内联 style 且无文本的空占位直接设置 `display: none`。

<img width="480" alt="修复后" src="https://github.com/user-attachments/assets/58ac9f17-dea0-46bc-8619-beca983bab18" />