### PR TITLE
fix(settings): 修复内容控件绘制到设置头部之上的问题

### DIFF
--- a/src/components/Settings/Settings.vue
+++ b/src/components/Settings/Settings.vue
@@ -635,6 +635,10 @@ function changeMenuItem(menuItem: MenuType) {
             scrollbarGutter: 'stable',
             overflowAnchor: 'none',
             overscrollBehavior: 'contain',
+            // 隔离内容控件的层叠上下文（如 .bew-segment-control__item 的 z-1），
+            // 避免毛玻璃关闭时与同 z-index 的 .settings-header 落入同一上下文、
+            // 因 DOM 顺序靠后而绘制到头部之上。
+            isolation: 'isolate',
           }"
           h-inherit of-y-auto of-x-hidden
           style="padding-top: 92px;"


### PR DESCRIPTION
滚动容器缺少层叠上下文隔离，毛玻璃关闭时 settings-content 与
滚动容器都不创建层叠上下文，内容控件（如 .bew-segment-control__item
的 z-index: 1）与同为 z-1 的 .settings-header 落入同一层叠上下文， 同值按 DOM 顺序绘制，靠后的内容控件浮到头部之上，滑动时顶部可见
细条闪色。给滚动容器加 isolation: isolate 永久隔离，与毛玻璃开关解耦。