### PR TITLE
style(settings): 规范settings-category-nav

### DIFF
--- a/src/components/Settings/components/SettingsCategoryLayout.vue
+++ b/src/components/Settings/components/SettingsCategoryLayout.vue
@@ -168,16 +168,16 @@ function handlePageMouseDown(event: MouseEvent) {
   line-height: var(--bew-line-height-body);
   overflow-anchor: none;
   transition:
-    background-color 0.2s ease,
-    color 0.2s ease;
+    background-color var(--bew-duration-normal) var(--bew-ease-standard),
+    color var(--bew-duration-normal) var(--bew-ease-standard);
 
-  &:hover {
+  &:hover:not(.active) {
     background: var(--bew-fill-2);
   }
 
   &.active {
-    color: var(--bew-theme-color);
-    background: var(--bew-fill-3);
+    color: var(--bew-text-auto);
+    background: var(--bew-theme-color-auto);
   }
 
   > span:last-child {


### PR DESCRIPTION
## 问题

设置页二级分类导航（`settings-category-nav`）的激活态不规范，而且是唯一一处在上面还要变色的，亮暗两种模式下对比度都不足，可读性差

## 修改

- active 改用 `--bew-theme-color-auto` 实色底 + `--bew-text-auto` 文字（亮色黑底白字 / 暗色白底黑字），与设置主导航的 `menu-item-activated` 保持同一规范；图标为字体图标自动跟随翻转
- hover 改为 `:hover:not(.active)`，激活项不再被 hover 重新着色
- transition 时长/缓动改用 `--bew-duration-normal` / `--bew-ease-standard` token，替换裸写 `0.2s ease`