### PR TITLE
fix(topbar): 统一遮罩浓度并修复顶栏收起时的残留

### DIFF
--- a/src/components/TopBar/components/TopBarHeader.vue
+++ b/src/components/TopBar/components/TopBarHeader.vue
@@ -18,7 +18,7 @@ const props = defineProps<{
   isDark: boolean
 }>()
 
-const { forceWhiteIcon, hasTopBarBackdrop, handleNotificationsItemClick } = useTopBarInteraction()
+const { forceWhiteIcon, hasPageBackdrop, handleNotificationsItemClick } = useTopBarInteraction()
 const { isLayoutEditing } = useLayoutEditMode()
 const { activatedPage } = useBewlyApp()
 const isNarrowLayout = useMediaQuery('(max-width: 767px)')
@@ -63,7 +63,9 @@ const SOLID_OVERLAY_MASK = overlayMask('--overlay-mask-plateau-solid')
 const SCROLLED_SHADE_ALPHA = 0.5
 const GLASS_TINT_ALPHA = 0.1
 
-const fadeGradient = computed(() => forceWhiteIcon.value
+// 雾配方只认「页面自带横幅」：那种底图的亮暗不受主题控制，只能恒用黑雾托住白图标。
+// 不能改认 forceWhiteIcon —— 它在「暗色 + 壁纸」也为真，会让暗色下有无壁纸变成两种配方（#1095）。
+const fadeGradient = computed(() => hasPageBackdrop.value
   ? smoothFade(alpha => `rgb(0 0 0 / ${alpha}%)`, 60)
   : smoothFade(alpha => `color-mix(in oklab, var(--bew-bg), transparent ${+(100 - alpha).toFixed(2)}%)`, 80))
 
@@ -74,13 +76,12 @@ function glassColor(alpha: number) {
   return useDarkGlass.value ? `rgb(0 0 0 / ${alpha})` : `rgb(255 255 255 / ${alpha})`
 }
 
-const scrolledShadeColor = computed(() => glassColor(SCROLLED_SHADE_ALPHA))
 const glassTintColor = computed(() => glassColor(GLASS_TINT_ALPHA))
 
+// 毛玻璃档恒用薄色，不按有无底图分档：分离前景靠的是模糊本身，
+// 再按底图加深会让「有壁纸」和「无壁纸」变成两个浓度（#1095）。
 const frostedOverlayStyle = computed(() => ({
-  backgroundColor: hasTopBarBackdrop.value && !props.reachTop
-    ? scrolledShadeColor.value
-    : glassTintColor.value,
+  backgroundColor: glassTintColor.value,
   backdropFilter: 'var(--bew-filter-glass-1)',
   WebkitBackdropFilter: 'var(--bew-filter-glass-1)',
   maskImage: FROSTED_OVERLAY_MASK,
@@ -88,7 +89,7 @@ const frostedOverlayStyle = computed(() => ({
 }))
 
 const solidOverlayStyle = computed(() => ({
-  backgroundColor: forceWhiteIcon.value ? 'rgb(0 0 0)' : 'var(--bew-bg)',
+  backgroundColor: hasPageBackdrop.value ? 'rgb(0 0 0)' : 'var(--bew-bg)',
   opacity: props.reachTop ? 0 : SCROLLED_SHADE_ALPHA,
   maskImage: SOLID_OVERLAY_MASK,
   WebkitMaskImage: SOLID_OVERLAY_MASK,

--- a/src/components/TopBar/composables/useTopBarInteraction.ts
+++ b/src/components/TopBar/composables/useTopBarInteraction.ts
@@ -103,9 +103,6 @@ export function useTopBarInteraction() {
       && !!settings.value.searchPageWallpaper
   })
 
-  // 顶栏底下压着底图时遮罩要留通透让图透出来；没有底图时遮罩色与页面底色一致，可以铺实。
-  const hasTopBarBackdrop = computed((): boolean => hasPageBackdrop.value || hasWallpaperBackdrop.value)
-
   // 遮罩是深色时图标才需要强制转白：页面底图恒用阴影，壁纸则只在暗色模式下才是黑雾。
   const forceWhiteIcon = computed((): boolean =>
     hasPageBackdrop.value || (hasWallpaperBackdrop.value && isDark.value))
@@ -285,7 +282,7 @@ export function useTopBarInteraction() {
     handleNotificationsItemClick,
     getTopBarItemHref,
     forceWhiteIcon,
-    hasTopBarBackdrop,
+    hasPageBackdrop,
     showSearchBar,
   }
 }

--- a/src/components/TopBar/styles/index.scss
+++ b/src/components/TopBar/styles/index.scss
@@ -1,3 +1,8 @@
+// 顶栏遮罩会越过栏体继续向下渐隐（TopBarHeader 的 SOLID_OVERLAY_MASK 高 64 + 16px）。
+// 遮罩是绝对定位的，不撑高 .top-bar，所以 .top-bar 的高度仍是 var(--bew-top-bar-height)，
+// translateY(-100%) 只退 64px，屏幕顶端会留下遮罩最后 16px（该处强度约 50%）。
+$top-bar-retract: calc(-1 * (var(--bew-top-bar-height) + var(--bew-space-4)));
+
 .top-bar-enter-active,
 .top-bar-leave-active {
   transition:
@@ -7,7 +12,8 @@
 
 .top-bar-enter-from,
 .top-bar-leave-to {
-  --uno: "opacity-0 transform -translate-y-full";
+  opacity: 0;
+  transform: translateY(#{$top-bar-retract});
 }
 
 .slide-in-enter-active,
@@ -51,7 +57,7 @@
 }
 
 .hide {
-  transform: translateY(-100%);
+  transform: translateY(#{$top-bar-retract});
 }
 
 :deep(.search-bar) {


### PR DESCRIPTION
修复 #1095，并顺带修掉一个 62b91b66 带出来的残留。

### 1. 统一遮罩浓度（#1095）

滚动后的遮罩同时从「有没有底图」取**强度**和**雾配方**，导致同一个「已滚动」状态渲染出多种浓度。

#### 毛玻璃档：恒用薄色

`hasTopBarBackdrop && !reachTop ? 0.5 : 0.1` 里「已滚动 + 无底图」这一格没有独立取值，会落回静止态的 0.1。按 issue 里定的 **0.24** 统一，改成恒用 `glassTintColor`——分离前景靠的是模糊本身，不需要再按底图加深。

#### 雾配方：改认 `hasPageBackdrop`

`fadeGradient` 和非毛玻璃档的遮罩底色原本认 `forceWhiteIcon`。但

```
forceWhiteIcon = hasPageBackdrop || (hasWallpaperBackdrop && isDark)
```

后半截让「暗色 + 壁纸」也为真，于是暗色下有壁纸走纯黑 60%、无壁纸走 `--bew-bg` 80%，仍是两种配方。改认 `hasPageBackdrop` 之后，普通页面不分亮暗、不分有无壁纸一律同一配方；空间页/频道页那种自带横幅的仍恒用黑雾托住白图标，`forceWhiteIcon` 继续只管图标转白。

顺带删掉 `hasTopBarBackdrop` 和 `scrolledShadeColor`，改完已无调用方。

**改后全矩阵（滚动后 y=46px 综合覆盖率）**

| | 暗色无壁纸 | 暗色有壁纸 | 亮色无壁纸 | 亮色有壁纸 |
|---|---|---|---|---|
| 毛玻璃开 | 0.232 | 0.232 | 0.232 | 0.232 |
| 毛玻璃关 | 0.653 | 0.653 | 0.653 | 0.653 |

横幅页仍是 0.199 / 0.615，有意保留。

### 2. 顶栏收起时遮罩残留 16px

非毛玻璃档的遮罩是 `64 + 16px`，但它是绝对定位的，不撑高 `.top-bar`——`.top-bar` 的高度仍是 `var(--bew-top-bar-height)`。所以 `translateY(-100%)` 只退 64px，遮罩最后 16px 会留在屏幕顶端，那处 mask 强度约 50%，叠 `opacity: 0.5` 后约 30% 覆盖。

改成按遮罩真实高度回退，enter/leave 过渡同步。

**复现**：视频页顶栏设为「鼠标移入时显示」，鼠标移开等顶栏收起，看屏幕最上沿，深色页面最明显。

### 验证

`lint` / `typecheck` / `build` 全绿。浏览器实测（首页、亮色、关毛玻璃）：

| | `.top-bar` 顶 | 遮罩底边 | 视口内残留 |
|---|---|---|---|
| 修复后 | −80 | 0 | **0px** |
| 修复前 | −64 | 16 | **16px** |

收起→展开来回各两次，`0 → −80 → 0 → −80 → 0`，展开态 `transform` 回到 `none`，无卡死。

---