### PR TITLE
fix(topbar): 修复通知栏弹出动画起始位置偏移 #1059

### DIFF
--- a/src/components/TopBar/components/TopBarRight.vue
+++ b/src/components/TopBar/components/TopBarRight.vue
@@ -151,8 +151,6 @@ watch(popupVisible, () => {
     topBarStore.closeAllPopups()
 }, { deep: true })
 
-// 将transformer初始化移到onMounted中
-// 声明组件ref
 const avatarPopRef = ref()
 const notificationsPopRef = ref()
 const momentsPopRef = ref()
@@ -162,19 +160,15 @@ const watchLaterPopRef = ref()
 const uploadPopRef = ref()
 const morePopRef = ref()
 
-// 在组件挂载后初始化transformer，传入ref对象
-onMounted(() => {
-  nextTick(() => {
-    setupTopBarItemTransformer('userPanel', avatarPopRef)
-    setupTopBarItemTransformer('notifications', notificationsPopRef)
-    setupTopBarItemTransformer('moments', momentsPopRef)
-    setupTopBarItemTransformer('favorites', favoritesPopRef)
-    setupTopBarItemTransformer('history', historyPopRef)
-    setupTopBarItemTransformer('watchLater', watchLaterPopRef)
-    setupTopBarItemTransformer('upload', uploadPopRef)
-    setupTopBarItemTransformer('more', morePopRef)
-  })
-})
+// 在 setup 同步初始化，使内部 watch 随组件卸载自动停止。
+setupTopBarItemTransformer('userPanel', avatarPopRef)
+setupTopBarItemTransformer('notifications', notificationsPopRef)
+setupTopBarItemTransformer('moments', momentsPopRef)
+setupTopBarItemTransformer('favorites', favoritesPopRef)
+setupTopBarItemTransformer('history', historyPopRef)
+setupTopBarItemTransformer('watchLater', watchLaterPopRef)
+setupTopBarItemTransformer('upload', uploadPopRef)
+setupTopBarItemTransformer('more', morePopRef)
 
 // Keep notification state in sync even when the item starts hidden and is
 // enabled later from the layout editor.

--- a/src/components/TopBar/composables/useTopBarInteraction.ts
+++ b/src/components/TopBar/composables/useTopBarInteraction.ts
@@ -182,9 +182,8 @@ export function useTopBarInteraction() {
         ([el, visible]) => {
           if (!visible || !el)
             return
-          // v-show 再次显示时引用不变，先清空才能触发定位。
-          transformer.value = undefined
           transformer.value = el
+          transformer.applyPosition()
         },
         { immediate: true, flush: 'post' },
       )

--- a/src/components/TopBar/composables/useTopBarInteraction.ts
+++ b/src/components/TopBar/composables/useTopBarInteraction.ts
@@ -33,7 +33,7 @@ function getConfiguredPageUrl(page: AppPage): string {
 export function useTopBarInteraction() {
   const topBarStore = useTopBarStore()
   const { closeAllPopups } = topBarStore
-  const topBarItemElements = reactive({})
+  const topBarItemElements: Record<string, Ref<HTMLElement | undefined>> = {}
   const topBarTransformers = reactive({})
 
   const isMouseOverPopup = reactive<Record<string, boolean>>({})
@@ -166,7 +166,11 @@ export function useTopBarInteraction() {
 
   // 设置顶栏项变换器
   function setupTopBarItemTransformer(key: string, targetRef?: any) {
-    const transformer = createTransformer(topBarItemElements[key], {
+    const trigger = topBarItemElements[key]
+    if (!trigger)
+      return
+
+    const transformer = createTransformer(trigger, {
       x: '0px',
       y: '50px',
       centerTarget: {

--- a/src/components/TopBar/composables/useTopBarInteraction.ts
+++ b/src/components/TopBar/composables/useTopBarInteraction.ts
@@ -177,12 +177,17 @@ export function useTopBarInteraction() {
     // 如果提供了targetRef，将其存储但不修改transformer的内部逻辑
     if (targetRef) {
       topBarTransformers[key] = targetRef
-      // 监听targetRef的变化，当targetRef有值时，将其设置为transformer的target
-      watch(targetRef, (newVal) => {
-        if (newVal) {
-          transformer.value = newVal
-        }
-      }, { immediate: true })
+      watch(
+        [targetRef, () => topBarStore.popupVisible[key]],
+        ([el, visible]) => {
+          if (!visible || !el)
+            return
+          // v-show 再次显示时引用不变，先清空才能触发定位。
+          transformer.value = undefined
+          transformer.value = el
+        },
+        { immediate: true, flush: 'post' },
+      )
       return targetRef
     }
 

--- a/src/utils/transformer.ts
+++ b/src/utils/transformer.ts
@@ -65,11 +65,10 @@ export function createTransformer(trigger: Ref<MaybeElement>, transformer: Trans
     if (target.value && transformer.centerTarget) {
       const el = unrefElement(target.value)
       const triggerEl = unrefElement(trigger)
-      if (el && triggerEl) {
+      if (el instanceof HTMLElement && triggerEl) {
         // offsetWidth/Height 是布局盒（CSSOM View），不含 transform。
-        // getBoundingClientRect 含 transform，enter/leave 动画中会得到错误宽高。
-        const targetWidth = el instanceof HTMLElement ? el.offsetWidth : el.getBoundingClientRect().width
-        const targetHeight = el instanceof HTMLElement ? el.offsetHeight : el.getBoundingClientRect().height
+        const targetWidth = el.offsetWidth
+        const targetHeight = el.offsetHeight
         const triggerRect = triggerEl.getBoundingClientRect()
 
         if (transformer.centerTarget.x) {

--- a/src/utils/transformer.ts
+++ b/src/utils/transformer.ts
@@ -14,12 +14,16 @@ export interface Transformer {
   notrigger?: boolean
 }
 
+export type TransformerHandle = Ref<MaybeElement> & {
+  applyPosition: () => void
+}
+
 /**
  * Covert transform to top and left style, if no chromium, use transform
  * @param trigger
  * @param transformer
  */
-export function createTransformer(trigger: Ref<MaybeElement>, transformer: Transformer) {
+export function createTransformer(trigger: Ref<MaybeElement>, transformer: Transformer): TransformerHandle {
   const target = ref<MaybeElement>()
   const style = ref<CSSProperties>({})
 
@@ -157,16 +161,13 @@ export function createTransformer(trigger: Ref<MaybeElement>, transformer: Trans
     }
   }
 
-  // v-if：target 在 DOM flush 后赋值，sync 立刻写入 left/top，赶在浏览器绘制首帧之前。
-  watch(target, () => {
-    applyPosition()
-  }, { flush: 'sync' })
-
-  // v-show：仅在真正显示时计算。IntersectionObserver 本身是异步的，不能再额外推迟。
+  // IntersectionObserver 在绘制之后通知，只作 getClientRects 仍为空时的补写。
   const targetVisibility = useElementVisibility(target)
   whenever(targetVisibility, () => {
     applyPosition()
   }, { flush: 'post' })
 
-  return target
+  const handle = target as TransformerHandle
+  handle.applyPosition = applyPosition
+  return handle
 }

--- a/src/utils/transformer.ts
+++ b/src/utils/transformer.ts
@@ -62,15 +62,18 @@ export function createTransformer(trigger: Ref<MaybeElement>, transformer: Trans
       const el = unrefElement(target.value)
       const triggerEl = unrefElement(trigger)
       if (el && triggerEl) {
-        const targetRect = el.getBoundingClientRect()
+        // offsetWidth/Height 是布局盒（CSSOM View），不含 transform。
+        // getBoundingClientRect 含 transform，enter/leave 动画中会得到错误宽高。
+        const targetWidth = el instanceof HTMLElement ? el.offsetWidth : el.getBoundingClientRect().width
+        const targetHeight = el instanceof HTMLElement ? el.offsetHeight : el.getBoundingClientRect().height
         const triggerRect = triggerEl.getBoundingClientRect()
 
         if (transformer.centerTarget.x) {
           // 计算 popup 的预期中心点位置
           const popupCenterX = triggerRect.left + triggerRect.width / 2
           // 计算 popup 居中后的左右边界
-          const popupLeft = popupCenterX - targetRect.width / 2
-          const popupRight = popupCenterX + targetRect.width / 2
+          const popupLeft = popupCenterX - targetWidth / 2
+          const popupRight = popupCenterX + targetWidth / 2
 
           const viewportWidth = window.innerWidth
           const edgeMargin = 16 // 与边缘保持的最小距离
@@ -89,15 +92,15 @@ export function createTransformer(trigger: Ref<MaybeElement>, transformer: Trans
 
           // 应用偏移
           if (offset !== 0) {
-            x = `calc(${transformer.x} - ${targetRect.width / 2}px + ${offset}px)`
+            x = `calc(${transformer.x} - ${targetWidth / 2}px + ${offset}px)`
           }
           else {
-            x = `calc(${transformer.x} - ${targetRect.width / 2}px)`
+            x = `calc(${transformer.x} - ${targetWidth / 2}px)`
           }
         }
 
         if (transformer.centerTarget.y) {
-          y = `calc(${transformer.y} - ${targetRect.height / 2}px)`
+          y = `calc(${transformer.y} - ${targetHeight / 2}px)`
         }
       }
     }
@@ -137,33 +140,33 @@ export function createTransformer(trigger: Ref<MaybeElement>, transformer: Trans
     return Object.keys(s).map(key => `${key}:${s[key]}`).join(';')
   }
 
-  // v-show
-  const targetVisibility = useElementVisibility(target)
-
-  // fix keleus#135
-  // 还原为 whenever，仅在显示时计算位置
-  whenever(targetVisibility, () => {
+  function applyPosition() {
     try {
-      const targetElement = unrefElement(target)
-      if (targetElement) {
-        // 使用 requestAnimationFrame 和 setTimeout 确保 DOM 完全稳定后再计算位置
-        // 这样可以避免在动画过程中计算位置导致的错误
-        requestAnimationFrame(() => {
-          setTimeout(() => {
-            const element = unrefElement(target)
-            if (element) {
-              update()
-              const style = element.getAttribute('style')
-              element.setAttribute('style', generateStyle(style))
-            }
-          }, 0)
-        })
-      }
+      const element = unrefElement(target)
+      if (!(element instanceof HTMLElement))
+        return
+      // 未生成 CSS 布局盒时跳过（display:none 或不在文档中，CSSOM View getClientRects）。
+      if (element.getClientRects().length === 0)
+        return
+
+      update()
+      element.setAttribute('style', generateStyle(element.getAttribute('style')))
     }
     catch (e) {
-      console.warn('Failed to update style on visibility change:', e)
+      console.warn('Failed to apply transformer position:', e)
     }
-  }, { flush: 'pre' })
+  }
+
+  // v-if：target 在 DOM flush 后赋值，sync 立刻写入 left/top，赶在浏览器绘制首帧之前。
+  watch(target, () => {
+    applyPosition()
+  }, { flush: 'sync' })
+
+  // v-show：仅在真正显示时计算。IntersectionObserver 本身是异步的，不能再额外推迟。
+  const targetVisibility = useElementVisibility(target)
+  whenever(targetVisibility, () => {
+    applyPosition()
+  }, { flush: 'post' })
 
   return target
 }

--- a/src/utils/transformer.ts
+++ b/src/utils/transformer.ts
@@ -65,46 +65,48 @@ export function createTransformer(trigger: Ref<MaybeElement>, transformer: Trans
     if (target.value && transformer.centerTarget) {
       const el = unrefElement(target.value)
       const triggerEl = unrefElement(trigger)
-      if (el instanceof HTMLElement && triggerEl) {
-        // offsetWidth/Height 是布局盒（CSSOM View），不含 transform。
-        const targetWidth = el.offsetWidth
-        const targetHeight = el.offsetHeight
-        const triggerRect = triggerEl.getBoundingClientRect()
+      // 触发器还不是 DOM 节点时不要写 left:0，否则弹层会贴按钮左缘往右伸。
+      if (!(el instanceof HTMLElement) || !triggerEl)
+        return
 
-        if (transformer.centerTarget.x) {
-          // 计算 popup 的预期中心点位置
-          const popupCenterX = triggerRect.left + triggerRect.width / 2
-          // 计算 popup 居中后的左右边界
-          const popupLeft = popupCenterX - targetWidth / 2
-          const popupRight = popupCenterX + targetWidth / 2
+      // offsetWidth/Height 是布局盒（CSSOM View），不含 transform。
+      const targetWidth = el.offsetWidth
+      const targetHeight = el.offsetHeight
+      const triggerRect = triggerEl.getBoundingClientRect()
 
-          const viewportWidth = window.innerWidth
-          const edgeMargin = 16 // 与边缘保持的最小距离
+      if (transformer.centerTarget.x) {
+        // 计算 popup 的预期中心点位置
+        const popupCenterX = triggerRect.left + triggerRect.width / 2
+        // 计算 popup 居中后的左右边界
+        const popupLeft = popupCenterX - targetWidth / 2
+        const popupRight = popupCenterX + targetWidth / 2
 
-          // 检查是否会超出边界
-          let offset = 0
+        const viewportWidth = window.innerWidth
+        const edgeMargin = 16 // 与边缘保持的最小距离
 
-          // 超出右边缘
-          if (popupRight > viewportWidth - edgeMargin) {
-            offset = -(popupRight - (viewportWidth - edgeMargin))
-          }
-          // 超出左边缘（优先级更高，因为通常更重要）
-          else if (popupLeft < edgeMargin) {
-            offset = edgeMargin - popupLeft
-          }
+        // 检查是否会超出边界
+        let offset = 0
 
-          // 应用偏移
-          if (offset !== 0) {
-            x = `calc(${transformer.x} - ${targetWidth / 2}px + ${offset}px)`
-          }
-          else {
-            x = `calc(${transformer.x} - ${targetWidth / 2}px)`
-          }
+        // 超出右边缘
+        if (popupRight > viewportWidth - edgeMargin) {
+          offset = -(popupRight - (viewportWidth - edgeMargin))
+        }
+        // 超出左边缘（优先级更高，因为通常更重要）
+        else if (popupLeft < edgeMargin) {
+          offset = edgeMargin - popupLeft
         }
 
-        if (transformer.centerTarget.y) {
-          y = `calc(${transformer.y} - ${targetHeight / 2}px)`
+        // 应用偏移
+        if (offset !== 0) {
+          x = `calc(${transformer.x} - ${targetWidth / 2}px + ${offset}px)`
         }
+        else {
+          x = `calc(${transformer.x} - ${targetWidth / 2}px)`
+        }
+      }
+
+      if (transformer.centerTarget.y) {
+        y = `calc(${transformer.y} - ${targetHeight / 2}px)`
       }
     }
 


### PR DESCRIPTION
Close #1059 

## Summary

- 悬停顶栏通知铃铛时，弹层结束位置正确，但进入动画第一帧会贴在图标上，并被右侧头像挡住。
- 在 Vue DOM 更新后、浏览器绘制首帧前写入居中后的 `left`/`top`。

Closes keleus/BewlyCat#1059

## Root Cause

`createTransformer` 等 Intersection Observer 判定可见后，再走 `requestAnimationFrame` + `setTimeout(0)`。Observer 本身是异步的，这条路径会落到第一次绘制之后；首帧只有 `position: absolute`、没有 `left`。

## Changes

- 在 `popupVisible` 变为 true 时用 Vue `flush: 'post'` 直接调用 `applyPosition()`。
- 弹层宽高改用 `offsetWidth` / `offsetHeight`（CSSOM View 布局盒，不含 transform）；没有布局盒时跳过。
- transformer 在 `setup` 中同步创建，watch 随组件卸载停止；按钮触发器保存原始 ref，避免 `reactive` 解包后变成 `undefined` 而写成 `left: 0`。
- Intersection Observer 只作为布局盒仍未生成时的补写。

## Behavior

- 普通按钮：弹层相对按钮水平居中。
- 靠右放不下时（如头像）：贴视口右边向左展开。
- 进入动画仍只过渡透明度和 `margin-top`。

## Test plan

- [x] 悬停通知铃铛：第一帧已与结束位置对齐，水平居中于铃铛
- [x] 同样检查动态 / 收藏 / 历史 / 稍后再看 / 投稿
