### PR TITLE
fix: 修复收藏弹窗已选勾选框对勾消失

### DIFF
--- a/src/styles/adaptedStyles/pages/userSpacePage.scss
+++ b/src/styles/adaptedStyles/pages/userSpacePage.scss
@@ -331,7 +331,9 @@
 
     .content .group-list li input[type="checkbox"]:checked + i,
     .content .group-list li input[type="checkbox"]:checked:hover + i {
-      background: var(--bew-theme-color) url("/assets/ic_check.svg") no-repeat 50% / 9px;
+      background: var(--bew-theme-color)
+        url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iOSIgaGVpZ2h0PSI5IiB2aWV3Qm94PSIwIDAgOSA5IiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8cGF0aCBkPSJNNy41IDIuNUwzLjc1IDYuMjVMMS41IDQiIHN0cm9rZT0id2hpdGUiIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz4KPC9zdmc+)
+        no-repeat 50% / 9px;
     }
 
     // 處理性別圖標背景顔色

--- a/src/styles/adaptedStyles/pages/videoPage.scss
+++ b/src/styles/adaptedStyles/pages/videoPage.scss
@@ -33,7 +33,12 @@
     }
 
     .content .group-list li input[type="checkbox"]:checked + i,
-    .content .group-list li input[type="checkbox"]:checked:hover + i,
+    .content .group-list li input[type="checkbox"]:checked:hover + i {
+      background: var(--bew-theme-color)
+        url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iOSIgaGVpZ2h0PSI5IiB2aWV3Qm94PSIwIDAgOSA5IiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8cGF0aCBkPSJNNy41IDIuNUwzLjc1IDYuMjVMMS41IDQiIHN0cm9rZT0id2hpdGUiIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz4KPC9zdmc+)
+        no-repeat 50% / 14px;
+    }
+
     .coin-operated-m-exp .like-checkbox input[type="checkbox"]:checked + i,
     .video-share-popover
       .video-share-dropdown

--- a/src/styles/adaptedStyles/pages/videoPage.scss
+++ b/src/styles/adaptedStyles/pages/videoPage.scss
@@ -43,7 +43,9 @@
       .bar-left
       > label
       #check-timestamp:checked::after {
-      background: var(--bew-theme-color) url("/assets/ic_check.svg") no-repeat 50% / 9px;
+      background: var(--bew-theme-color)
+        url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iOSIgaGVpZ2h0PSI5IiB2aWV3Qm94PSIwIDAgOSA5IiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8cGF0aCBkPSJNNy41IDIuNUwzLjc1IDYuMjVMMS41IDQiIHN0cm9rZT0id2hpdGUiIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz4KPC9zdmc+)
+        no-repeat 50% / 9px;
     }
 
     .content .group-list li input[type="checkbox"] + i,
@@ -57,18 +59,6 @@
     .normal-base-item:hover .info .title,
     .normal-base-item.active .info .title {
       color: var(--bew-theme-color) !important;
-    }
-
-    // Firefox specific fix for checkbox visibility
-    @-moz-document url-prefix() {
-      .content .group-list li input[type="checkbox"]:checked + i,
-      .content .group-list li input[type="checkbox"]:checked:hover + i {
-        background-color: var(--bew-theme-color) !important;
-        background-image: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iOSIgaGVpZ2h0PSI5IiB2aWV3Qm94PSIwIDAgOSA5IiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8cGF0aCBkPSJNNy41IDIuNUwzLjc1IDYuMjVMMS41IDQiIHN0cm9rZT0id2hpdGUiIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiLz4KPC9zdmc+) !important;
-        background-repeat: no-repeat !important;
-        background-position: 50% !important;
-        background-size: 9px !important;
-      }
     }
 
     .note-list .list-note-operation,


### PR DESCRIPTION
## 问题描述

收藏弹窗已选勾选框的对勾在 Chrome 下无法正常显示（Firefox 不受影响），同样受影响的还有投币页「同时点赞内容」勾选框。

## 原因分析

adaptedStyles 注入 B 站页面后，`url("/assets/ic_check.svg")` 以页面域名为基准解析导致 404，对勾背景加载失败。Firefox 因存在 `@-moz-document` 内联 base64 兜底规则而未受影响。

## 修复方案

- `videoPage.scss`：将 `url("/assets/ic_check.svg")` 替换为内联 base64 SVG，移除冗余的 Firefox `@-moz-document` 兜底规则；同时将收藏夹勾选框对勾放大至 14px，并与投币、分享时间戳勾选框规则拆分（后者保持 9px）
- `userSpacePage.scss`：同步替换为内联 base64 SVG，修复个人空间收藏夹弹窗的同样问题

## 验证

- `pnpm typecheck`
- `pnpm lint`
