### PR TITLE
fix: 优化评论回复分页区配色与页号显示

### DIFF
--- a/src/inject/index.ts
+++ b/src/inject/index.ts
@@ -338,6 +338,10 @@ else if (shouldInitializePageScript) {
           background: var(--bew-comment-replies-mask-bg, rgba(var(--bg1_rgb), 0.85)) !important;
         }
 
+        #pagination {
+          color: var(--bew-text-3) !important;
+        }
+
         :host([data-bewly-comment-reply-tree]) {
           --bew-comment-reply-branch-radius: var(--bew-radius-lg, 12px);
           --bew-comment-reply-indent-step: var(--bew-space-8, 32px);
@@ -807,6 +811,25 @@ else if (shouldInitializePageScript) {
       && currentSettings?.commentReplyPaginationMode !== 'pagination'
   }
 
+  function updateCommentReplyPaginationHead(component: any, currentPage: number) {
+    const head = component?.shadowRoot?.querySelector('#pagination-head') as HTMLElement | null | undefined
+    if (!head)
+      return
+    const prefix = `第${currentPage}页，共`
+    const first = head.firstChild
+    if (first && first.nodeType === Node.TEXT_NODE && first.textContent !== prefix)
+      first.textContent = prefix
+  }
+
+  function restoreCommentReplyPaginationHead(component: any) {
+    const head = component?.shadowRoot?.querySelector('#pagination-head') as HTMLElement | null | undefined
+    if (!head)
+      return
+    const first = head.firstChild
+    if (first && first.nodeType === Node.TEXT_NODE && first.textContent !== '共')
+      first.textContent = '共'
+  }
+
   function getCommentReplyInvisibleIds(renderer: any): Set<string> {
     if (!renderer.invisibleID || typeof renderer.invisibleID !== 'object')
       return new Set()
@@ -1172,12 +1195,12 @@ else if (shouldInitializePageScript) {
           if (state.loading) {
             return [{ text: '加载中…', idx: currentPage, clickable: false }]
           }
-          const hasNext = items.some(item => Number(item?.idx) === currentPage && item?.clickable !== false)
-          return [{
-            text: hasNext ? '加载更多' : '没有更多回复',
-            idx: currentPage,
-            clickable: hasNext,
-          }]
+          const totalPage = Number(this.totalPage) || 0
+          const hasNext = currentPage < totalPage
+          queueMicrotask(() => updateCommentReplyPaginationHead(this, currentPage))
+          return hasNext
+            ? [{ text: '加载更多', idx: currentPage, clickable: true }]
+            : []
         },
       })
     }
@@ -3087,8 +3110,10 @@ else if (shouldInitializePageScript) {
       commentReplyPaginationModeStates.set(component, paginationEnabled)
       component.requestUpdate?.()
     }
-    if (!paginationEnabled)
+    if (!paginationEnabled) {
       clearCommentReplyPaginationState(component, true)
+      restoreCommentReplyPaginationHead(component)
+    }
     const existingState = commentReplyTreeStates.get(component)
     if (treeMode === null && !existingState?.enabled) {
       component.removeAttribute('data-bewly-comment-reply-tree')


### PR DESCRIPTION
- 原生 #pagination 使用 var(--text1)，暗色下桥接为 --bew-text-1（近白偏亮），覆盖为 --bew-text-3；hover 沿用原生 var(--brand_blue)。

- 显示当前的页号，最后一页只显示收起。

<img width="819" height="181" alt="PixPin_2026-08-18_05-55-28" src="https://github.com/user-attachments/assets/9aeb6a5e-2826-4dc4-93ac-894c75eb4e38" />

