### PR TITLE
fix(home): 推荐全部被过滤时不再显示空白页

### DIFF
--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -1135,6 +1135,7 @@ home:
   app_authorization_required: App 模式的 access token 已缺失或过期，请重新授权后继续使用个性推荐
   reauthorize_app: 重新授权
   recommendation_filter_risk_warning: 当前过滤条件在 100 条有效推荐中仅保留了 {count} 条，容易频繁请求并触发接口风控，建议适当放宽过滤条件。
+  recommendation_filters_empty: 当前过滤条件下暂时没有可显示的视频。
   tell_us_why: 为什么这么做...
   not_interested_desc: >
     你可以使用 <kbd>↑</kbd> 和 <kbd>↓</kbd> 来选择原因，或者直接使用数字键选择原因，按 <kbd>Enter</kbd>

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -1150,6 +1150,7 @@ home:
   app_authorization_required: App 模式的 access token 已遺失或過期，請重新授權後繼續使用個人化推薦
   reauthorize_app: 重新授權
   recommendation_filter_risk_warning: 目前過濾條件在 100 條有效推薦中只保留了 {count} 條，容易頻繁請求並觸發介面風控，建議適度放寬過濾條件。
+  recommendation_filters_empty: 目前過濾條件下暫時沒有可顯示的影片。
   tell_us_why: 為什麼這樣做...
   not_interested_desc: >
     你可以用 <kbd>↑</kbd> 和 <kbd>↓</kbd> 來選擇原因，或者直接使用數字鍵來選擇原因，按 <kbd>Enter</kbd>

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -1232,6 +1232,7 @@ home:
   app_authorization_required: The App mode access token is missing or expired. Re-authorize to continue using personalized recommendations.
   reauthorize_app: Re-authorize
   recommendation_filter_risk_warning: The current filters retained only {count} of 100 valid recommendations. This may cause frequent requests and trigger API risk control. Consider relaxing the filters.
+  recommendation_filters_empty: No videos are currently available with the active recommendation filters.
   tell_us_why: Choose a reason why
   not_interested_desc: >-
     You can use <kbd>↑</kbd> and <kbd>↓</kbd> to choose the reason, or using

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -1150,6 +1150,7 @@ home:
   app_authorization_required: App 模式嘅 access token 已經遺失或者過期，請重新授權之後再繼續使用個人化推介
   reauthorize_app: 重新授權
   recommendation_filter_risk_warning: 而家嘅過濾條件喺 100 條有效推介入面淨係留低 {count} 條，容易造成頻繁請求並觸發接口風控，建議放寬過濾條件。
+  recommendation_filters_empty: 而家嘅過濾條件下暫時冇影片可以顯示。
   tell_us_why: 點解噉做...
   not_interested_desc: >
     你可以用 <kbd>↑</kbd> 同 <kbd>↓</kbd> 嚟揀個理由，抑或用數字鍵嚟直接揀理由，撳 <kbd>Enter</kbd>

--- a/src/contentScripts/views/Home/components/ForYou.vue
+++ b/src/contentScripts/views/Home/components/ForYou.vue
@@ -253,6 +253,13 @@ const filteredFeedRetentionRate = computed(() => filteredFeedCandidateCount.valu
 const requiresManualFilteredPaging = computed(() => hasActiveRecommendationFilter.value
   && filteredFeedCandidateCount.value >= FILTERED_FEED_SAMPLE_SIZE
   && filteredFeedRetentionRate.value < FILTERED_FEED_MIN_RETENTION_RATE)
+const showFilteredEmptyState = computed(() => hasActiveRecommendationFilter.value
+  && filteredFeedCandidateCount.value > 0
+  && currentVideoList.value.length === 0
+  && !isLoading.value
+  && !requestFailed.value
+  && !needToLoginFirst.value
+  && !noMoreContent.value)
 
 const recommendationFilterSettingsSignature = computed(() => JSON.stringify([
   settings.value.disableFilterForFollowedUser,
@@ -836,12 +843,9 @@ async function initData() {
   appConsecutiveEmptyLoads.value = 0 // 重置APP模式空加载计数器
   requestFailed.value = false // 重置请求失败状态
   needToLoginFirst.value = false
-  try {
-    await getData('refresh')
-  }
-  finally {
-    hasInitializedData.value = true
-  }
+  // 先允许 Grid 接管后续预加载，避免首批稀疏结果在 loading 结束时触发的 loadMore 被初始化守卫丢弃。
+  hasInitializedData.value = true
+  await getData('refresh')
 }
 
 async function getData(webRequestType: WebRecommendRequestType = 'refresh') {
@@ -1678,7 +1682,7 @@ defineExpose({
 <template>
   <div>
     <VideoCardGrid
-      v-if="!needToLoginFirst"
+      v-if="!needToLoginFirst && !showFilteredEmptyState"
       :items="currentVideoList"
       :grid-layout="gridLayout"
       :loading="isLoading"
@@ -1697,8 +1701,21 @@ defineExpose({
       @load-more="handleLoadMore"
     />
 
+    <Empty
+      v-if="showFilteredEmptyState"
+      mt-6
+      :description="$t('home.recommendation_filters_empty')"
+    >
+      <Button type="primary" @click="handleManualLoadMore">
+        <template #left>
+          <span i-tabler-arrow-down />
+        </template>
+        {{ $t('common.load_more') }}
+      </Button>
+    </Empty>
+
     <div
-      v-if="requiresManualFilteredPaging && !isLoading && !noMoreContent"
+      v-if="requiresManualFilteredPaging && !showFilteredEmptyState && !isLoading && !noMoreContent"
       class="filtered-feed-load-more"
     >
       <Button type="secondary" @click="handleManualLoadMore">


### PR DESCRIPTION
## 遇到的问题

用户开启首页推荐过滤后，如果条件比较严格，例如只保留时长超过 3600 秒的视频，B 站返回的第一批推荐可能全部被过滤掉。

过滤本身是正常的，但 BewlyCat 此时只显示一块空白区域，既没有说明原因，也没有继续加载的入口，看起来很像扩展白屏或加载失败。

## 为什么现有的“检查 100 条后提示风控风险”没有出现

这里的 100 条是**多次请求累加出来的数量**，不是打开首页时一次获取 100 条。

当第一批推荐全部被过滤时：

1. 页面还没有检查到 100 条，因此不会显示风控警告；
2. 为避免频繁请求，开启过滤后不会由首页逻辑自动连续请求下一批；
3. 视频网格又需要至少已有一张卡片，才能通过滚动预加载下一批；
4. 当前卡片数量为 0，所以第二批请求永远不会发生，检查数量也就永远到不了 100 条。

如果第一批只留下少量卡片，网格原本可以继续预加载，但首次加载结束时“允许继续加载”的状态设置得稍晚，这次预加载可能被忽略，于是页面也可能长期只剩一两张卡片。



- 第一批推荐被全部过滤后，显示“当前过滤条件下暂时没有可显示的视频”，不再留下没有说明的空白区域；
- 提供“加载更多”按钮，由用户决定是否继续请求下一批，避免为了补满页面而自动连续请求；
- 提前准备好首次加载后的预加载状态，让只保留少量卡片时能够继续使用现有的网格预加载逻辑；
- 保留原有的过滤条件、100 条统计和风控警告逻辑，不会自动关闭或放宽用户设置的过滤条件。

## 验证

- `pnpm lint`
- `pnpm typecheck`

Closes #1165
