### PR TITLE
fix(topbar): 修复磨砂玻璃性能开销、滚动跃变与实色顶栏宽度

### DIFF
--- a/src/components/TopBar/components/TopBarHeader.vue
+++ b/src/components/TopBar/components/TopBarHeader.vue
@@ -212,17 +212,20 @@ function refreshSearchContent() {
         磨砂层跟随「启用毛玻璃效果」开关，默认不渲染。
         堆叠 backdrop-filter 的合成开销是真实的，默认给所有人开会让低端设备掉帧；
         雾色层本身已经提供了可读性所需的遮挡，模糊只是质感加成，所以让它可选。
+
+        开启后模糊层常驻，不跟随 reachTop 挂载／卸载：reachTop 是 scrollTop === 0，
+        滚 1px 就翻转，从前那层 <Transition name="fade"> 会让整叠磨砂在 300ms 里凭空
+        淡入，用户看得见"材质生效"的过程；壁纸模式下同时还叠着雾色 0.8 → 1，两个变化
+        撞在一起更刺眼。iOS 的做法是导航栏材质常在、滚动只加强，这里对齐。
       -->
-      <Transition name="fade">
-        <div v-if="!reachTop && settings.enableFrostedGlass" class="top-bar-header__blur-stack">
-          <div
-            v-for="(layer, index) in blurLayers"
-            :key="index"
-            class="top-bar-header__blur-layer"
-            :style="layer"
-          />
-        </div>
-      </Transition>
+      <div v-if="settings.enableFrostedGlass" class="top-bar-header__blur-stack">
+        <div
+          v-for="(layer, index) in blurLayers"
+          :key="index"
+          class="top-bar-header__blur-layer"
+          :style="layer"
+        />
+      </div>
 
       <div
         class="top-bar-header__tint"

--- a/src/components/TopBar/components/TopBarHeader.vue
+++ b/src/components/TopBar/components/TopBarHeader.vue
@@ -90,9 +90,14 @@ const tintBackground = computed(() => {
 
   // 亮色白雾、暗色黑雾。这里不能图省事用 --bew-bg：
   // 它在暗色下是深灰，跟深色页面几乎同色，压上去看不出任何变化。
+  //
+  // 亮色要压到满，暗色 75 就够 —— 这个不对称是实测出来的：亮色页面下方是深色文字，
+  // 白雾没压满时透出来的残影在浅底上格外扎眼；暗色页面透出的是浅色文字压在深底上，
+  // 同样残留量看着轻得多。顶部未滚动时这一层还有 opacity: 0.8，所以满值不会一上来
+  // 就糊成一块白。
   return props.isDark
     ? fogGradient('0 0 0', 75)
-    : fogGradient('255 255 255', 80)
+    : fogGradient('255 255 255', 100)
 })
 
 const leftSection = ref<HTMLElement | null>(null)

--- a/src/components/TopBar/components/TopBarHeader.vue
+++ b/src/components/TopBar/components/TopBarHeader.vue
@@ -56,12 +56,20 @@ function fogGradient(color: string, peak: number) {
 // 顶部五层叠满约等于 blur(18px)，到底部只剩不足 1px，自然归零。
 const BLUR_LAYER_COUNT = 5
 
+// 模糊本身会让颜色趋灰（邻域求平均），saturate 是对此的补偿。
+// 但 --bew-filter-glass-1 的 180% 是照纯色页面背景定的，压在壁纸照片上会把原图
+// 的彩度直接放大 1.8 倍 —— 表现为顶栏明显泛色（青蓝壁纸上尤其刺眼）。
+// 降到刚够抵消模糊导致的褪色即可，不再额外加彩。
+const BLUR_SATURATE = 120
+
 const blurLayers = Array.from({ length: BLUR_LAYER_COUNT }, (_, index) => {
   const solid = ((BLUR_LAYER_COUNT - 1 - index) / BLUR_LAYER_COUNT) * 100
   const fade = ((BLUR_LAYER_COUNT - index) / BLUR_LAYER_COUNT) * 100
   const mask = `linear-gradient(to bottom, rgb(0 0 0 / 100%) 0, rgb(0 0 0 / 100%) ${solid}%, rgb(0 0 0 / 0%) ${fade}%)`
   // 饱和度只加在覆盖最广的最底层，避免逐层累积把颜色推过头
-  const filter = index === 0 ? `blur(${2 ** index}px) saturate(180%)` : `blur(${2 ** index}px)`
+  const filter = index === 0
+    ? `blur(${2 ** index}px) saturate(${BLUR_SATURATE}%)`
+    : `blur(${2 ** index}px)`
   return {
     backdropFilter: filter,
     WebkitBackdropFilter: filter,

--- a/src/components/TopBar/components/TopBarHeader.vue
+++ b/src/components/TopBar/components/TopBarHeader.vue
@@ -78,6 +78,10 @@ const blurLayers = Array.from({ length: BLUR_LAYER_COUNT }, (_, index) => {
   }
 })
 
+// 实色模式只占顶栏本身的高度，渐变模式才向下延伸出淡出区间
+const backdropHeight = computed(() =>
+  settings.value.enableTopBarGradient ? OVERLAY_HEIGHT : 'var(--bew-top-bar-height)')
+
 // 雾化层只改清晰度，还需要一层雾色叠上去才有"雾"的质感。
 const tintBackground = computed(() => {
   // 壁纸模式下方是图片，压黑雾才压得住
@@ -205,39 +209,48 @@ function refreshSearchContent() {
 <template>
   <main
     class="top-bar-header"
-    :class="{
-      'top-bar-header--solid': !settings.enableTopBarGradient,
-      'top-bar-header--solid-force-white': !settings.enableTopBarGradient && forceWhiteIcon,
-    }"
     max-w="$bew-page-max-width"
     grid="~ cols-[auto_1fr_auto] items-center gap-4"
     p="x-12" m-auto
     h="$bew-top-bar-height"
   >
-    <!-- 顶栏边缘雾化：渐进模糊 + 雾色 -->
-    <div v-if="settings.enableTopBarGradient" class="top-bar-header__scroll-edge" :style="{ height: OVERLAY_HEIGHT }">
-      <!--
-        磨砂层跟随「启用毛玻璃效果」开关，默认不渲染。
-        堆叠 backdrop-filter 的合成开销是真实的，默认给所有人开会让低端设备掉帧；
-        雾色层本身已经提供了可读性所需的遮挡，模糊只是质感加成，所以让它可选。
+    <!--
+      顶栏背景层。这里必须是绝对定位的独立元素，不能把背景直接画在 .top-bar-header 上：
+      .top-bar-header 受 max-width: var(--bew-page-max-width) 约束并居中，而它自身
+      position 是 static，所以这一层的包含块是全宽的 .top-bar —— 宽屏下背景才能铺到
+      视口两端，不会像画在 .top-bar-header 上那样两侧露出间距。
+    -->
+    <div class="top-bar-header__backdrop" :style="{ height: backdropHeight }">
+      <template v-if="settings.enableTopBarGradient">
+        <!--
+          磨砂层跟随「启用毛玻璃效果」开关，默认不渲染。
+          堆叠 backdrop-filter 的合成开销是真实的，默认给所有人开会让低端设备掉帧；
+          雾色层本身已经提供了可读性所需的遮挡，模糊只是质感加成，所以让它可选。
 
-        开启后模糊层常驻，不跟随 reachTop 挂载／卸载：reachTop 是 scrollTop === 0，
-        滚 1px 就翻转，从前那层 <Transition name="fade"> 会让整叠磨砂在 300ms 里凭空
-        淡入，用户看得见"材质生效"的过程；壁纸模式下同时还叠着雾色 0.8 → 1，两个变化
-        撞在一起更刺眼。iOS 的做法是导航栏材质常在、滚动只加强，这里对齐。
-      -->
-      <div v-if="settings.enableFrostedGlass" class="top-bar-header__blur-stack">
+          开启后模糊层常驻，不跟随 reachTop 挂载／卸载：reachTop 是 scrollTop === 0，
+          滚 1px 就翻转，从前那层 <Transition name="fade"> 会让整叠磨砂在 300ms 里凭空
+          淡入，用户看得见"材质生效"的过程；壁纸模式下同时还叠着雾色 0.8 → 1，两个变化
+          撞在一起更刺眼。iOS 的做法是导航栏材质常在、滚动只加强，这里对齐。
+        -->
+        <div v-if="settings.enableFrostedGlass" class="top-bar-header__blur-stack">
+          <div
+            v-for="(layer, index) in blurLayers"
+            :key="index"
+            class="top-bar-header__blur-layer"
+            :style="layer"
+          />
+        </div>
+
         <div
-          v-for="(layer, index) in blurLayers"
-          :key="index"
-          class="top-bar-header__blur-layer"
-          :style="layer"
+          class="top-bar-header__tint"
+          :style="{ background: tintBackground, opacity: reachTop ? 0.8 : 1 }"
         />
-      </div>
+      </template>
 
       <div
-        class="top-bar-header__tint"
-        :style="{ background: tintBackground, opacity: reachTop ? 0.8 : 1 }"
+        v-else
+        class="top-bar-header__solid"
+        :class="{ 'top-bar-header__solid--force-white': forceWhiteIcon }"
       />
     </div>
 
@@ -291,19 +304,7 @@ function refreshSearchContent() {
   min-height: var(--bew-top-bar-height);
 }
 
-.top-bar-header--solid {
-  background: var(--bew-top-bar-solid-background);
-  box-shadow: var(--bew-top-bar-solid-shadow);
-  transition:
-    background-color var(--bew-duration-moderate) var(--bew-ease-standard),
-    box-shadow var(--bew-duration-moderate) var(--bew-ease-standard);
-}
-
-.top-bar-header--solid-force-white {
-  background: var(--bew-top-bar-solid-background-force-white);
-}
-
-.top-bar-header__scroll-edge {
+.top-bar-header__backdrop {
   position: absolute;
   top: 0;
   left: 0;
@@ -313,13 +314,26 @@ function refreshSearchContent() {
 
 .top-bar-header__blur-stack,
 .top-bar-header__blur-layer,
-.top-bar-header__tint {
+.top-bar-header__tint,
+.top-bar-header__solid {
   position: absolute;
   inset: 0;
 }
 
 .top-bar-header__tint {
   transition: opacity 0.3s ease;
+}
+
+.top-bar-header__solid {
+  background: var(--bew-top-bar-solid-background);
+  box-shadow: var(--bew-top-bar-solid-shadow);
+  transition:
+    background-color var(--bew-duration-moderate) var(--bew-ease-standard),
+    box-shadow var(--bew-duration-moderate) var(--bew-ease-standard);
+}
+
+.top-bar-header__solid--force-white {
+  background: var(--bew-top-bar-solid-background-force-white);
 }
 
 .top-bar-header__side {

--- a/src/components/TopBar/components/TopBarHeader.vue
+++ b/src/components/TopBar/components/TopBarHeader.vue
@@ -208,8 +208,13 @@ function refreshSearchContent() {
   >
     <!-- 顶栏边缘雾化：渐进模糊 + 雾色 -->
     <div v-if="settings.enableTopBarGradient" class="top-bar-header__scroll-edge" :style="{ height: OVERLAY_HEIGHT }">
+      <!--
+        磨砂层跟随「启用毛玻璃效果」开关，默认不渲染。
+        堆叠 backdrop-filter 的合成开销是真实的，默认给所有人开会让低端设备掉帧；
+        雾色层本身已经提供了可读性所需的遮挡，模糊只是质感加成，所以让它可选。
+      -->
       <Transition name="fade">
-        <div v-if="!reachTop" class="top-bar-header__blur-stack">
+        <div v-if="!reachTop && settings.enableFrostedGlass" class="top-bar-header__blur-stack">
           <div
             v-for="(layer, index) in blurLayers"
             :key="index"


### PR DESCRIPTION
跟进 #983 的讨论，默认状态反而比 #983 之前还省。

只改了 `TopBarHeader.vue` 一个文件，五个改动拆成五个独立提交。

## 1. 磨砂改为跟随「启用毛玻璃效果」，默认不渲染

可读性遮挡本来就由雾色层提供，模糊只是质感加成，所以让它可选。

| | 带 backdrop-filter 的层 |
|---|---|
| #983 之前 | 滚动时 1 |
| #983 之后 | 滚动时 5 |
| 本 PR 默认 | **0** |
| 本 PR 开毛玻璃 | 5 |

## 2. 磨砂层常驻，消除滚动瞬间的材质淡入

磨砂原本挂在 `v-if="!reachTop"` 上还包了 `Transition`。`reachTop` 是 `scrollTop === 0`，滚 1px 就翻转，整叠磨砂在 300ms 内凭空淡入，能明显看见「钝一下」。

改为常驻，滚动带来的差异只留雾色浓度，和 iOS 导航栏材质常在的做法一致。

这个行为 #983 之前就有，只是那时顶部雾色更浓（壁纸 60% 黑）盖住了。

## 3. 磨砂饱和度 180% → 120%

`--bew-filter-glass-1` 的 180% 是照纯色背景定的，压在壁纸照片上会把原图彩度放大 1.8 倍，顶栏明显泛色，青蓝壁纸下尤其刺眼。

## 4. 实色顶栏背景铺满视口宽度

实色背景原本画在 `.top-bar-header` 上，而它受 `max-width: 2280px` 约束并居中，宽屏上两侧就露出间距。

渐变模式没这问题：雾化层是绝对定位的，而 `.top-bar-header` 自身 `position` 是 `static`，包含块其实是全宽的 `.top-bar`。

所以把实色也改成同一层结构，新增 `.top-bar-header__backdrop` 统一承载渐变和实色两种填充。

## 5. 亮色雾色 80% → 100%

磨砂默认关掉后遮挡全靠雾色，亮色下 80% 白雾压不住深色文字。暗色 75%、壁纸 42% 不变 —— 暗色透出的是浅色文字压在深底上，同样残留量观感轻得多。

## 验证

`lint` / `typecheck` / `knip` 全部通过。

人工验证过：默认（毛玻璃关）× 亮/暗、开毛玻璃 × 壁纸、实色 × 宽屏、实色 × 壁纸。

**没实测过帧率**，只能给上面那张层数对比表。
