### PR TITLE
feat(video-card): 按照 Pop 规范重新设计右键菜单并加入入场动画

### DIFF
--- a/src/components/MomentCard/MomentCard.vue
+++ b/src/components/MomentCard/MomentCard.vue
@@ -258,11 +258,11 @@ function handleMoreBtnClick(event: Event) {
   showVideoOptions.value = false
   videoOptionsFloatingStyles.value = {
     position: 'fixed',
-    top: `${position.top}px`,
+    top: position.top,
+    bottom: position.bottom,
     left: `${position.left}px`,
     width: `${position.width}px`,
     maxHeight: `${position.maxHeight}px`,
-    transform: position.transform,
   }
   showVideoOptions.value = true
 }
@@ -1719,7 +1719,6 @@ function handleAdditionalClick(event: MouseEvent) {
 
 .moment-card__more-btn.is-open {
   color: var(--bew-text-1);
-  background: var(--bew-fill-2);
 }
 
 .moment-card__more-btn:active {

--- a/src/components/VideoCard/VideoCardContextMenu/VideoCardContextMenu.vue
+++ b/src/components/VideoCard/VideoCardContextMenu/VideoCardContextMenu.vue
@@ -29,6 +29,10 @@ const emit = defineEmits<{
   (event: 'close'): void
   (event: 'reopen'): void
 }>()
+
+// styles 带 bottom（无 top）即向上展开，缩放原点随之翻转到锚点下缘
+const opensUpward = computed(() => props.contextMenuStyles.bottom !== undefined && props.contextMenuStyles.top === undefined)
+
 // 添加滚动相关的变量和方法
 const menuListRef = ref<HTMLElement | null>(null)
 const canScrollUp = ref(false)
@@ -525,13 +529,15 @@ async function unfollowUser() {
 <template>
   <div>
     <!-- more popup -->
-    <div v-if="showContextMenu">
+    <Transition name="context-menu" appear>
       <div
-        style="backdrop-filter: var(--bew-filter-glass-1); box-shadow: var(--bew-shadow-edge-glow-1), var(--bew-shadow-1);"
+        v-if="showContextMenu"
+        style="backdrop-filter: var(--b-context-menu-glass, var(--bew-filter-glass-1)); box-shadow: var(--bew-shadow-edge-glow-1), var(--bew-shadow-1);"
         :style="contextMenuStyles"
-        p-1 bg="$bew-elevated"
-        border="1 $bew-border-color"
         class="context-menu-container"
+        :class="opensUpward && 'context-menu-container--up'"
+        p-2 bg="$bew-elevated"
+        border="1 $bew-popover-border-color"
       >
         <button
           v-show="canScrollUp"
@@ -622,16 +628,18 @@ async function unfollowUser() {
           <i class="i-mingcute:down-line" aria-hidden="true" />
         </button>
       </div>
-    </div>
+    </Transition>
 
     <!-- mask -->
-    <div
-      v-if="showContextMenu"
-      pos="fixed top-0 left-0" w-full h-full
-      style="z-index: 9998;"
-      @click="handleClose"
-      @click.right.prevent.stop="handleReopen"
-    />
+    <Transition name="fade">
+      <div
+        v-if="showContextMenu"
+        pos="fixed top-0 left-0" w-full h-full
+        style="z-index: 9998;"
+        @click="handleClose"
+        @click.right.prevent.stop="handleReopen"
+      />
+    </Transition>
 
     <DislikeDialog
       v-if="showDislikeDialog"
@@ -674,13 +682,31 @@ async function unfollowUser() {
 </template>
 
 <style lang="scss" scoped>
+// Chromium 在 opacity/transform 动画期间会丢弃 backdrop-filter（crbug.com/40877283），
+// 故玻璃与缩放同步插值到恒等滤镜，避免动画结束才出现毛玻璃
+.context-menu-enter-active,
+.context-menu-leave-active {
+  transition:
+    opacity var(--bew-duration-fast) var(--bew-ease-standard),
+    transform var(--bew-duration-fast) var(--bew-ease-standard),
+    backdrop-filter var(--bew-duration-fast) var(--bew-ease-standard);
+}
+
+.context-menu-enter-from,
+.context-menu-leave-to {
+  --b-context-menu-glass: blur(0px) saturate(100%);
+
+  opacity: 0;
+  transform: scale(0.9);
+}
+
 .context-menu-item {
   --uno: "hover:bg-$bew-fill-2 rounded-$bew-menu-item-radius cursor-pointer";
-  --uno: "flex items-center";
+  --uno: "flex items-center transition-colors duration-200 ease-$bew-ease-standard";
 
   width: 100%;
   min-height: 32px;
-  padding: var(--bew-space-2);
+  padding: var(--bew-space-2) var(--bew-space-3) var(--bew-space-2) var(--bew-space-2);
   border: 0;
   color: inherit;
   background: transparent;
@@ -693,11 +719,13 @@ async function unfollowUser() {
 .item-icon {
   --uno: "inline-block color-$bew-text-color-2";
 
-  margin-right: var(--bew-space-2);
+  margin-right: var(--bew-space-3);
 }
 
 .divider {
-  --uno: "w-full h-1px px-2px bg-$bew-border-color";
+  --uno: "w-full h-1px bg-$bew-border-color";
+
+  margin: var(--bew-space-1) 0;
 }
 
 .context-menu-container {
@@ -705,10 +733,15 @@ async function unfollowUser() {
   display: flex;
   flex-direction: column;
   width: min(240px, calc(100vw - var(--bew-space-4)));
-  max-height: min(406px, calc(100vh - var(--bew-space-4)));
+  transform-origin: top right; // 菜单右缘对齐按钮右缘，右上角即按钮位置
+  max-height: min(480px, calc(100vh - var(--bew-space-4))); // 与 floatingMenu.ts 的 preferredMaxHeight 同步
   overflow: hidden;
   z-index: 9999;
   border-radius: var(--bew-popover-radius);
+}
+
+.context-menu-container--up {
+  transform-origin: bottom right;
 }
 
 .context-menu-list {
@@ -716,7 +749,6 @@ async function unfollowUser() {
   min-height: 0;
   overflow-y: auto;
   overscroll-behavior: contain;
-  padding: var(--bew-space-1) 0;
   margin: 0;
   list-style: none;
 

--- a/src/components/VideoCard/composables/useVideoCardLogic.ts
+++ b/src/components/VideoCard/composables/useVideoCardLogic.ts
@@ -417,11 +417,11 @@ export function useVideoCardLogic(propsOrGetter: MaybeRefOrGetter<VideoCardProps
     showVideoOptions.value = false
     videoOptionsFloatingStyles.value = {
       position: 'fixed',
-      top: `${position.top}px`,
+      top: position.top,
+      bottom: position.bottom,
       left: `${position.left}px`,
       width: `${position.width}px`,
       maxHeight: `${position.maxHeight}px`,
-      transform: position.transform,
     }
     showVideoOptions.value = true
   }

--- a/src/utils/floatingMenu.ts
+++ b/src/utils/floatingMenu.ts
@@ -12,7 +12,8 @@ export function computeFloatingMenuPosition(
   const availableWidth = Math.max(0, viewportWidth - inset * 2)
   const availableHeight = Math.max(0, viewportHeight - inset * 2)
   const width = Math.min(240, availableWidth)
-  const preferredMaxHeight = Math.min(406, availableHeight)
+  // 默认选项集完整展开约 470px；需与 VideoCardContextMenu 的 max-height 同步
+  const preferredMaxHeight = Math.min(480, availableHeight)
   const left = clamp(anchor.right - width, inset, Math.max(inset, viewportWidth - width - inset))
 
   const spaceBelow = Math.max(0, viewportHeight - inset - anchor.bottom - gap)
@@ -23,10 +24,8 @@ export function computeFloatingMenuPosition(
   // Anchor upward-opening menus by their bottom edge. Their actual height varies
   // with the visible option count, so subtracting the maximum height here would
   // leave an increasingly large gap as options are hidden.
-  const top = openBelow
-    ? anchor.bottom + gap
-    : anchor.top - gap
-  const transform = openBelow ? undefined : 'translateY(-100%)'
+  const top = openBelow ? `${anchor.bottom + gap}px` : undefined
+  const bottom = openBelow ? undefined : `${viewportHeight - anchor.top + gap}px`
 
-  return { left, top, width, maxHeight, transform }
+  return { left, top, bottom, width, maxHeight }
 }


### PR DESCRIPTION
## 概述

视频卡右键菜单（动态页三点菜单共享同一组件）此前设计语言割裂，本 PR 统一规范并补齐动效。以下部分是AI写的，不过都测试过

## 菜单本体（VideoCardContextMenu）

- **密度**：容器 padding 4→8px（`--bew-popover-padding`），同心圆公式（16−8=8px）自动成立，菜单项圆角与顶栏 Pop 一致
- **边框**：`$bew-border-color` → `$bew-popover-border-color`（玻璃表面专用）
- **hover**：菜单项补 200ms 颜色过渡；间距对齐 UploadPop 菜单项节奏（图标右 12px、右 padding 12px）
- **入场/出场动画**：150ms `scale(0.9) → 1`，`transform-origin` 设在按钮位置（右上角），向上展开时自动翻转为右下角；遮罩复用全局 fade
- **毛玻璃同步渐显**：backdrop-filter 插值到恒等滤镜（`blur(0) saturate(100%)`），规避 Chromium 在 opacity/transform 动画期间丢弃 backdrop-filter 导致的"动画结束玻璃才出现"（crbug.com/40877283），与顶栏/搜索框的既有处理一致
- **高度**：上限 406→480px，默认选项集（约 470px）不再必然滚动；视口不足仍按可用空间收缩

## 定位（floatingMenu）

- 向上展开从 `top + translateY(-100%)` 改为 `bottom` 定位——几何等价，但腾出 transform 通道给动画（原内联 transform 会覆盖动画帧）

## 动态页（MomentCard）

三点按钮 hover/active 对齐视频卡 more-btn 规范（hover fill-2 / active fill-3 / 打开仅图标变色）

## 测试

- 动态页与视频卡右键：菜单从按钮位置缩放展开，玻璃全程渐显，默认选项集无滚动条
- 页面底部卡片（向上展开）动画方向正确翻转
- 窄窗口下仍正确收缩与滚动
- 亮色/暗色模式均验证