### PR TITLE
fix: 修复非主页页面设置下拉菜单无法正常显示的问题

### DIFF
--- a/src/components/MediaEpisodeSelect/MediaEpisodeSelect.vue
+++ b/src/components/MediaEpisodeSelect/MediaEpisodeSelect.vue
@@ -50,8 +50,8 @@ function calculatePosition() {
 
   const rect = containerRef.value.getBoundingClientRect()
   dropdownPosition.value = {
-    top: rect.bottom + window.scrollY,
-    left: rect.left + window.scrollX,
+    top: rect.bottom,
+    left: rect.left,
     width: rect.width,
   }
 }
@@ -136,7 +136,7 @@ watchEffect(() => {
             left: `${dropdownPosition.left}px`,
             width: `${dropdownPosition.width}px`,
           }"
-          pos="absolute"
+          pos="fixed"
           p="2"
           m="t-2"
           z="10004"

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -68,8 +68,8 @@ function calculatePosition(desiredHeight: number) {
   const availableSpace = openUp ? spaceAbove : spaceBelow
 
   dropdownPosition.value = {
-    top: (openUp ? rect.top : rect.bottom) + window.scrollY,
-    left: rect.left + window.scrollX,
+    top: (openUp ? rect.top : rect.bottom),
+    left: rect.left,
     width: rect.width,
     openUp,
     // 极端矮视口下也不能超过实际可用空间，否则仍会溢出贴边
@@ -197,7 +197,7 @@ function onMouseEnter() {
             transform: dropdownPosition.openUp ? `translateY(calc(-100% - ${DROPDOWN_MARGIN}px))` : undefined,
             marginTop: dropdownPosition.openUp ? undefined : `${DROPDOWN_MARGIN}px`,
           }"
-          pos="absolute" p="2"
+          pos="fixed" p="2"
           z="10004" flex="~ col gap-1"
           w="full" overflow-y-overlay will-change-transform
         >


### PR DESCRIPTION
## 问题描述

在非主页的 Bilibili 页面（视频、番剧、搜索、up主主页等）打开BewlyCat设置时，下拉菜单（`Select.vue`、`MediaEpisodeSelect.vue`）无法在正确位置显示，会被渲染到屏幕外；仅主页正常。

## 原因分析

下拉菜单通过 `<Teleport>` 挂载到 Shadow DOM 内，用 `position: absolute` + 视口坐标 + `scrollY/scrollX` 定位，其坐标相对最近定位祖先（包含块）计算，而包含块随页面不同而变化：

- **标准主页**：`#bewly`（shadow host）被注入内联 `position: fixed; inset: 0`（`contentScripts/index.ts`），优先级高于 `.settings-open` 的 `position: relative`，包含块始终锚定在视口原点，坐标恰好正确。
- **其余页面**：`#bewly` 无内联定位样式，打开设置后 `.settings-open` 使其变为 `position: relative`，成为包含块；但它在 `document.body` 末尾（B站内容之后），以视口为基准计算的坐标被解析为相对该盒子的偏移，下拉菜单因此渲染到屏幕外。

## 修复方案

将两处下拉菜单改为 `position: fixed` + 纯 `getBoundingClientRect()` 坐标（fixed 始终相对视口定位，与 Settings 搜索弹窗既有方案一致）：

- `src/components/Select.vue`
- `src/components/MediaEpisodeSelect.vue`

## 验证

- [x] `pnpm typecheck`
- [x] `pnpm lint`