### PR TITLE
fix(home): 为推荐过滤结果为空时增加提示

### DIFF
--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -1135,6 +1135,7 @@ home:
   app_authorization_required: App 模式的 access token 已缺失或过期，请重新授权后继续使用个性推荐
   reauthorize_app: 重新授权
   recommendation_filter_risk_warning: 当前过滤条件在 100 条有效推荐中仅保留了 {count} 条，容易频繁请求并触发接口风控，建议适当放宽过滤条件。
+  recommendation_filters_empty: 当前过滤条件下暂时没有可显示的视频。
   tell_us_why: 为什么这么做...
   not_interested_desc: >
     你可以使用 <kbd>↑</kbd> 和 <kbd>↓</kbd> 来选择原因，或者直接使用数字键选择原因，按 <kbd>Enter</kbd>

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -1150,6 +1150,7 @@ home:
   app_authorization_required: App 模式的 access token 已遺失或過期，請重新授權後繼續使用個人化推薦
   reauthorize_app: 重新授權
   recommendation_filter_risk_warning: 目前過濾條件在 100 條有效推薦中只保留了 {count} 條，容易頻繁請求並觸發介面風控，建議適度放寬過濾條件。
+  recommendation_filters_empty: 目前過濾條件下暫時沒有可顯示的影片。
   tell_us_why: 為什麼這樣做...
   not_interested_desc: >
     你可以用 <kbd>↑</kbd> 和 <kbd>↓</kbd> 來選擇原因，或者直接使用數字鍵來選擇原因，按 <kbd>Enter</kbd>

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -1232,6 +1232,7 @@ home:
   app_authorization_required: The App mode access token is missing or expired. Re-authorize to continue using personalized recommendations.
   reauthorize_app: Re-authorize
   recommendation_filter_risk_warning: The current filters retained only {count} of 100 valid recommendations. This may cause frequent requests and trigger API risk control. Consider relaxing the filters.
+  recommendation_filters_empty: No videos are currently available with the active recommendation filters.
   tell_us_why: Choose a reason why
   not_interested_desc: >-
     You can use <kbd>↑</kbd> and <kbd>↓</kbd> to choose the reason, or using

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -1150,6 +1150,7 @@ home:
   app_authorization_required: App 模式嘅 access token 已經遺失或者過期，請重新授權之後再繼續使用個人化推介
   reauthorize_app: 重新授權
   recommendation_filter_risk_warning: 而家嘅過濾條件喺 100 條有效推介入面淨係留低 {count} 條，容易造成頻繁請求並觸發接口風控，建議放寬過濾條件。
+  recommendation_filters_empty: 而家嘅過濾條件下暫時冇影片可以顯示。
   tell_us_why: 點解噉做...
   not_interested_desc: >
     你可以用 <kbd>↑</kbd> 同 <kbd>↓</kbd> 嚟揀個理由，抑或用數字鍵嚟直接揀理由，撳 <kbd>Enter</kbd>

--- a/src/contentScripts/views/Home/components/ForYou.vue
+++ b/src/contentScripts/views/Home/components/ForYou.vue
@@ -253,6 +253,13 @@ const filteredFeedRetentionRate = computed(() => filteredFeedCandidateCount.valu
 const requiresManualFilteredPaging = computed(() => hasActiveRecommendationFilter.value
   && filteredFeedCandidateCount.value >= FILTERED_FEED_SAMPLE_SIZE
   && filteredFeedRetentionRate.value < FILTERED_FEED_MIN_RETENTION_RATE)
+const showFilteredEmptyState = computed(() => hasActiveRecommendationFilter.value
+  && filteredFeedCandidateCount.value > 0
+  && currentVideoList.value.length === 0
+  && !isLoading.value
+  && !requestFailed.value
+  && !needToLoginFirst.value
+  && !noMoreContent.value)
 
 const recommendationFilterSettingsSignature = computed(() => JSON.stringify([
   settings.value.disableFilterForFollowedUser,
@@ -1678,7 +1685,7 @@ defineExpose({
 <template>
   <div>
     <VideoCardGrid
-      v-if="!needToLoginFirst"
+      v-if="!needToLoginFirst && !showFilteredEmptyState"
       :items="currentVideoList"
       :grid-layout="gridLayout"
       :loading="isLoading"
@@ -1697,8 +1704,21 @@ defineExpose({
       @load-more="handleLoadMore"
     />
 
+    <Empty
+      v-if="showFilteredEmptyState"
+      mt-6
+      :description="$t('home.recommendation_filters_empty')"
+    >
+      <Button type="primary" @click="handleManualLoadMore">
+        <template #left>
+          <span i-tabler-arrow-down />
+        </template>
+        {{ $t('common.load_more') }}
+      </Button>
+    </Empty>
+
     <div
-      v-if="requiresManualFilteredPaging && !isLoading && !noMoreContent"
+      v-if="requiresManualFilteredPaging && !showFilteredEmptyState && !isLoading && !noMoreContent"
       class="filtered-feed-load-more"
     >
       <Button type="secondary" @click="handleManualLoadMore">

--- a/src/contentScripts/views/Home/components/ForYou.vue
+++ b/src/contentScripts/views/Home/components/ForYou.vue
@@ -843,12 +843,9 @@ async function initData() {
   appConsecutiveEmptyLoads.value = 0 // 重置APP模式空加载计数器
   requestFailed.value = false // 重置请求失败状态
   needToLoginFirst.value = false
-  try {
-    await getData('refresh')
-  }
-  finally {
-    hasInitializedData.value = true
-  }
+  // 先允许 Grid 接管后续预加载，避免首批稀疏结果在 loading 结束时触发的 loadMore 被初始化守卫丢弃。
+  hasInitializedData.value = true
+  await getData('refresh')
 }
 
 async function getData(webRequestType: WebRecommendRequestType = 'refresh') {


### PR DESCRIPTION
## 改动说明

- 当个性推荐启用了过滤条件、接口已返回有效候选项，但所有候选项都被过滤掉时，显示明确的空状态，而不是留下空白内容区域。
- 空状态提供“加载更多”按钮，继续请求下一批推荐，同时保留现有的手动加载与风控保护逻辑。
- 调整初始化标记的时序，让首批只保留少量卡片时，`VideoCardGrid` 在 loading 结束后触发的预加载不会被初始化守卫丢弃。
- 避免空状态与低留存率下已有的“加载更多”按钮重复显示。
- 补充简体中文、繁体中文、英文和粤语文案。

## 根因

当前过滤分页策略会在存在活动过滤条件时关闭 `ForYou` 的递归补页，交给 `VideoCardGrid` 的预加载或低留存率下的手动分页继续请求。这里存在两个边界情况：

1. **首批为零卡片**：`VideoCardGrid.canLoadMore()` 要求 `items.length > 0`，因此无法发起下一次预加载；候选计数也无法达到显示原有手动加载按钮所需的 100 条，页面进入无提示、无恢复入口的死锁状态。
2. **首批只有少量卡片**：loading 结束后 Grid 会尝试预加载，但此时 `initData()` 仍未在 `finally` 中把 `hasInitializedData` 设为 `true`，该次 `loadMore` 会被父组件守卫丢弃；当 sentinel 一直处于相交状态时，也不一定会再次触发。

本 PR 为零结果提供明确提示和用户主动加载入口，并在初始请求开始前开放 Grid 的预加载守卫，使少量结果可以沿用项目现有的预加载策略继续补充内容。它不会放宽或关闭用户设置的过滤条件，也不会恢复 `ForYou` 中可能触发风控的递归请求。

## 验证

- `pnpm lint`
- `pnpm typecheck`

Closes #1165
