### PR TITLE
fix: 顶栏过渡动画修复与移除设置分组折叠

### DIFF
--- a/src/components/ProgressiveBlurSurface.vue
+++ b/src/components/ProgressiveBlurSurface.vue
@@ -1,4 +1,17 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+
+const props = withDefaults(defineProps<{
+  /** 过渡到恒等滤镜，视觉上等同于关闭，但保留平滑动画与挂载状态 */
+  inactive?: boolean
+}>(), { inactive: false })
+
+// 恒等滤镜：blur(0) + saturate(100%) 不产生任何视觉效果，
+// 且与各层 blur(Npx)（首层另含 saturate(180%)）函数结构一致，可平滑插值。
+// Chromium 在 opacity 动画期间会丢弃 backdrop-filter（crbug.com/40877283），
+// 因此需要淡出时保持挂载并把各层过渡到恒等滤镜，而不是靠 opacity 或卸载隐藏。
+const IDENTITY_BACKDROP_FILTER = 'blur(0px) saturate(100%)'
+
 const BLUR_LAYER_COUNT = 5
 
 const blurLayers = Array.from({ length: BLUR_LAYER_COUNT }, (_, index) => {
@@ -14,12 +27,17 @@ const blurLayers = Array.from({ length: BLUR_LAYER_COUNT }, (_, index) => {
     WebkitMaskImage: mask,
   }
 })
+
+const layerStyles = computed(() =>
+  blurLayers.map(layer => (props.inactive
+    ? { ...layer, backdropFilter: IDENTITY_BACKDROP_FILTER, WebkitBackdropFilter: IDENTITY_BACKDROP_FILTER }
+    : layer)))
 </script>
 
 <template>
   <div class="progressive-blur-surface" aria-hidden="true">
     <div
-      v-for="(layer, index) in blurLayers"
+      v-for="(layer, index) in layerStyles"
       :key="index"
       class="progressive-blur-surface__layer"
       :style="layer"
@@ -33,5 +51,9 @@ const blurLayers = Array.from({ length: BLUR_LAYER_COUNT }, (_, index) => {
   position: absolute;
   inset: 0;
   pointer-events: none;
+}
+
+.progressive-blur-surface__layer {
+  transition: backdrop-filter var(--bew-duration-moderate) var(--bew-ease-standard);
 }
 </style>

--- a/src/components/SearchBar/SearchBar.vue
+++ b/src/components/SearchBar/SearchBar.vue
@@ -900,7 +900,9 @@ function handleClearKeyword() {
   @mixin card-content {
     --uno: "text-base outline-none w-full bg-$b-search-bar-normal-color border-1 border-$bew-border-color";
     --uno: "shadow-[var(--bew-shadow-2),var(--bew-shadow-edge-glow-1)]";
-    backdrop-filter: var(--bew-filter-glass-1);
+    // --b-search-bar-glass 由外部（如顶栏的 slide-out 过渡）覆盖为恒等滤镜，
+    // 让玻璃与透明度动画同步渐变，避免 Chromium 丢弃 backdrop-filter 造成饱和度跳变
+    backdrop-filter: var(--b-search-bar-glass, var(--bew-filter-glass-1));
   }
 
   .search-bar {
@@ -932,6 +934,7 @@ function handleClearKeyword() {
         color var(--bew-duration-normal) var(--bew-ease-standard),
         opacity var(--bew-duration-normal) var(--bew-ease-standard),
         box-shadow var(--bew-duration-normal) var(--bew-ease-standard),
+        backdrop-filter var(--bew-duration-moderate) var(--bew-ease-standard),
         border-radius var(--bew-duration-moderate) var(--bew-ease-standard);
 
       &::placeholder {

--- a/src/components/Settings/PluginComponentsAndPages/Home/Home.vue
+++ b/src/components/Settings/PluginComponentsAndPages/Home/Home.vue
@@ -291,10 +291,100 @@ function handleToggleHomeTab(tab: any) {
     </SettingsItemGroup>
 
     <SettingsItemGroup
+      :title="$t('settings.group_home_tabs')"
+    >
+      <SettingsItem
+        :title="$t('settings.home_tabs_adjustment')"
+        :desc="$t('settings.home_tabs_adjustment_desc')"
+        right-width="auto"
+      >
+        <template #title>
+          <div flex="~ gap-4 items-center">
+            {{ $t('settings.home_tabs_adjustment') }}
+            <Button size="small" type="secondary" @click="resetHomeTabs">
+              <template #left>
+                <div i-mingcute:back-line />
+              </template>
+              {{ $t('common.operation.reset') }}
+            </Button>
+          </div>
+        </template>
+
+        <template #bottom>
+          <draggable
+            v-model="settings.homePageTabVisibilityList"
+            item-key="page"
+            :component-data="{ style: 'display: flex; gap: 0.5rem; flex-wrap: wrap;' }"
+          >
+            <template #item="{ element }">
+              <div
+                class="bew-settings-option--lift"
+                flex="~ gap-2 items-center" p="x-4 y-2" bg="$bew-fill-1" rounded="$bew-radius" cursor-all-scroll
+                duration-300
+                :style="{
+                  background: element.visible ? 'var(--bew-theme-color-20)' : 'var(--bew-fill-1)',
+                  color: element.visible ? 'var(--bew-theme-color)' : 'var(--bew-text-1)',
+                }"
+                @click="handleToggleHomeTab(element)"
+              >
+                {{ $t(mainStore.homeTabs.find(tab => tab.page === element.page)?.i18nKey ?? '') }}
+              </div>
+            </template>
+          </draggable>
+        </template>
+      </SettingsItem>
+      <SettingsItem :title="$t('settings.home_tabs_position')" right-width="auto">
+        <SettingsSegmentedControl
+          v-model="settings.homeTabsPosition"
+          :label="$t('settings.home_tabs_position')"
+          :options="homeTabsPositionOptions"
+        />
+      </SettingsItem>
+      <SettingsItem :title="$t('settings.fixed_home_tabs_on_home_page')" right-width="auto">
+        <Radio v-model="settings.fixedHomeTabsOnHomePage" />
+      </SettingsItem>
+    </SettingsItemGroup>
+
+    <SettingsItemGroup :title="$t('settings.group_search_page_mode')">
+      <SettingsItem :title="$t('settings.use_search_page_mode')" right-width="auto">
+        <Radio v-model="settings.useSearchPageModeOnHomePage" />
+      </SettingsItem>
+      <template v-if="settings.useSearchPageModeOnHomePage">
+        <SettingsItem :title="$t('settings.settings_shared_with_the_search_page')" right-width="auto">
+          <template #desc>
+            <span class="bew-warning-text">{{ $t('settings.settings_shared_with_the_search_page_desc') }}</span>
+          </template>
+          <Button type="secondary" center @click="showSearchPageModeSharedSettings = true">
+            {{ $t('settings.btn.open_settings') }}
+          </Button>
+
+          <Dialog
+            v-if="showSearchPageModeSharedSettings"
+            width="80%"
+            max-width="900px"
+            content-height="64vh"
+            :show-footer="false"
+            :title="$t('settings.settings_shared_with_the_search_page')"
+            append-to-bewly-body
+            @close="showSearchPageModeSharedSettings = false"
+          >
+            <template #desc>
+              <span class="bew-warning-text">{{ $t('settings.settings_shared_with_the_search_page_desc') }}</span>
+            </template>
+
+            <SearchPage />
+          </Dialog>
+        </SettingsItem>
+
+        <SettingsItem :title="$t('settings.search_page_mode_wallpaper_fixed')" right-width="auto">
+          <Radio v-model="settings.searchPageModeWallpaperFixed" />
+        </SettingsItem>
+      </template>
+    </SettingsItemGroup>
+
+    <SettingsItemGroup
       :title="$t('settings.group_recommendation_filters')"
       :desc="$t('settings.group_recommendation_filters_desc')"
-      collapsible
-      default-collapsed
     >
       <SettingsItem
         :title="$t('settings.show_recommendation_filter_risk_warning')"
@@ -427,65 +517,8 @@ function handleToggleHomeTab(tab: any) {
     </SettingsItemGroup>
 
     <SettingsItemGroup
-      :title="$t('settings.group_home_tabs')"
-    >
-      <SettingsItem
-        :title="$t('settings.home_tabs_adjustment')"
-        :desc="$t('settings.home_tabs_adjustment_desc')"
-        right-width="auto"
-      >
-        <template #title>
-          <div flex="~ gap-4 items-center">
-            {{ $t('settings.home_tabs_adjustment') }}
-            <Button size="small" type="secondary" @click="resetHomeTabs">
-              <template #left>
-                <div i-mingcute:back-line />
-              </template>
-              {{ $t('common.operation.reset') }}
-            </Button>
-          </div>
-        </template>
-
-        <template #bottom>
-          <draggable
-            v-model="settings.homePageTabVisibilityList"
-            item-key="page"
-            :component-data="{ style: 'display: flex; gap: 0.5rem; flex-wrap: wrap;' }"
-          >
-            <template #item="{ element }">
-              <div
-                class="bew-settings-option--lift"
-                flex="~ gap-2 items-center" p="x-4 y-2" bg="$bew-fill-1" rounded="$bew-radius" cursor-all-scroll
-                duration-300
-                :style="{
-                  background: element.visible ? 'var(--bew-theme-color-20)' : 'var(--bew-fill-1)',
-                  color: element.visible ? 'var(--bew-theme-color)' : 'var(--bew-text-1)',
-                }"
-                @click="handleToggleHomeTab(element)"
-              >
-                {{ $t(mainStore.homeTabs.find(tab => tab.page === element.page)?.i18nKey ?? '') }}
-              </div>
-            </template>
-          </draggable>
-        </template>
-      </SettingsItem>
-      <SettingsItem :title="$t('settings.home_tabs_position')" right-width="auto">
-        <SettingsSegmentedControl
-          v-model="settings.homeTabsPosition"
-          :label="$t('settings.home_tabs_position')"
-          :options="homeTabsPositionOptions"
-        />
-      </SettingsItem>
-      <SettingsItem :title="$t('settings.fixed_home_tabs_on_home_page')" right-width="auto">
-        <Radio v-model="settings.fixedHomeTabsOnHomePage" />
-      </SettingsItem>
-    </SettingsItemGroup>
-
-    <SettingsItemGroup
       :title="$t('settings.group_following')"
       :desc="$t('settings.group_following_desc')"
-      collapsible
-      default-collapsed
     >
       <SettingsItem :title="$t('settings.use_following_new_layout')" :desc="$t('settings.use_following_new_layout_desc')" right-width="auto">
         <Radio v-model="settings.useFollowingNewLayout" />
@@ -514,43 +547,6 @@ function handleToggleHomeTab(tab: any) {
       <SettingsItem :title="$t('settings.following_filter_dynamic_videos')" :desc="$t('settings.following_filter_dynamic_videos_desc')" right-width="auto">
         <Radio v-model="settings.followingFilterDynamicVideos" />
       </SettingsItem>
-    </SettingsItemGroup>
-
-    <SettingsItemGroup :title="$t('settings.group_search_page_mode')">
-      <SettingsItem :title="$t('settings.use_search_page_mode')" right-width="auto">
-        <Radio v-model="settings.useSearchPageModeOnHomePage" />
-      </SettingsItem>
-      <template v-if="settings.useSearchPageModeOnHomePage">
-        <SettingsItem :title="$t('settings.settings_shared_with_the_search_page')" right-width="auto">
-          <template #desc>
-            <span class="bew-warning-text">{{ $t('settings.settings_shared_with_the_search_page_desc') }}</span>
-          </template>
-          <Button type="secondary" center @click="showSearchPageModeSharedSettings = true">
-            {{ $t('settings.btn.open_settings') }}
-          </Button>
-
-          <Dialog
-            v-if="showSearchPageModeSharedSettings"
-            width="80%"
-            max-width="900px"
-            content-height="64vh"
-            :show-footer="false"
-            :title="$t('settings.settings_shared_with_the_search_page')"
-            append-to-bewly-body
-            @close="showSearchPageModeSharedSettings = false"
-          >
-            <template #desc>
-              <span class="bew-warning-text">{{ $t('settings.settings_shared_with_the_search_page_desc') }}</span>
-            </template>
-
-            <SearchPage />
-          </Dialog>
-        </SettingsItem>
-
-        <SettingsItem :title="$t('settings.search_page_mode_wallpaper_fixed')" right-width="auto">
-          <Radio v-model="settings.searchPageModeWallpaperFixed" />
-        </SettingsItem>
-      </template>
     </SettingsItemGroup>
   </div>
 </template>

--- a/src/components/Settings/PluginComponentsAndPages/Moments/Moments.vue
+++ b/src/components/Settings/PluginComponentsAndPages/Moments/Moments.vue
@@ -260,8 +260,6 @@ const momentsTabsPositionOptions = computed<{ label: string, value: TabsPosition
       :title="$t('settings.group_moments_wanted_users')"
       :desc="$t('settings.group_moments_wanted_users_desc')"
       icon="i-tabler-star-filled"
-      collapsible
-      default-collapsed
     >
       <SettingsItem
         :title="$t('settings.moments_enable_wanted_filter')"
@@ -281,8 +279,6 @@ const momentsTabsPositionOptions = computed<{ label: string, value: TabsPosition
       :title="$t('settings.group_moments_pinned_users')"
       :desc="$t('settings.group_moments_pinned_users_desc')"
       icon="i-tabler-pin-filled"
-      collapsible
-      default-collapsed
     >
       <SettingsItem :title="$t('settings.moments_pinned_users')">
         <template #bottom>

--- a/src/components/Settings/PluginComponentsAndPages/TopBar/TopBarVisualConfig.vue
+++ b/src/components/Settings/PluginComponentsAndPages/TopBar/TopBarVisualConfig.vue
@@ -179,6 +179,22 @@ function toggleChannel(value: string) {
 <template>
   <div class="topbar-settings-groups" :data-settings-title="$t('settings.group_topbar')">
     <SettingsItemGroup
+      :title="$t('settings.topbar_style_settings')"
+      :desc="$t('settings.topbar_style_settings_desc')"
+    >
+      <SettingsItem
+        :title="$t('settings.top_bar_style')"
+        :desc="$t('settings.top_bar_style_desc')"
+        right-width="auto"
+      >
+        <Select v-model="settings.topBarStyle" :options="topBarStyleOptions" w="220px" />
+      </SettingsItem>
+      <SettingsItem :title="$t('settings.show_top_bar_theme_color_gradient')" right-width="auto">
+        <Radio v-model="settings.showTopBarThemeColorGradient" />
+      </SettingsItem>
+    </SettingsItemGroup>
+
+    <SettingsItemGroup
       :title="$t('settings.topbar_display_settings')"
       :desc="$t('settings.topbar_display_settings_desc')"
     >
@@ -374,27 +390,9 @@ function toggleChannel(value: string) {
     </SettingsItemGroup>
 
     <SettingsItemGroup
-      :title="$t('settings.topbar_style_settings')"
-      :desc="$t('settings.topbar_style_settings_desc')"
-    >
-      <SettingsItem
-        :title="$t('settings.top_bar_style')"
-        :desc="$t('settings.top_bar_style_desc')"
-        right-width="auto"
-      >
-        <Select v-model="settings.topBarStyle" :options="topBarStyleOptions" w="220px" />
-      </SettingsItem>
-      <SettingsItem :title="$t('settings.show_top_bar_theme_color_gradient')" right-width="auto">
-        <Radio v-model="settings.showTopBarThemeColorGradient" />
-      </SettingsItem>
-    </SettingsItemGroup>
-
-    <SettingsItemGroup
       :title="$t('settings.group_topbar_pinned_channels')"
       :desc="$t('settings.topbar_pinned_channels_desc')"
       icon="i-tabler:pin-filled"
-      collapsible
-      default-collapsed
     >
       <SettingsItem :title="$t('settings.topbar_pinned_channels_title')">
         <template #title>
@@ -500,7 +498,7 @@ function toggleChannel(value: string) {
 .topbar-section-actions {
   display: flex;
   justify-content: flex-end;
-  padding-top: var(--bew-space-3);
+  padding: var(--bew-space-3) 0 var(--bew-space-4);
 }
 
 .logo-style-picker {

--- a/src/components/Settings/PluginComponentsAndPages/VideoCard/VideoCard.vue
+++ b/src/components/Settings/PluginComponentsAndPages/VideoCard/VideoCard.vue
@@ -226,18 +226,15 @@ function confirmListLayoutBreakpoint() {
     <SettingsItemGroup
       :title="$t('settings.group_video_card_context_menu')"
       :desc="$t('settings.group_video_card_context_menu_desc')"
-      collapsible
     >
       <VideoCardContextMenuEditor />
     </SettingsItemGroup>
 
-    <!-- 阴影设置仅适用于现代布局，默认折叠 -->
+    <!-- 阴影设置仅适用于现代布局 -->
     <SettingsItemGroup
       v-if="isModernLayout"
       :title="$t('settings.video_card_shadow_curve')"
       :desc="$t('settings.video_card_shadow_curve_desc')"
-      collapsible
-      default-collapsed
     >
       <SettingsItem :title="$t('settings.video_card_shadow_curve')" :desc="$t('settings.video_card_shadow_curve_desc')" right-width="auto">
         <ShadowCurveEditor v-model="settings.videoCardShadowCurve" />

--- a/src/components/Settings/Shortcuts/Shortcuts.vue
+++ b/src/components/Settings/Shortcuts/Shortcuts.vue
@@ -357,7 +357,7 @@ function resetAllShortcuts() {
 
     <!-- Configurable Extension Shortcuts -->
     <template v-for="group in configurableShortcutsGroups" :key="group.title">
-      <SettingsItemGroup :title="group.title" collapsible>
+      <SettingsItemGroup :title="group.title">
         <template v-for="shortcutDef in group.shortcuts" :key="shortcutDef.id">
           <SettingsItem :title="shortcutDef.name" :desc="shortcutDef.description" right-width="auto">
             <div class="shortcut-item-config">
@@ -432,11 +432,7 @@ function resetAllShortcuts() {
     </SettingsItemGroup>
 
     <!-- Official Bilibili Shortcuts (Read-only) -->
-    <SettingsItemGroup
-      :title="t('settings.shortcuts.group.official_bilibili')"
-      collapsible
-      default-collapsed
-    >
+    <SettingsItemGroup :title="t('settings.shortcuts.group.official_bilibili')">
       <SettingsItem
         v-for="shortcut in officialShortcuts"
         :key="shortcut.key"

--- a/src/components/Settings/components/SettingsItemGroup.vue
+++ b/src/components/Settings/components/SettingsItemGroup.vue
@@ -1,49 +1,15 @@
 <script setup lang="ts">
-const props = withDefaults(defineProps<{
+defineProps<{
   title?: string
   desc?: string
-  collapsible?: boolean
-  defaultCollapsed?: boolean
   warningDesc?: boolean
   icon?: string
-}>(), {
-  collapsible: false,
-  defaultCollapsed: false,
-  warningDesc: false,
-})
-
-const collapsed = ref(props.defaultCollapsed)
+}>()
 </script>
 
 <template>
   <div class="b-settings-item-group" :data-settings-title="title">
-    <button
-      v-if="collapsible"
-      type="button"
-      class="group-heading"
-      :aria-expanded="!collapsed"
-      @click="collapsed = !collapsed"
-    >
-      <span>
-        <span class="group-title" text="base $bew-text-1" fw-bold>
-          <i v-if="icon" :class="icon" />
-          {{ title }}
-        </span>
-        <span
-          v-if="desc"
-          block text="sm $bew-text-2" fw-normal
-          :class="{ 'warning-desc': warningDesc }"
-        >
-          {{ desc }}
-        </span>
-      </span>
-      <i
-        i-mingcute:down-line
-        class="collapse-icon"
-        :class="{ collapsed }"
-      />
-    </button>
-    <template v-else-if="title || desc">
+    <template v-if="title || desc">
       <p class="group-title" text="base $bew-text-1" fw-bold>
         <i v-if="icon" :class="icon" />
         {{ title }}
@@ -54,7 +20,6 @@ const collapsed = ref(props.defaultCollapsed)
     </template>
 
     <main
-      v-show="!collapsed"
       style="box-shadow: var(--bew-shadow-edge-glow-1), var(--bew-shadow-1);"
       mt-2 px-4 mx--4 rounded="$bew-radius"
       bg="$bew-fill-alt"
@@ -70,27 +35,6 @@ const collapsed = ref(props.defaultCollapsed)
   --uno: "mt-6";
 }
 
-.group-heading {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  color: inherit;
-  text-align: left;
-  cursor: pointer;
-
-  .group-title {
-    transition: color var(--bew-duration-normal) var(--bew-ease-standard);
-  }
-
-  &:hover {
-    .group-title,
-    .collapse-icon {
-      color: var(--bew-theme-color);
-    }
-  }
-}
-
 .group-title {
   display: inline-flex;
   align-items: center;
@@ -100,21 +44,6 @@ const collapsed = ref(props.defaultCollapsed)
 .group-title > i {
   color: var(--bew-theme-color);
   font-size: var(--bew-icon-size-md);
-}
-
-.collapse-icon {
-  width: 20px;
-  height: 20px;
-  flex: 0 0 auto;
-  color: var(--bew-text-2);
-  font-size: var(--bew-icon-size-md);
-  transition:
-    color var(--bew-duration-normal) var(--bew-ease-standard),
-    transform var(--bew-duration-normal) var(--bew-ease-standard);
-
-  &.collapsed {
-    transform: rotate(-90deg);
-  }
 }
 
 .warning-desc {

--- a/src/components/Settings/components/SettingsSectionHeading.vue
+++ b/src/components/Settings/components/SettingsSectionHeading.vue
@@ -1,45 +1,15 @@
 <script setup lang="ts">
-withDefaults(defineProps<{
+defineProps<{
   title: string
   desc?: string
   icon?: string
-  collapsible?: boolean
   warning?: boolean
   badge?: string
-}>(), {
-  collapsible: false,
-})
-
-const collapsed = defineModel<boolean>('collapsed', {
-  default: false,
-})
+}>()
 </script>
 
 <template>
-  <button
-    v-if="collapsible"
-    type="button"
-    class="settings-section-heading settings-section-heading--button"
-    :data-settings-title="title"
-    :aria-expanded="!collapsed"
-    @click="collapsed = !collapsed"
-  >
-    <span v-if="icon" class="settings-section-heading__icon" :class="icon" />
-    <span class="settings-section-heading__content">
-      <h2>
-        {{ title }}
-        <span v-if="badge" class="settings-risk-badge bew-warning-badge">{{ badge }}</span>
-      </h2>
-      <p v-if="desc" :class="{ warning }">{{ desc }}</p>
-    </span>
-    <i
-      i-mingcute:down-line
-      class="settings-section-heading__chevron"
-      :class="{ collapsed }"
-    />
-  </button>
   <header
-    v-else
     class="settings-section-heading"
     :data-settings-title="title"
   >
@@ -73,36 +43,6 @@ const collapsed = defineModel<boolean>('collapsed', {
 
 .settings-section-heading__content {
   min-width: 0;
-}
-
-.settings-section-heading--button {
-  width: 100%;
-  color: inherit;
-  text-align: left;
-  cursor: pointer;
-
-  &:hover {
-    .settings-section-heading__content h2,
-    .settings-section-heading__chevron {
-      color: var(--bew-theme-color);
-    }
-  }
-}
-
-.settings-section-heading__chevron {
-  width: 22px;
-  height: 22px;
-  flex: 0 0 auto;
-  margin-left: auto;
-  color: var(--bew-text-2);
-  font-size: var(--bew-icon-size-md);
-  transition:
-    color var(--bew-duration-normal) var(--bew-ease-standard),
-    transform 0.2s ease;
-
-  &.collapsed {
-    transform: rotate(-90deg);
-  }
 }
 
 h2 {

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -649,7 +649,7 @@ const VideoPageTopBarConfigEnum = VideoPageTopBarConfig
         v-if="topBarStore.showTopBar || isLayoutEditing"
         ref="headerTarget"
         class="top-bar"
-        w="full" transition="opacity duration-300, transform duration-300, background-color duration-300"
+        w="full"
         :class="{
           'hide': hideTopBar && !isLayoutEditing,
           'force-white-icon': forceWhiteIcon,
@@ -690,6 +690,7 @@ const VideoPageTopBarConfigEnum = VideoPageTopBarConfig
   right: 0;
   z-index: 999;
   position: fixed;
+  transition: transform var(--bew-duration-moderate) var(--bew-ease-standard);
 }
 
 .top-bar--solid {
@@ -697,7 +698,8 @@ const VideoPageTopBarConfigEnum = VideoPageTopBarConfig
   box-shadow: var(--bew-top-bar-solid-shadow);
   transition:
     background-color var(--bew-duration-moderate) var(--bew-ease-standard),
-    box-shadow var(--bew-duration-moderate) var(--bew-ease-standard);
+    box-shadow var(--bew-duration-moderate) var(--bew-ease-standard),
+    transform var(--bew-duration-moderate) var(--bew-ease-standard);
 }
 
 .top-bar--solid-force-white {

--- a/src/components/TopBar/TopBar.vue
+++ b/src/components/TopBar/TopBar.vue
@@ -690,13 +690,16 @@ const VideoPageTopBarConfigEnum = VideoPageTopBarConfig
   right: 0;
   z-index: 999;
   position: fixed;
-  transition: transform var(--bew-duration-moderate) var(--bew-ease-standard);
+  transition:
+    opacity var(--bew-duration-moderate) var(--bew-ease-standard),
+    transform var(--bew-duration-moderate) var(--bew-ease-standard);
 }
 
 .top-bar--solid {
   background: var(--bew-top-bar-solid-background);
   box-shadow: var(--bew-top-bar-solid-shadow);
   transition:
+    opacity var(--bew-duration-moderate) var(--bew-ease-standard),
     background-color var(--bew-duration-moderate) var(--bew-ease-standard),
     box-shadow var(--bew-duration-moderate) var(--bew-ease-standard),
     transform var(--bew-duration-moderate) var(--bew-ease-standard);

--- a/src/components/TopBar/components/TopBarHeader.vue
+++ b/src/components/TopBar/components/TopBarHeader.vue
@@ -19,12 +19,15 @@ const props = defineProps<{
   isDark: boolean
 }>()
 
-const { forceWhiteIcon, handleNotificationsItemClick, showSearchBar } = useTopBarInteraction()
+const { forceWhiteIcon, handleNotificationsItemClick } = useTopBarInteraction()
 const { isLayoutEditing } = useLayoutEditMode()
 const { activatedPage } = useBewlyApp()
 const isNarrowLayout = useMediaQuery('(max-width: 767px)')
-const showTopBarSearchEditor = computed(() => showSearchBar.value
-  || (isLayoutEditing.value && activatedPage.value !== AppPage.Search))
+// 搜索控件常驻挂载，显隐交给 TopBarSearch 内部的 Transition 播放动画；
+// 若在此处跟随 showSearchBar 卸载整棵子树，内部的 slide-out 过渡会被同步卸载吞掉。
+// 仅布局编辑模式需要整体隐藏（搜索页本身有搜索框，不展示编辑目标）。
+const showTopBarSearchEditor = computed(() =>
+  !isLayoutEditing.value || activatedPage.value !== AppPage.Search)
 const usesGradientTopBar = computed(() => settings.value.topBarStyle !== 'solid')
 const usesProgressiveFog = computed(() => settings.value.topBarStyle === 'progressiveFog')
 

--- a/src/components/TopBar/components/TopBarHeader.vue
+++ b/src/components/TopBar/components/TopBarHeader.vue
@@ -55,6 +55,24 @@ const progressiveFogTint = computed(() => {
     : fogGradient('255 255 255', 80)
 })
 
+// Chromium 在 opacity 动画期间会丢弃 backdrop-filter（crbug.com/40877283），
+// 因此玻璃遮罩常驻挂载，毛玻璃开启时改用 backdrop-filter 在玻璃与恒等滤镜间插值，
+// 避免滚到顶部/离开顶部时出现饱和度跳变；毛玻璃关闭时本就无滤镜，仍走 opacity 过渡。
+const IDENTITY_BACKDROP_FILTER = 'blur(0px) saturate(100%)'
+const glassOverlayStyle = computed(() => {
+  if (settings.value.enableFrostedGlass) {
+    return {
+      backgroundColor: 'transparent',
+      backdropFilter: props.reachTop ? IDENTITY_BACKDROP_FILTER : 'var(--bew-filter-glass-1)',
+    }
+  }
+  return {
+    backgroundColor: 'var(--bew-bg)',
+    opacity: props.reachTop ? 0 : 0.9,
+    backdropFilter: 'none',
+  }
+})
+
 const leftSection = ref<HTMLElement | null>(null)
 const rightSection = ref<HTMLElement | null>(null)
 const searchSection = ref<HTMLElement | null>(null)
@@ -181,9 +199,8 @@ function refreshSearchContent() {
       class="top-bar-header__progressive-fog"
       :style="{ height: OVERLAY_HEIGHT }"
     >
-      <Transition name="fade">
-        <ProgressiveBlurSurface v-if="!reachTop" />
-      </Transition>
+      <!-- 常驻挂载并在 reachTop 时过渡到恒等滤镜，避免 fade 卸载时饱和度跳变 -->
+      <ProgressiveBlurSurface :inactive="reachTop" />
       <div
         class="top-bar-header__progressive-fog-tint"
         :style="{
@@ -194,23 +211,8 @@ function refreshSearchContent() {
     </div>
 
     <template v-else-if="usesGradientTopBar">
-      <!-- 默认的低开销顶栏遮罩 -->
-      <Transition name="fade">
-        <div
-          v-if="!reachTop"
-          style="
-            mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 1), rgba(0, 0, 0, 1) 24px, rgba(0, 0, 0, 0.9) 44px, transparent);
-            -webkit-mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 1), rgba(0, 0, 0, 1) 24px, rgba(0, 0, 0, 0.9) 44px, transparent);
-          "
-          pos="absolute top-0 left-0" w-full h="$bew-top-bar-height"
-          pointer-events-none
-          :style="{
-            backgroundColor: settings.enableFrostedGlass ? 'transparent' : 'var(--bew-bg)',
-            opacity: settings.enableFrostedGlass ? 1 : 0.9,
-            backdropFilter: settings.enableFrostedGlass ? 'var(--bew-filter-glass-1)' : 'none',
-          }"
-        />
-      </Transition>
+      <!-- 默认的低开销顶栏遮罩：常驻挂载，玻璃与恒等滤镜间插值（见 glassOverlayStyle） -->
+      <div class="top-bar-header__glass-overlay" :style="glassOverlayStyle" />
 
       <div
         pos="absolute top-0 left-0" w-full
@@ -301,6 +303,26 @@ function refreshSearchContent() {
   position: absolute;
   inset: 0;
   transition: opacity var(--bew-duration-moderate) var(--bew-ease-standard);
+}
+
+.top-bar-header__glass-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: var(--bew-top-bar-height);
+  pointer-events: none;
+  mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 1), rgba(0, 0, 0, 1) 24px, rgba(0, 0, 0, 0.9) 44px, transparent);
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 1),
+    rgba(0, 0, 0, 1) 24px,
+    rgba(0, 0, 0, 0.9) 44px,
+    transparent
+  );
+  transition:
+    opacity var(--bew-duration-moderate) var(--bew-ease-standard),
+    backdrop-filter var(--bew-duration-moderate) var(--bew-ease-standard);
 }
 
 .top-bar-header__side {

--- a/src/components/TopBar/styles/index.scss
+++ b/src/components/TopBar/styles/index.scss
@@ -35,6 +35,9 @@
 .slide-out-leave-to,
 .slide-out-enter-from {
   --uno: "transform important:-translate-y-4 opacity-0";
+  // 搜索框自带玻璃滤镜，出场/入场时把滤镜过渡到恒等值，
+  // 与 opacity 动画同步，避免 Chromium 丢弃 backdrop-filter 造成饱和度跳变（crbug.com/40877283）
+  --b-search-bar-glass: blur(0px) saturate(100%);
 }
 
 .fade-enter-active,


### PR DESCRIPTION
## 概述

两组改动：顶栏过渡体验修复（滚动隐藏瞬移、玻璃饱和度跳变、搜索框出入场动画），以及移除设置页的分组折叠功能

## 顶栏修复

### 滚动隐藏时顶栏瞬移
- 根因：header 上 UnoCSS attributify 写法 `transition="opacity duration-300, ..."` 实际从未生成任何 CSS，且 `.top-bar--solid` 的 transition 列表只含 background-color / box-shadow，`.hide` 的 `translateY(-100%)` 一直是瞬移
- 修复：删除无效 attributify 写法，`.top-bar` 显式声明 transform 过渡；solid 变体列表补上 transform

### 首页顶部搜索框玻璃饱和度跳变
- 根因：Chromium 对带 backdrop-filter 的元素做 opacity 动画时会直接丢弃滤镜（crbug.com/40877283）
- 修复：玻璃表面改为常驻挂载，在 `blur(20px) saturate(180%)` ↔ `blur(0px) saturate(100%)`（恒等滤镜）之间插值，与显隐同步过渡；ProgressiveBlurSurface 新增 `inactive` prop，雾化模式 5 层全部插值

### 搜索框出入场动画
- 此前首页 reachTop 时搜索框直接消失，下滑时直接出现
- 现在搜索控件常驻挂载，显隐交给 slide-out：改为纯 transform 整条滑出视口（，玻璃经 `--b-search-bar-glass` 变量与位移同步插值

## 设置页

- 移除所有分组的展开折叠功能；SettingsItemGroup 删除 collapsible / default-collapsed / chevron，SettingsSectionHeading 的折叠分支从未被任何调用方使用，作为死代码一并清理
- 顶栏：样式分组（顶栏样式 + 主题色渐变）移至最前；常驻分区去折叠；重置按钮底部间距与 SettingsItem 对齐
- 首页：「个性推荐」过滤与「正在关注」移至页面末尾
- 动态：想看分组、固定 UP 主去折叠
- 视频卡片：更多菜单、阴影渐变曲线（仅现代布局渲染，既有行为）去折叠
- 快捷键：各分组及官方快捷键去折叠

## 测试
pnpm typecheck 通过
pnpm lint 通过