### PR TITLE
fix(settings): 修复设置窗顶缘细线与毛玻璃强度滑块失效

### DIFF
--- a/src/components/Settings/Settings.vue
+++ b/src/components/Settings/Settings.vue
@@ -607,8 +607,8 @@ function changeMenuItem(menuItem: MenuType) {
         <div
           ref="scrollViewportRef"
           :style="{
-            maskImage: settings.enableFrostedGlass ? 'linear-gradient(to bottom, transparent 0%, black 92px 30%)' : 'none',
-            WebkitMaskImage: settings.enableFrostedGlass ? 'linear-gradient(to bottom, transparent 0%, black 92px 30%)' : 'none',
+            maskImage: settings.enableFrostedGlass ? 'linear-gradient(to bottom, transparent 0%, black 92px 30%)' : 'linear-gradient(to bottom, transparent 0%, black 55px, black 100%)',
+            WebkitMaskImage: settings.enableFrostedGlass ? 'linear-gradient(to bottom, transparent 0%, black 92px 30%)' : 'linear-gradient(to bottom, transparent 0%, black 55px, black 100%)',
             scrollbarGutter: 'stable',
             overflowAnchor: 'none',
             overscrollBehavior: 'contain',

--- a/src/components/Slider.vue
+++ b/src/components/Slider.vue
@@ -12,6 +12,12 @@ const props = withDefaults(defineProps<Props>(), {
 const modelValue = defineModel<number>({ required: true })
 const rangeRef = ref<HTMLInputElement | null>(null)
 
+// 原生 input 的 v-model 写入的是字符串，存储层的 Number.isFinite 校验
+// 会把它当非法值重置回默认（毛玻璃强度即因此失效）。这里统一转成数字。
+function onInput(event: Event) {
+  modelValue.value = Number((event.currentTarget as HTMLInputElement).value)
+}
+
 function updateBackground() {
   const range = rangeRef.value
   if (!range)
@@ -30,9 +36,10 @@ onMounted(updateBackground)
   <label cursor-pointer flex items-center gap-3 w="$b-slider-width">
     <input
       ref="rangeRef"
-      v-model="modelValue" type="range" :min="min" :max="max" class="slider"
+      :value="modelValue" type="range" :min="min" :max="max" class="slider"
       appearance-none outline-none bg="$bew-fill-1" rounded="$b-slider-height"
       border="size-$b-border-width color-$bew-border-color" w="$b-slider-width" h="$b-slider-height"
+      @input="onInput"
     >
     <span>{{ label }}</span>
   </label>

--- a/src/contentScripts/index.ts
+++ b/src/contentScripts/index.ts
@@ -1195,6 +1195,7 @@ else if (shouldInitializeContentScript) {
   }
 
   function injectApp() {
+    const isDev = import.meta.env.DEV
     const bewlyElArr: NodeListOf<Element> = document.querySelectorAll('#bewly')
     if (bewlyElArr.length > 0) {
       bewlyElArr.forEach((el: Element) => {
@@ -1204,8 +1205,10 @@ else if (shouldInitializeContentScript) {
         // Remove bewly element if the version is less than the current version
         if (compareVersions(elVersion, version) < 0)
           disposeBewlyHost(el)
-        // Only the development mode element remains
-        else if (!elIsDev)
+        // 同模式重复注入的旧宿主已过期：dev 不清除会越堆越多，
+        // watcher 的 querySelector('#bewly') 命中陈旧的第一个宿主，
+        // 内联 CSS 变量（如 --bew-filter-glass-1 毛玻璃强度）到不了实际渲染的宿主。
+        else if (!elIsDev || isDev)
           disposeBewlyHost(el)
       })
     }


### PR DESCRIPTION
  内容（body）：
  ## 修复内容

  ### 1. 实色模式下设置窗顶缘细线

  - 毛玻璃关闭时滚动视口没有 mask，`<main>` 内容（描述文字、按钮）在 Header 遮盖层边缘露出，被压成 ≤5px 的细横线
  - 修复：实色模式给滚动视口补上顶部淡入 mask（`linear-gradient(to bottom, transparent 0%, black 55px, black
  100%)`），内容在顶部 55px 内渐进透明，毛玻璃分支保持不变
<img width="1155" height="491" alt="image" src="https://github.com/user-attachments/assets/ae7c9193-cc2f-4ad2-9982-d0def7c08f91" />

  ### 2. 毛玻璃模糊强度滑块失效
  - 根因：`fix(slider): 同步外部值与填充进度` 重构后，原生 `<input>` 的 `v-model` 向数字设置写入**字符串**（如
  `"5"`），存储层迁移校验 `Number.isFinite("5")` 返回 false，每次拖动都被重置回默认值 20 ——
  表现为毛玻璃效果正常但强度不可调
  - 修复：Slider 写入前统一 `Number()` 转换，恢复数值语义（v1.7.6 行为），同时修复所有受影响的数字滑块（壁纸模糊强度等）

  ### 3. 顺带修复
  - dev 模式下重复注入的 `#bewly` 宿主不再累积，避免 watcher 把 CSS 变量写到陈旧宿主导致设置不生效