### PR TITLE
fix: 净化分享链接时保留分 P 参数

### DIFF
--- a/src/inject/index.ts
+++ b/src/inject/index.ts
@@ -3227,7 +3227,6 @@ else if (shouldInitializePageScript) {
     'buvid',
     'is_story_h5',
     'mid',
-    'p',
     'plat_id',
     'share_from',
     'timestamp',

--- a/src/utils/main.ts
+++ b/src/utils/main.ts
@@ -494,7 +494,6 @@ const BILIBILI_TRACKING_PARAMS = [
   'buvid',
   'is_story_h5',
   'mid',
-  'p',
   'plat_id',
   'share_from',
   'timestamp',


### PR DESCRIPTION
## Summary

- 保留多 P 视频分享链接中的 `p` 分 P 定位参数
- 继续清理既有追踪参数，并保留 `t` 时间定位参数

Fixes #1000

其实就是删了两行代码避免把分p去掉