### PR TITLE
fix(player-control): 控制栏按钮鼠标点击不再聚焦，避免空格重复触发

### DIFF
--- a/src/contentScripts/bewlyWidescreenControl.ts
+++ b/src/contentScripts/bewlyWidescreenControl.ts
@@ -122,6 +122,10 @@ function createControlContainer(): HTMLElement {
   icon.appendChild(iconWrapper)
   container.append(icon, tooltip)
 
+  // 鼠标点击不聚焦按钮：否则焦点残留，之后按空格/回车会再次触发切换
+  container.addEventListener('mousedown', (event) => {
+    event.preventDefault()
+  })
   container.addEventListener('click', (event) => {
     event.preventDefault()
     event.stopPropagation()

--- a/src/contentScripts/videoScreenshotControl.ts
+++ b/src/contentScripts/videoScreenshotControl.ts
@@ -167,6 +167,10 @@ function createControlContainer(): HTMLElement {
   icon.appendChild(iconWrapper)
   container.appendChild(icon)
 
+  // 鼠标点击不聚焦按钮：否则焦点残留，之后按空格/回车会再次触发截图
+  container.addEventListener('mousedown', (event) => {
+    event.preventDefault()
+  })
   container.addEventListener('click', () => {
     void captureCurrentFrame(container)
   })


### PR DESCRIPTION
截图与宽屏两个自定义按钮（div[role=button][tabindex=0]）被鼠标点击后焦点残留，
之后按空格/回车会再次触发截图或宽屏切换。
在 mousedown 上阻止默认聚焦，鼠标操作不再留下焦点；
键盘用户仍可通过 Tab 聚焦，空格/回车激活不受影响。