### PR TITLE
fix(topbar): 修复点击顶栏开新标签返回后弹窗残留自动重开的问题

### DIFF
--- a/src/components/TopBar/composables/useTopBarInteraction.ts
+++ b/src/components/TopBar/composables/useTopBarInteraction.ts
@@ -42,7 +42,7 @@ function getConfiguredPageUrl(page: AppPage): string {
 export function useTopBarInteraction() {
   const topBarStore = useTopBarStore()
   const { closeAllPopups } = topBarStore
-  const topBarItemElements: Partial<Record<TopBarPopupKey, Ref<HTMLElement | undefined>>> = {}
+  const topBarItemElements: Partial<Record<TopBarPopupKey, Ref<HTMLElement | undefined> & { reset?: () => void }>> = {}
   const topBarTransformers = reactive<Partial<Record<TopBarPopupKey, Ref<any>>>>({})
 
   const isMouseOverPopup = reactive<Record<string, boolean>>({})
@@ -293,6 +293,9 @@ export function useTopBarInteraction() {
     handledClickEvents.add(event)
     event.preventDefault()
     event.stopPropagation()
+    // 点击将打开新标签页：先复位该 hover 实例（清 pending enter timer 并关闭
+    // 已打开弹窗），避免新标签聚焦、原标签失焦后定时器在后台触发把弹窗重新打开。
+    topBarItemElements[key]?.reset?.()
     closeAllPopups()
     openConfiguredPageFromTopBar(page)
   }

--- a/src/composables/useDelayedHover.ts
+++ b/src/composables/useDelayedHover.ts
@@ -1,18 +1,28 @@
+import { useEventListener } from '@vueuse/core'
+import type { Ref } from 'vue'
+
 import { settings } from '~/logic'
 
 // Hover and focus-triggered opening are disabled when touchscreen optimization is enabled.
 export function useDelayedHover({ enterDelay = 300, leaveDelay = 300, beforeEnter, enter, beforeLeave, leave }:
 { enterDelay?: number, leaveDelay?: number, beforeEnter?: () => void, enter: () => void, beforeLeave?: () => void, leave: () => void }) {
-  const el = ref<HTMLElement>()
+  const el = ref<HTMLElement>() as Ref<HTMLElement | undefined> & { reset: () => void }
 
   let enterTimer: any | undefined
   let leaveTimer: any | undefined
   let focusWithin = false
   let mouseWithin = false
+  let isEntered = false
   // 区分焦点来源：鼠标点击弹窗内容也会把焦点落进去（focusin 冒泡到容器），
   // 若算作焦点驻留，移出后关闭逻辑会被 focusWithin 卡住，需要再点一下才能收起。
   // 只有非指针触发的焦点（键盘 Tab 等）才维持弹窗打开。
   let lastPointerDownAt = 0
+  // 切回标签页时浏览器会恢复失焦前的焦点并向该元素派发 focusin（实测与
+  // window:focus 同任务、间隔约 1ms），这不是键盘驻留，却会把弹窗重新打开。
+  // 用 restoringWindowFocus 标记过滤这批焦点事件：window:focus 时置位，
+  // 渲染一帧后自动过期 —— 恢复焦点的 focusin 必然落在同帧内，而真实键盘
+  // Tab 聚焦发生在人手操作的时间尺度上，远晚于一帧。
+  let restoringWindowFocus = false
 
   function clearHoverTimers() {
     if (enterTimer) {
@@ -38,6 +48,7 @@ export function useDelayedHover({ enterDelay = 300, leaveDelay = 300, beforeEnte
       leaveTimer = undefined
     }
     enterTimer = setTimeout(() => {
+      isEntered = true
       enter()
     }, enterDelay)
   }
@@ -57,8 +68,24 @@ export function useDelayedHover({ enterDelay = 300, leaveDelay = 300, beforeEnte
       leaveTimer = undefined
     }
     leaveTimer = setTimeout(() => {
+      isEntered = false
       leave()
     }, leaveDelay)
+  }
+
+  // 主动复位该 hover 实例：清掉 pending enter/leave timer、回到 idle、关闭已打开弹窗。
+  // 幂等，可重复调用。
+  // focusWithin 承担键盘/焦点语义（键盘 Tab 驻留弹窗），不属于 hover 的 transient
+  // 状态，reset() 不清除它，避免破坏键盘驻留。
+  function reset() {
+    clearHoverTimers()
+    mouseWithin = false
+    if (isEntered) {
+      isEntered = false
+      if (beforeLeave)
+        beforeLeave()
+      leave()
+    }
   }
 
   function handleMouseEnter() {
@@ -81,6 +108,10 @@ export function useDelayedHover({ enterDelay = 300, leaveDelay = 300, beforeEnte
   function handleFocusIn() {
     // pointerdown 后紧随的 focusin 是点击顺带产生的，不算键盘驻留
     if (Date.now() - lastPointerDownAt < 200)
+      return
+
+    // 切回标签页时浏览器恢复焦点派发的 focusin 也不算键盘驻留
+    if (restoringWindowFocus)
       return
 
     focusWithin = true
@@ -136,6 +167,22 @@ export function useDelayedHover({ enterDelay = 300, leaveDelay = 300, beforeEnte
   }, { immediate: true })
 
   onScopeDispose(clearHoverTimers)
+
+  // 页面失焦（如点击打开新标签、切换到其它窗口）是交互生命周期边界：复位 hover 状态，
+  // 避免 pending enter timer 在后台标签触发把弹窗重新打开，或已打开的弹窗残留到下次聚焦。
+  // VueUse useEventListener 随组件 scope 自动清理，不会重复注册。
+  useEventListener(window, 'blur', reset)
+
+  // 标记窗口正在恢复焦点：本帧内到达的 focusin 是浏览器自动恢复的焦点，
+  // 不代表键盘驻留（见 restoringWindowFocus 注释）。渲染一帧后标记过期。
+  useEventListener(window, 'focus', () => {
+    restoringWindowFocus = true
+    requestAnimationFrame(() => {
+      restoringWindowFocus = false
+    })
+  })
+
+  el.reset = reset
 
   return el
 }


### PR DESCRIPTION
**问题**

点击顶栏图标打开新标签页并返回原标签后，之前的弹窗会残留，或被后台挂起的 hover enter 定时器重新触发打开。

**修复**

- `useDelayedHover` 新增幂等的 `reset()` 方法：清除 pending 的 enter/leave 定时器，若弹窗处于打开状态则主动关闭。保留 `focusWithin`（键盘 Tab 驻留语义）不受影响。
- 监听 `window: blur` 事件，在页面失焦（如打开新标签）时自动调用 `reset()`。
- 监听 `window: focus` 事件，标记一帧内的 `focusin` 为浏览器自动恢复焦点，避免被误判为键盘 Tab 驻留而重新打开弹窗。
- `useTopBarInteraction` 中点击顶栏项打开新标签时，主动调用对应实例的 `reset()`。

**影响范围**

`src/composables/useDelayedHover.ts`、`src/components/TopBar/composables/useTopBarInteraction.ts`