### PR TITLE
feat(moments): 动态页整体优化

### DIFF
--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -1397,7 +1397,7 @@ moments:
   followers: 粉丝
   posts: 动态
   publish: 发布动态
-  live_now: 正在直播
+  live_now: 直播中
   group_label: 动态分组
   all_posts: 全部动态
   wanted_only: 只看想看的 UP 主

--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -1376,7 +1376,7 @@ moments:
   bilibili_user: B站用户
   original_author: 原作者
   live_post: 直播动态
-  video_post: 视频动态
+  video_post: 投稿了视频
   image_post: 图文动态
   text_post: 纯文字动态
   original_post: 原动态
@@ -1435,7 +1435,7 @@ moments:
   fit_window: 适应窗口
   rotate_clockwise: 顺时针旋转
 moment_card:
-  video_post: 视频动态
+  video_post: 投稿了视频
   cancel_reservation: 取消预约
   reserve: 预约
   open_space: 打开 {name} 的空间

--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -1443,8 +1443,6 @@ moment_card:
   charging_exclusive: 充电专属
   added_watch_later: 已添加稍后再看
   add_watch_later: 添加至稍后再看
-  added: 已添加
-  watch_later: 稍后再看
   live_post: 直播动态
   open_original_video: '打开原视频：{title}'
   author_images: '{name} 的动态图片'

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -1458,8 +1458,6 @@ moment_card:
   charging_exclusive: 充電專屬
   added_watch_later: 已加入稍後再看
   add_watch_later: 加入稍後再看
-  added: 已加入
-  watch_later: 稍後再看
   live_post: 直播動態
   open_original_video: '開啟原影片：{title}'
   author_images: '{name} 的動態圖片'

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -1412,7 +1412,7 @@ moments:
   followers: 粉絲
   posts: 動態
   publish: 發布動態
-  live_now: 正在直播
+  live_now: 直播中
   group_label: 動態分組
   all_posts: 全部動態
   wanted_only: 只看想看的 UP 主

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -1391,7 +1391,7 @@ moments:
   bilibili_user: B站使用者
   original_author: 原作者
   live_post: 直播動態
-  video_post: 影片動態
+  video_post: 投稿了影片
   image_post: 圖文動態
   text_post: 純文字動態
   original_post: 原動態
@@ -1450,7 +1450,7 @@ moments:
   fit_window: 適應視窗
   rotate_clockwise: 順時針旋轉
 moment_card:
-  video_post: 影片動態
+  video_post: 投稿了影片
   cancel_reservation: 取消預約
   reserve: 預約
   open_space: 開啟 {name} 的空間

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -1480,7 +1480,7 @@ moments:
   bilibili_user: Bilibili user
   original_author: Original author
   live_post: Live post
-  video_post: Video post
+  video_post: Uploaded a video
   image_post: Image post
   text_post: Text post
   original_post: Original post
@@ -1539,7 +1539,7 @@ moments:
   fit_window: Fit to window
   rotate_clockwise: Rotate clockwise
 moment_card:
-  video_post: Video post
+  video_post: Uploaded a video
   cancel_reservation: Cancel reservation
   reserve: Reserve
   open_space: Open {name}'s profile

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -1501,7 +1501,7 @@ moments:
   followers: Followers
   posts: Posts
   publish: Publish post
-  live_now: Live now
+  live_now: Live
   group_label: Post groups
   all_posts: All posts
   wanted_only: Wanted uploaders only

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -1547,8 +1547,6 @@ moment_card:
   charging_exclusive: Charging exclusive
   added_watch_later: Added to Watch later
   add_watch_later: Add to Watch later
-  added: Added
-  watch_later: Watch later
   live_post: Live post
   open_original_video: 'Open original video: {title}'
   author_images: '{name} post images'

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -1391,7 +1391,7 @@ moments:
   bilibili_user: B站用戶
   original_author: 原作者
   live_post: 直播動態
-  video_post: 影片動態
+  video_post: 投稿咗影片
   image_post: 圖文動態
   text_post: 純文字動態
   original_post: 原動態
@@ -1450,7 +1450,7 @@ moments:
   fit_window: 適應視窗
   rotate_clockwise: 順時針旋轉
 moment_card:
-  video_post: 影片動態
+  video_post: 投稿咗影片
   cancel_reservation: 取消預約
   reserve: 預約
   open_space: 打開 {name} 嘅空間

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -1458,8 +1458,6 @@ moment_card:
   charging_exclusive: 充電專屬
   added_watch_later: 已加到稍後再睇
   add_watch_later: 加到稍後再睇
-  added: 已加
-  watch_later: 稍後再睇
   live_post: 直播動態
   open_original_video: '打開原影片：{title}'
   author_images: '{name} 嘅動態圖片'

--- a/src/components/MomentCard/MomentCard.vue
+++ b/src/components/MomentCard/MomentCard.vue
@@ -1274,7 +1274,7 @@ function handleAdditionalClick(event: MouseEvent) {
   position: relative;
   display: flex;
   flex-direction: column;
-  margin-top: var(--bew-space-3);
+  margin-top: var(--bew-space-4);
   overflow: hidden;
   /* 推特引用推文式：与卡片同底色，仅用描边框出被转发内容 */
   border: 1px solid color-mix(in oklab, var(--bew-border-color), transparent 58%);
@@ -1320,7 +1320,7 @@ function handleAdditionalClick(event: MouseEvent) {
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: var(--bew-space-3);
-  margin-top: var(--bew-space-3);
+  margin-top: var(--bew-space-4);
   padding: var(--bew-space-3) var(--bew-space-4);
   border-radius: var(--bew-interactive-radius);
   color: inherit;
@@ -1480,7 +1480,7 @@ function handleAdditionalClick(event: MouseEvent) {
   display: flex;
   align-items: center;
   gap: var(--bew-space-3);
-  padding: var(--bew-space-3) var(--bew-space-4);
+  padding: var(--bew-space-4);
 }
 
 .moment-card__identity {
@@ -1547,7 +1547,7 @@ function handleAdditionalClick(event: MouseEvent) {
 }
 
 .moment-card__main {
-  padding: 0 var(--bew-space-4) var(--bew-space-3);
+  padding: 0 var(--bew-space-4) var(--bew-space-4);
 }
 
 .moment-card__main--has-media {
@@ -1587,7 +1587,7 @@ function handleAdditionalClick(event: MouseEvent) {
 .moment-card__main--live {
   display: flex;
   flex-direction: column;
-  gap: var(--bew-space-3);
+  gap: var(--bew-space-4);
 }
 
 .moment-card__main--live .moment-card__body {
@@ -1608,14 +1608,14 @@ function handleAdditionalClick(event: MouseEvent) {
 }
 
 .moment-card__gallery-host {
-  margin-top: var(--bew-space-3);
+  margin-top: var(--bew-space-4);
 }
 
 .moment-card__gallery {
   position: relative;
   display: grid;
   grid-template-columns: 1fr;
-  margin-top: var(--bew-space-3);
+  margin-top: var(--bew-space-4);
   overflow: hidden;
   border-radius: var(--bew-media-radius);
   aspect-ratio: 1;

--- a/src/components/MomentCard/MomentCard.vue
+++ b/src/components/MomentCard/MomentCard.vue
@@ -585,7 +585,6 @@ function handleAdditionalClick(event: MouseEvent) {
                 v-if="moment.images.length"
                 :src="getMomentThumbnailUrl(moment.images[0])"
                 :alt="moment.title"
-                :class="{ 'is-ready': ready }"
                 loading="lazy"
                 decoding="async"
                 @load="handleCoverLoad"
@@ -708,22 +707,6 @@ function handleAdditionalClick(event: MouseEvent) {
             <span v-if="moment.isChargeExclusive" class="moment-card__charge-badge">
               {{ moment.chargeBadge || t('moment_card.charging_exclusive') }}
             </span>
-            <button
-              v-if="settings.showVideoCardWatchLater && moment.isVideo && !moment.isLive"
-              type="button"
-              class="moment-card__watch-later"
-              :class="{ 'is-added': isWatchLaterAdded(moment), 'is-loading': isWatchLaterLoading(moment) }"
-              :aria-busy="isWatchLaterLoading(moment) || undefined"
-              :aria-disabled="isWatchLaterLoading(moment) || undefined"
-              :aria-label="isWatchLaterAdded(moment) ? t('moment_card.added_watch_later') : t('moment_card.add_watch_later')"
-              :aria-pressed="isWatchLaterAdded(moment)"
-              :title="isWatchLaterAdded(moment) ? t('moment_card.added') : t('moment_card.watch_later')"
-              @click.stop="emit('toggleWatchLater', moment)"
-            >
-              <span v-if="isWatchLaterLoading(moment)" i-svg-spinners:ring-resize aria-hidden="true" />
-              <span v-else-if="isWatchLaterAdded(moment)" i-line-md:confirm aria-hidden="true" />
-              <span v-else i-mingcute:carplay-line aria-hidden="true" />
-            </button>
           </div>
           <div v-else-if="(moment.isVideo || moment.isLive) && (!moment.isChargeExclusive || moment.isVideo)" class="moment-card__media moment-card__cover moment-card__text-cover moment-card__text-cover--video">
             <a
@@ -739,22 +722,6 @@ function handleAdditionalClick(event: MouseEvent) {
             <span v-if="moment.isLive" i-tabler-live-photo class="moment-card__text-cover-icon" />
             <span v-else i-tabler-player-play-filled class="moment-card__text-cover-icon" />
             <span>{{ moment.isLive ? t('moment_card.live_post') : t('moment_card.video_post') }}</span>
-            <button
-              v-if="settings.showVideoCardWatchLater && moment.isVideo && !moment.isLive"
-              type="button"
-              class="moment-card__watch-later"
-              :class="{ 'is-added': isWatchLaterAdded(moment), 'is-loading': isWatchLaterLoading(moment) }"
-              :aria-busy="isWatchLaterLoading(moment) || undefined"
-              :aria-disabled="isWatchLaterLoading(moment) || undefined"
-              :aria-label="isWatchLaterAdded(moment) ? t('moment_card.added_watch_later') : t('moment_card.add_watch_later')"
-              :aria-pressed="isWatchLaterAdded(moment)"
-              :title="isWatchLaterAdded(moment) ? t('moment_card.added') : t('moment_card.watch_later')"
-              @click.stop="emit('toggleWatchLater', moment)"
-            >
-              <span v-if="isWatchLaterLoading(moment)" i-svg-spinners:ring-resize aria-hidden="true" />
-              <span v-else-if="isWatchLaterAdded(moment)" i-line-md:confirm aria-hidden="true" />
-              <span v-else i-mingcute:carplay-line aria-hidden="true" />
-            </button>
           </div>
           <div class="moment-card__body">
             <p v-if="moment.title && !moment.forward?.video" class="moment-card__title">
@@ -844,7 +811,7 @@ function handleAdditionalClick(event: MouseEvent) {
                   :aria-disabled="isWatchLaterLoading(moment.forward.video)"
                   :aria-label="isWatchLaterAdded(moment.forward.video) ? t('moment_card.added_watch_later') : t('moment_card.add_watch_later')"
                   :aria-pressed="isWatchLaterAdded(moment.forward.video)"
-                  :title="isWatchLaterAdded(moment.forward.video) ? t('moment_card.added') : t('moment_card.watch_later')"
+                  :title="isWatchLaterAdded(moment.forward.video) ? t('moment_card.added_watch_later') : t('moment_card.add_watch_later')"
                   @click.stop.prevent="emit('toggleWatchLater', moment.forward.video)"
                   @keydown.enter.stop.prevent="emit('toggleWatchLater', moment.forward.video)"
                   @keydown.space.stop.prevent="emit('toggleWatchLater', moment.forward.video)"
@@ -1267,7 +1234,6 @@ function handleAdditionalClick(event: MouseEvent) {
     background-color var(--bew-duration-normal) var(--bew-ease-standard);
 }
 
-.moment-card__cover:hover .moment-card__watch-later,
 .moment-card__video-card-cover:hover .moment-card__watch-later,
 .moment-card__watch-later:focus-visible {
   opacity: 1;
@@ -1707,15 +1673,6 @@ function handleAdditionalClick(event: MouseEvent) {
   width: 100%;
   height: 100%;
   object-fit: cover;
-}
-
-.moment-card__video-card-cover > img {
-  opacity: 0;
-  transition: opacity 0.12s ease;
-}
-
-.moment-card__video-card-cover > img.is-ready {
-  opacity: 1;
 }
 
 /* 信息区从条顶开始排：标题在上、简介/作者紧随，不随封面高度做垂直居中 */

--- a/src/components/MomentCard/MomentCard.vue
+++ b/src/components/MomentCard/MomentCard.vue
@@ -284,6 +284,13 @@ function handleCardClick(event: MouseEvent) {
 }
 
 function handlePermalinkClick(event: MouseEvent) {
+  // 整卡 a 内嵌的交互件（稍后再看等）自行处理点击，这里只拦掉默认跳转
+  const nested = (event.target as HTMLElement | null)?.closest('button, a')
+  if (nested && nested !== event.currentTarget) {
+    event.preventDefault()
+    return
+  }
+
   // 左键走卡片弹窗；a 只留给中键 / ctrl / meta 等原生打开。
   if (shouldUseNativeLinkOpen(event))
     return
@@ -578,6 +585,7 @@ function handleAdditionalClick(event: MouseEvent) {
                 v-if="moment.images.length"
                 :src="getMomentThumbnailUrl(moment.images[0])"
                 :alt="moment.title"
+                :class="{ 'is-ready': ready }"
                 loading="lazy"
                 decoding="async"
                 @load="handleCoverLoad"
@@ -1261,9 +1269,7 @@ function handleAdditionalClick(event: MouseEvent) {
 
 .moment-card__cover:hover .moment-card__watch-later,
 .moment-card__video-card-cover:hover .moment-card__watch-later,
-.moment-card__video-card-cover:focus-within .moment-card__watch-later,
-.moment-card__watch-later:focus-visible,
-.moment-card__watch-later.is-added {
+.moment-card__watch-later:focus-visible {
   opacity: 1;
   transform: scale(1);
 }
@@ -1701,6 +1707,15 @@ function handleAdditionalClick(event: MouseEvent) {
   width: 100%;
   height: 100%;
   object-fit: cover;
+}
+
+.moment-card__video-card-cover > img {
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+
+.moment-card__video-card-cover > img.is-ready {
+  opacity: 1;
 }
 
 /* 信息区从条顶开始排：标题在上、简介/作者紧随，不随封面高度做垂直居中 */

--- a/src/components/MomentCard/MomentCard.vue
+++ b/src/components/MomentCard/MomentCard.vue
@@ -1396,13 +1396,19 @@ function handleAdditionalClick(event: MouseEvent) {
   flex-direction: column;
   margin-top: var(--bew-space-4);
   overflow: hidden;
-  /* 推特引用推文式：与卡片同底色，仅用描边框出被转发内容 */
+  /* 与横条视频卡同层级的内容块：fill 底 + 描边，点击跳原动态 */
   border: 1px solid color-mix(in oklab, var(--bew-border-color), transparent 58%);
   border-radius: var(--bew-card-radius);
   color: var(--bew-text-2);
-  background: transparent;
+  background: var(--bew-fill-1);
   font-size: var(--bew-font-size-control);
   line-height: var(--bew-line-height-control);
+  transition: background-color 0.16s ease;
+}
+
+.moment-card__forward:hover,
+.moment-card__forward:focus-visible {
+  background: var(--bew-fill-2);
 }
 
 .moment-card__forward-copy {
@@ -1669,16 +1675,12 @@ function handleAdditionalClick(event: MouseEvent) {
   background: var(--bew-fill-1);
   box-sizing: border-box;
   text-decoration: none;
-  transition:
-    border-color 0.16s ease,
-    background-color 0.16s ease;
+  transition: background-color 0.16s ease;
 }
 
 .moment-card__video-card:hover,
 .moment-card__video-card:focus-visible {
-  border-color: color-mix(in oklab, var(--bew-theme-color), transparent 48%);
-  background: color-mix(in oklab, var(--bew-theme-color) 7%, var(--bew-fill-1));
-  outline: none;
+  background: var(--bew-fill-2);
 }
 
 .moment-card__video-card-cover {

--- a/src/components/MomentCard/MomentCard.vue
+++ b/src/components/MomentCard/MomentCard.vue
@@ -491,7 +491,9 @@ function handleAdditionalClick(event: MouseEvent) {
             @click="handleAuthorClick"
           >{{ moment.author.name }}</a>
           <strong v-else>{{ moment.author.name }}</strong>
-          <small>{{ moment.time || t('moment_card.just_now') }}</small>
+          <small>
+            {{ moment.time || t('moment_card.just_now') }}<template v-if="moment.isVideo && !moment.isLive"> · {{ t('moment_card.video_post') }}</template>
+          </small>
         </span>
         <button
           v-if="menuVideo"

--- a/src/components/MomentCard/MomentCard.vue
+++ b/src/components/MomentCard/MomentCard.vue
@@ -1700,19 +1700,18 @@ function handleAdditionalClick(event: MouseEvent) {
   object-fit: cover;
 }
 
+/* 信息区从条顶开始排：标题在上、简介/作者紧随，不随封面高度做垂直居中 */
 .moment-card__video-card-info {
   display: flex;
   min-width: 0;
   flex-direction: column;
-  justify-content: center;
   gap: var(--bew-space-2);
-  padding: var(--bew-space-2) var(--bew-space-3);
+  padding: var(--bew-space-3) var(--bew-space-4);
 }
 
 .moment-card__video-card-info strong {
   display: -webkit-box;
   min-width: 0;
-  flex: 1 1 auto;
   overflow: hidden;
   color: var(--bew-text-1);
   font-size: var(--bew-font-size-body);
@@ -1728,8 +1727,8 @@ function handleAdditionalClick(event: MouseEvent) {
   margin: 0;
   overflow: hidden;
   color: var(--bew-text-3);
-  font-size: var(--bew-font-size-caption);
-  line-height: var(--bew-line-height-caption);
+  font-size: var(--bew-font-size-control);
+  line-height: var(--bew-line-height-control);
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
 }

--- a/src/components/MomentCard/MomentCard.vue
+++ b/src/components/MomentCard/MomentCard.vue
@@ -518,329 +518,449 @@ function handleAdditionalClick(event: MouseEvent) {
       <div
         class="moment-card__main"
         :class="{
-          'moment-card__main--has-media': (!moment.isChargeExclusive || moment.isVideo) && (
-            (moment.images.length > 0 && (moment.isVideo || moment.isLive))
-            || (!moment.images.length && (moment.isVideo || moment.isLive))
-          ),
           'moment-card__main--video': moment.isVideo || (!moment.isChargeExclusive && moment.isLive),
           'moment-card__main--live': !moment.isChargeExclusive && moment.isLive,
         }"
       >
-        <div
-          v-if="moment.images.length && (moment.isVideo || moment.isLive)"
-          class="moment-card__media moment-card__cover moment-card__cover--media"
-          @mouseenter="emit('mediaEnter', moment)"
-          @mouseleave="emit('mediaLeave', moment)"
-        >
-          <a
-            v-if="cardHref"
-            class="moment-card__permalink"
-            :href="cardHref"
-            tabindex="-1"
-            aria-hidden="true"
-            draggable="false"
-            rel="noopener noreferrer"
-            @click.capture="handlePermalinkClick"
-          />
-          <img
-            :src="getMomentThumbnailUrl(moment.images[0])"
-            :alt="moment.title"
-            :class="{ 'is-ready': ready }"
-            loading="lazy"
-            decoding="async"
-            @load="handleCoverLoad"
+        <!-- 官方式横条视频卡：左封面、右标题与简介；转发视频复用同一结构 -->
+        <template v-if="moment.isVideo && !moment.isLive">
+          <div
+            v-if="moment.richText.length || (getCardPreviewText(moment) && !moment.descInherited)"
+            class="moment-card__body"
           >
-          <video
-            v-if="previewActive && previewUrl"
-            :ref="handlePreviewVideo"
-            :src="moment.isLive ? undefined : previewUrl"
-            autoplay
-            muted
-            :loop="!moment.isLive"
-            playsinline
-            @canplay="emit('previewCanplay', $event)"
-          />
-          <span
-            v-if="moment.isVideo && showVideoCoverStats"
-            class="moment-card__video-stats"
-          >
-            <span class="moment-card__video-stat-group">
-              <span v-if="settings.showVideoCardViewCount && moment.videoPlay">
-                <span i-mingcute:play-circle-line aria-hidden="true" />
-                {{ moment.videoPlay }}
-              </span>
-            </span>
-            <span v-if="showVideoDuration" class="moment-card__video-duration">{{ moment.duration }}</span>
-          </span>
-          <span v-if="moment.isLive" class="moment-card__live-mark">
-            LIVE
-            <span i-svg-spinners:pulse-3 aria-hidden="true" />
-          </span>
-          <span v-if="moment.isChargeExclusive" class="moment-card__charge-badge">
-            {{ moment.chargeBadge || t('moment_card.charging_exclusive') }}
-          </span>
-          <button
-            v-if="settings.showVideoCardWatchLater && moment.isVideo && !moment.isLive"
-            type="button"
-            class="moment-card__watch-later"
-            :class="{ 'is-added': isWatchLaterAdded(moment), 'is-loading': isWatchLaterLoading(moment) }"
-            :aria-busy="isWatchLaterLoading(moment) || undefined"
-            :aria-disabled="isWatchLaterLoading(moment) || undefined"
-            :aria-label="isWatchLaterAdded(moment) ? t('moment_card.added_watch_later') : t('moment_card.add_watch_later')"
-            :aria-pressed="isWatchLaterAdded(moment)"
-            :title="isWatchLaterAdded(moment) ? t('moment_card.added') : t('moment_card.watch_later')"
-            @click.stop="emit('toggleWatchLater', moment)"
-          >
-            <span v-if="isWatchLaterLoading(moment)" i-svg-spinners:ring-resize aria-hidden="true" />
-            <span v-else-if="isWatchLaterAdded(moment)" i-line-md:confirm aria-hidden="true" />
-            <span v-else i-mingcute:carplay-line aria-hidden="true" />
-          </button>
-        </div>
-        <div v-else-if="(moment.isVideo || moment.isLive) && (!moment.isChargeExclusive || moment.isVideo)" class="moment-card__media moment-card__cover moment-card__text-cover moment-card__text-cover--video">
-          <a
-            v-if="cardHref"
-            class="moment-card__permalink"
-            :href="cardHref"
-            tabindex="-1"
-            aria-hidden="true"
-            draggable="false"
-            rel="noopener noreferrer"
-            @click.capture="handlePermalinkClick"
-          />
-          <span v-if="moment.isLive" i-tabler-live-photo class="moment-card__text-cover-icon" />
-          <span v-else i-tabler-player-play-filled class="moment-card__text-cover-icon" />
-          <span>{{ moment.isLive ? t('moment_card.live_post') : t('moment_card.video_post') }}</span>
-          <button
-            v-if="settings.showVideoCardWatchLater && moment.isVideo && !moment.isLive"
-            type="button"
-            class="moment-card__watch-later"
-            :class="{ 'is-added': isWatchLaterAdded(moment), 'is-loading': isWatchLaterLoading(moment) }"
-            :aria-busy="isWatchLaterLoading(moment) || undefined"
-            :aria-disabled="isWatchLaterLoading(moment) || undefined"
-            :aria-label="isWatchLaterAdded(moment) ? t('moment_card.added_watch_later') : t('moment_card.add_watch_later')"
-            :aria-pressed="isWatchLaterAdded(moment)"
-            :title="isWatchLaterAdded(moment) ? t('moment_card.added') : t('moment_card.watch_later')"
-            @click.stop="emit('toggleWatchLater', moment)"
-          >
-            <span v-if="isWatchLaterLoading(moment)" i-svg-spinners:ring-resize aria-hidden="true" />
-            <span v-else-if="isWatchLaterAdded(moment)" i-line-md:confirm aria-hidden="true" />
-            <span v-else i-mingcute:carplay-line aria-hidden="true" />
-          </button>
-        </div>
-        <div class="moment-card__body">
-          <p v-if="moment.title && !moment.forward?.video" class="moment-card__title">
-            <VideoWatchedTag
-              v-if="moment.isVideo"
-              :aid="moment.aid"
-              :bvid="moment.bvid"
-            />
-            {{ moment.title }}
-          </p>
-          <p
-            v-if="moment.mediaMeta && !moment.isChargeExclusive && (!moment.isVideo || moment.isLive)"
-            class="moment-card__media-meta"
-            :class="{ 'moment-card__media-meta--live': moment.isLive }"
-          >
-            {{ moment.mediaMeta }}
-          </p>
-          <p v-if="!moment.isLive && (moment.richText.length || getCardPreviewText(moment))" class="moment-card__desc">
-            <template v-if="moment.richText.length">
-              <template v-for="(segment, segmentIndex) in moment.richText" :key="`${moment.id}-${segmentIndex}`">
-                <img
-                  v-if="segment.type === 'emoji' && segment.imageUrl"
-                  :src="segment.imageUrl"
-                  :alt="segment.text"
-                  :title="segment.text"
-                  class="moment-card__emoji"
-                  :class="{ 'moment-card__emoji--large': segment.size === 2 }"
-                  loading="lazy"
-                  decoding="async"
-                >
-                <a
-                  v-else-if="segment.type === 'link' && segment.url"
-                  :href="segment.url"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="moment-card__rich-link"
-                  @click="handleRichLinkClick($event, segment.url)"
-                >
-                  {{ segment.text }}
-                </a>
-                <template v-else>
-                  {{ segment.text }}
+            <p class="moment-card__desc">
+              <template v-if="moment.richText.length">
+                <template v-for="(segment, segmentIndex) in moment.richText" :key="`${moment.id}-${segmentIndex}`">
+                  <img
+                    v-if="segment.type === 'emoji' && segment.imageUrl"
+                    :src="segment.imageUrl"
+                    :alt="segment.text"
+                    :title="segment.text"
+                    class="moment-card__emoji"
+                    :class="{ 'moment-card__emoji--large': segment.size === 2 }"
+                    loading="lazy"
+                    decoding="async"
+                  >
+                  <a
+                    v-else-if="segment.type === 'link' && segment.url"
+                    :href="segment.url"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="moment-card__rich-link"
+                    @click="handleRichLinkClick($event, segment.url)"
+                  >
+                    {{ segment.text }}
+                  </a>
+                  <template v-else>
+                    {{ segment.text }}
+                  </template>
                 </template>
               </template>
-            </template>
-            <template v-else>
-              {{ getCardPreviewText(moment) }}
-            </template>
-          </p>
+              <template v-else>
+                {{ getCardPreviewText(moment) }}
+              </template>
+            </p>
+          </div>
           <a
-            v-if="moment.forward?.video"
-            :href="moment.forward.video.url || undefined"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="moment-card__forward-video"
-            :aria-label="t('moment_card.open_original_video', { title: moment.forward.video.title })"
-            @click="handleForwardVideoClick"
+            :href="cardHref || undefined"
+            class="moment-card__video-card"
+            :aria-label="t('moment_card.open_original_video', { title: moment.title })"
+            @click.capture="handlePermalinkClick"
           >
-            <span class="moment-card__forward-video-cover">
+            <span
+              class="moment-card__video-card-cover"
+              @mouseenter="emit('mediaEnter', moment)"
+              @mouseleave="emit('mediaLeave', moment)"
+            >
               <img
-                :src="getMomentThumbnailUrl(moment.forward.video.cover)"
-                :alt="moment.forward.video.title"
+                v-if="moment.images.length"
+                :src="getMomentThumbnailUrl(moment.images[0])"
+                :alt="moment.title"
                 loading="lazy"
                 decoding="async"
+                @load="handleCoverLoad"
               >
+              <span v-else class="moment-card__text-cover moment-card__text-cover--video">
+                <span i-tabler-player-play-filled class="moment-card__text-cover-icon" aria-hidden="true" />
+                <span>{{ t('moment_card.video_post') }}</span>
+              </span>
+              <video
+                v-if="previewActive && previewUrl"
+                :ref="handlePreviewVideo"
+                :src="previewUrl"
+                autoplay
+                muted
+                loop
+                playsinline
+                @canplay="emit('previewCanplay', $event)"
+              />
               <span
-                v-if="showForwardVideoCoverStats"
+                v-if="showVideoCoverStats"
                 class="moment-card__video-stats"
               >
                 <span class="moment-card__video-stat-group">
-                  <span v-if="settings.showVideoCardViewCount && moment.forward.video.play">
+                  <span v-if="settings.showVideoCardViewCount && moment.videoPlay">
                     <span i-mingcute:play-circle-line aria-hidden="true" />
-                    {{ moment.forward.video.play }}
+                    {{ moment.videoPlay }}
                   </span>
                 </span>
-                <span v-if="showForwardVideoDuration" class="moment-card__video-duration">{{ moment.forward.video.duration }}</span>
+                <span v-if="showVideoDuration" class="moment-card__video-duration">{{ moment.duration }}</span>
               </span>
-              <span
-                v-if="settings.showVideoCardWatchLater && getWatchLaterStateKey(moment.forward.video)"
-                role="button"
-                :tabindex="isWatchLaterLoading(moment.forward.video) ? -1 : 0"
+              <span v-if="moment.isChargeExclusive" class="moment-card__charge-badge">
+                {{ moment.chargeBadge || t('moment_card.charging_exclusive') }}
+              </span>
+              <button
+                v-if="settings.showVideoCardWatchLater"
+                type="button"
                 class="moment-card__watch-later"
-                :class="{
-                  'is-added': isWatchLaterAdded(moment.forward.video),
-                  'is-disabled': isWatchLaterLoading(moment.forward.video),
-                }"
-                :aria-disabled="isWatchLaterLoading(moment.forward.video)"
-                :aria-label="isWatchLaterAdded(moment.forward.video) ? t('moment_card.added_watch_later') : t('moment_card.add_watch_later')"
-                :aria-pressed="isWatchLaterAdded(moment.forward.video)"
-                :title="isWatchLaterAdded(moment.forward.video) ? t('moment_card.added') : t('moment_card.watch_later')"
-                @click.stop.prevent="emit('toggleWatchLater', moment.forward.video)"
-                @keydown.enter.stop.prevent="emit('toggleWatchLater', moment.forward.video)"
-                @keydown.space.stop.prevent="emit('toggleWatchLater', moment.forward.video)"
+                :class="{ 'is-added': isWatchLaterAdded(moment), 'is-loading': isWatchLaterLoading(moment) }"
+                :aria-busy="isWatchLaterLoading(moment) || undefined"
+                :aria-disabled="isWatchLaterLoading(moment) || undefined"
+                :aria-label="isWatchLaterAdded(moment) ? t('moment_card.added_watch_later') : t('moment_card.add_watch_later')"
+                :aria-pressed="isWatchLaterAdded(moment)"
+                :title="isWatchLaterAdded(moment) ? t('moment_card.added_watch_later') : t('moment_card.add_watch_later')"
+                @click.stop="emit('toggleWatchLater', moment)"
               >
-                <span v-if="isWatchLaterLoading(moment.forward.video)" i-svg-spinners:ring-resize aria-hidden="true" />
-                <span v-else-if="isWatchLaterAdded(moment.forward.video)" i-line-md:confirm aria-hidden="true" />
+                <span v-if="isWatchLaterLoading(moment)" i-svg-spinners:ring-resize aria-hidden="true" />
+                <span v-else-if="isWatchLaterAdded(moment)" i-line-md:confirm aria-hidden="true" />
                 <span v-else i-mingcute:carplay-line aria-hidden="true" />
-              </span>
+              </button>
             </span>
-            <span class="moment-card__forward-video-info">
+            <span class="moment-card__video-card-info">
               <strong>
                 <VideoWatchedTag
-                  :aid="moment.forward.video.aid"
-                  :bvid="moment.forward.video.bvid"
+                  v-if="moment.isVideo"
+                  :aid="moment.aid"
+                  :bvid="moment.bvid"
                 />
-                {{ moment.forward.video.title || moment.forward.fallback }}
+                {{ moment.title || t('moment_card.video_post') }}
               </strong>
-              <small>
-                <span i-tabler-user aria-hidden="true" />
+              <p
+                v-if="moment.descInherited && getCardPreviewText(moment)"
+                class="moment-card__video-card-desc"
+              >
+                {{ getCardPreviewText(moment) }}
+              </p>
+            </span>
+          </a>
+        </template>
+        <template v-else>
+          <div
+            v-if="moment.images.length && (moment.isVideo || moment.isLive)"
+            class="moment-card__media moment-card__cover moment-card__cover--media"
+            @mouseenter="emit('mediaEnter', moment)"
+            @mouseleave="emit('mediaLeave', moment)"
+          >
+            <a
+              v-if="cardHref"
+              class="moment-card__permalink"
+              :href="cardHref"
+              tabindex="-1"
+              aria-hidden="true"
+              draggable="false"
+              rel="noopener noreferrer"
+              @click.capture="handlePermalinkClick"
+            />
+            <img
+              :src="getMomentThumbnailUrl(moment.images[0])"
+              :alt="moment.title"
+              :class="{ 'is-ready': ready }"
+              loading="lazy"
+              decoding="async"
+              @load="handleCoverLoad"
+            >
+            <video
+              v-if="previewActive && previewUrl"
+              :ref="handlePreviewVideo"
+              :src="moment.isLive ? undefined : previewUrl"
+              autoplay
+              muted
+              :loop="!moment.isLive"
+              playsinline
+              @canplay="emit('previewCanplay', $event)"
+            />
+            <span
+              v-if="moment.isVideo && showVideoCoverStats"
+              class="moment-card__video-stats"
+            >
+              <span class="moment-card__video-stat-group">
+                <span v-if="settings.showVideoCardViewCount && moment.videoPlay">
+                  <span i-mingcute:play-circle-line aria-hidden="true" />
+                  {{ moment.videoPlay }}
+                </span>
+              </span>
+              <span v-if="showVideoDuration" class="moment-card__video-duration">{{ moment.duration }}</span>
+            </span>
+            <span v-if="moment.isLive" class="moment-card__live-mark">
+              LIVE
+              <span i-svg-spinners:pulse-3 aria-hidden="true" />
+            </span>
+            <span v-if="moment.isChargeExclusive" class="moment-card__charge-badge">
+              {{ moment.chargeBadge || t('moment_card.charging_exclusive') }}
+            </span>
+            <button
+              v-if="settings.showVideoCardWatchLater && moment.isVideo && !moment.isLive"
+              type="button"
+              class="moment-card__watch-later"
+              :class="{ 'is-added': isWatchLaterAdded(moment), 'is-loading': isWatchLaterLoading(moment) }"
+              :aria-busy="isWatchLaterLoading(moment) || undefined"
+              :aria-disabled="isWatchLaterLoading(moment) || undefined"
+              :aria-label="isWatchLaterAdded(moment) ? t('moment_card.added_watch_later') : t('moment_card.add_watch_later')"
+              :aria-pressed="isWatchLaterAdded(moment)"
+              :title="isWatchLaterAdded(moment) ? t('moment_card.added') : t('moment_card.watch_later')"
+              @click.stop="emit('toggleWatchLater', moment)"
+            >
+              <span v-if="isWatchLaterLoading(moment)" i-svg-spinners:ring-resize aria-hidden="true" />
+              <span v-else-if="isWatchLaterAdded(moment)" i-line-md:confirm aria-hidden="true" />
+              <span v-else i-mingcute:carplay-line aria-hidden="true" />
+            </button>
+          </div>
+          <div v-else-if="(moment.isVideo || moment.isLive) && (!moment.isChargeExclusive || moment.isVideo)" class="moment-card__media moment-card__cover moment-card__text-cover moment-card__text-cover--video">
+            <a
+              v-if="cardHref"
+              class="moment-card__permalink"
+              :href="cardHref"
+              tabindex="-1"
+              aria-hidden="true"
+              draggable="false"
+              rel="noopener noreferrer"
+              @click.capture="handlePermalinkClick"
+            />
+            <span v-if="moment.isLive" i-tabler-live-photo class="moment-card__text-cover-icon" />
+            <span v-else i-tabler-player-play-filled class="moment-card__text-cover-icon" />
+            <span>{{ moment.isLive ? t('moment_card.live_post') : t('moment_card.video_post') }}</span>
+            <button
+              v-if="settings.showVideoCardWatchLater && moment.isVideo && !moment.isLive"
+              type="button"
+              class="moment-card__watch-later"
+              :class="{ 'is-added': isWatchLaterAdded(moment), 'is-loading': isWatchLaterLoading(moment) }"
+              :aria-busy="isWatchLaterLoading(moment) || undefined"
+              :aria-disabled="isWatchLaterLoading(moment) || undefined"
+              :aria-label="isWatchLaterAdded(moment) ? t('moment_card.added_watch_later') : t('moment_card.add_watch_later')"
+              :aria-pressed="isWatchLaterAdded(moment)"
+              :title="isWatchLaterAdded(moment) ? t('moment_card.added') : t('moment_card.watch_later')"
+              @click.stop="emit('toggleWatchLater', moment)"
+            >
+              <span v-if="isWatchLaterLoading(moment)" i-svg-spinners:ring-resize aria-hidden="true" />
+              <span v-else-if="isWatchLaterAdded(moment)" i-line-md:confirm aria-hidden="true" />
+              <span v-else i-mingcute:carplay-line aria-hidden="true" />
+            </button>
+          </div>
+          <div class="moment-card__body">
+            <p v-if="moment.title && !moment.forward?.video" class="moment-card__title">
+              <VideoWatchedTag
+                v-if="moment.isVideo"
+                :aid="moment.aid"
+                :bvid="moment.bvid"
+              />
+              {{ moment.title }}
+            </p>
+            <p
+              v-if="moment.mediaMeta && !moment.isChargeExclusive && (!moment.isVideo || moment.isLive)"
+              class="moment-card__media-meta"
+              :class="{ 'moment-card__media-meta--live': moment.isLive }"
+            >
+              {{ moment.mediaMeta }}
+            </p>
+            <p v-if="!moment.isLive && (moment.richText.length || getCardPreviewText(moment))" class="moment-card__desc">
+              <template v-if="moment.richText.length">
+                <template v-for="(segment, segmentIndex) in moment.richText" :key="`${moment.id}-${segmentIndex}`">
+                  <img
+                    v-if="segment.type === 'emoji' && segment.imageUrl"
+                    :src="segment.imageUrl"
+                    :alt="segment.text"
+                    :title="segment.text"
+                    class="moment-card__emoji"
+                    :class="{ 'moment-card__emoji--large': segment.size === 2 }"
+                    loading="lazy"
+                    decoding="async"
+                  >
+                  <a
+                    v-else-if="segment.type === 'link' && segment.url"
+                    :href="segment.url"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="moment-card__rich-link"
+                    @click="handleRichLinkClick($event, segment.url)"
+                  >
+                    {{ segment.text }}
+                  </a>
+                  <template v-else>
+                    {{ segment.text }}
+                  </template>
+                </template>
+              </template>
+              <template v-else>
+                {{ getCardPreviewText(moment) }}
+              </template>
+            </p>
+            <a
+              v-if="moment.forward?.video"
+              :href="moment.forward.video.url || undefined"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="moment-card__video-card"
+              :aria-label="t('moment_card.open_original_video', { title: moment.forward.video.title })"
+              @click="handleForwardVideoClick"
+            >
+              <span class="moment-card__video-card-cover">
+                <img
+                  :src="getMomentThumbnailUrl(moment.forward.video.cover)"
+                  :alt="moment.forward.video.title"
+                  loading="lazy"
+                  decoding="async"
+                >
+                <span
+                  v-if="showForwardVideoCoverStats"
+                  class="moment-card__video-stats"
+                >
+                  <span class="moment-card__video-stat-group">
+                    <span v-if="settings.showVideoCardViewCount && moment.forward.video.play">
+                      <span i-mingcute:play-circle-line aria-hidden="true" />
+                      {{ moment.forward.video.play }}
+                    </span>
+                  </span>
+                  <span v-if="showForwardVideoDuration" class="moment-card__video-duration">{{ moment.forward.video.duration }}</span>
+                </span>
+                <span
+                  v-if="settings.showVideoCardWatchLater && getWatchLaterStateKey(moment.forward.video)"
+                  role="button"
+                  :tabindex="isWatchLaterLoading(moment.forward.video) ? -1 : 0"
+                  class="moment-card__watch-later"
+                  :class="{
+                    'is-added': isWatchLaterAdded(moment.forward.video),
+                    'is-disabled': isWatchLaterLoading(moment.forward.video),
+                  }"
+                  :aria-disabled="isWatchLaterLoading(moment.forward.video)"
+                  :aria-label="isWatchLaterAdded(moment.forward.video) ? t('moment_card.added_watch_later') : t('moment_card.add_watch_later')"
+                  :aria-pressed="isWatchLaterAdded(moment.forward.video)"
+                  :title="isWatchLaterAdded(moment.forward.video) ? t('moment_card.added') : t('moment_card.watch_later')"
+                  @click.stop.prevent="emit('toggleWatchLater', moment.forward.video)"
+                  @keydown.enter.stop.prevent="emit('toggleWatchLater', moment.forward.video)"
+                  @keydown.space.stop.prevent="emit('toggleWatchLater', moment.forward.video)"
+                >
+                  <span v-if="isWatchLaterLoading(moment.forward.video)" i-svg-spinners:ring-resize aria-hidden="true" />
+                  <span v-else-if="isWatchLaterAdded(moment.forward.video)" i-line-md:confirm aria-hidden="true" />
+                  <span v-else i-mingcute:carplay-line aria-hidden="true" />
+                </span>
+              </span>
+              <span class="moment-card__video-card-info">
+                <strong>
+                  <VideoWatchedTag
+                    :aid="moment.forward.video.aid"
+                    :bvid="moment.forward.video.bvid"
+                  />
+                  {{ moment.forward.video.title || moment.forward.fallback }}
+                </strong>
+                <small>
+                  <span i-tabler-user aria-hidden="true" />
+                  <a
+                    v-if="forwardAuthorSpaceUrl"
+                    :href="forwardAuthorSpaceUrl"
+                    class="moment-card__forward-author"
+                    rel="noopener noreferrer"
+                    @click="handleForwardAuthorClick"
+                  >{{ moment.forward.author }}</a>
+                  <template v-else>{{ moment.forward.author }}</template>
+                </small>
+              </span>
+            </a>
+            <div
+              v-else-if="moment.forward"
+              class="moment-card__forward"
+              :class="{
+                'moment-card__forward--draw': Boolean(moment.forward.images?.length),
+              }"
+              role="button"
+              tabindex="0"
+              :aria-label="t('moment_card.open_origin_moment', { name: moment.forward.author })"
+              @click="handleForwardOriginClick"
+              @keydown="handleForwardOriginKeydown"
+            >
+              <div class="moment-card__forward-copy">
                 <a
                   v-if="forwardAuthorSpaceUrl"
                   :href="forwardAuthorSpaceUrl"
                   class="moment-card__forward-author"
                   rel="noopener noreferrer"
                   @click="handleForwardAuthorClick"
-                >{{ moment.forward.author }}</a>
-                <template v-else>{{ moment.forward.author }}</template>
-              </small>
-            </span>
-          </a>
-          <div
-            v-else-if="moment.forward"
-            class="moment-card__forward"
-            :class="{
-              'moment-card__forward--draw': Boolean(moment.forward.images?.length),
-            }"
-            role="button"
-            tabindex="0"
-            :aria-label="t('moment_card.open_origin_moment', { name: moment.forward.author })"
-            @click="handleForwardOriginClick"
-            @keydown="handleForwardOriginKeydown"
-          >
-            <div class="moment-card__forward-copy">
-              <a
-                v-if="forwardAuthorSpaceUrl"
-                :href="forwardAuthorSpaceUrl"
-                class="moment-card__forward-author"
-                rel="noopener noreferrer"
-                @click="handleForwardAuthorClick"
-              >@{{ moment.forward.author }}</a>
-              <strong v-else>@{{ moment.forward.author }}</strong>
-              <p>{{ moment.forward.title || moment.forward.text || moment.forward.fallback }}</p>
-            </div>
-            <div
-              v-if="showForwardScrollGallery"
-              class="moment-card__forward-gallery-host"
-            >
-              <MomentImageGallery
-                :images="moment.forward.images || []"
-                :image-ratios="moment.forward.imageRatios"
-                :alt-prefix="t('moment_card.author_images', { name: moment.forward.author })"
-                :container-width="forwardScrollGalleryWidth"
-                @cover-load="handleGalleryCoverLoad"
-                @preview="handleForwardGalleryPreview"
-              />
-            </div>
-            <div
-              v-else-if="moment.forward.images?.length"
-              class="moment-card__forward-gallery moment-card__forward-gallery--1"
-              :style="forwardSingleImageGalleryStyle"
-              tabindex="0"
-              role="button"
-              @click="handleImagePreviewClick($event, moment.forward.images || [], 0)"
-              @keydown="handleImagePreviewKeydown($event, moment.forward.images || [], 0)"
-            >
-              <img
-                :src="getMomentThumbnailUrl(moment.forward.images[0], LANDSCAPE_SINGLE_IMAGE_MAX_WIDTH * 2)"
-                :alt="t('moment_card.author_images', { name: moment.forward.author })"
-                :aria-label="t('moment_card.view_author_images', { name: moment.forward.author })"
-                loading="lazy"
-                decoding="async"
-                @load="handleCoverLoad"
+                >@{{ moment.forward.author }}</a>
+                <strong v-else>@{{ moment.forward.author }}</strong>
+                <p>{{ moment.forward.title || moment.forward.text || moment.forward.fallback }}</p>
+              </div>
+              <div
+                v-if="showForwardScrollGallery"
+                class="moment-card__forward-gallery-host"
               >
+                <MomentImageGallery
+                  :images="moment.forward.images || []"
+                  :image-ratios="moment.forward.imageRatios"
+                  :alt-prefix="t('moment_card.author_images', { name: moment.forward.author })"
+                  :container-width="forwardScrollGalleryWidth"
+                  @cover-load="handleGalleryCoverLoad"
+                  @preview="handleForwardGalleryPreview"
+                />
+              </div>
+              <div
+                v-else-if="moment.forward.images?.length"
+                class="moment-card__forward-gallery moment-card__forward-gallery--1"
+                :style="forwardSingleImageGalleryStyle"
+                tabindex="0"
+                role="button"
+                @click="handleImagePreviewClick($event, moment.forward.images || [], 0)"
+                @keydown="handleImagePreviewKeydown($event, moment.forward.images || [], 0)"
+              >
+                <img
+                  :src="getMomentThumbnailUrl(moment.forward.images[0], LANDSCAPE_SINGLE_IMAGE_MAX_WIDTH * 2)"
+                  :alt="t('moment_card.author_images', { name: moment.forward.author })"
+                  :aria-label="t('moment_card.view_author_images', { name: moment.forward.author })"
+                  loading="lazy"
+                  decoding="async"
+                  @load="handleCoverLoad"
+                >
+              </div>
             </div>
           </div>
-        </div>
 
-        <div
-          v-if="showOwnScrollGallery"
-          class="moment-card__gallery-host"
-        >
-          <MomentImageGallery
-            :images="moment.images"
-            :image-ratios="moment.imageRatios"
-            :alt-prefix="t('moment_card.author_images', { name: moment.author.name })"
-            :container-width="ownScrollGalleryWidth"
-            @cover-load="handleGalleryCoverLoad"
-            @preview="handleGalleryPreview"
+          <div
+            v-if="showOwnScrollGallery"
+            class="moment-card__gallery-host"
           >
+            <MomentImageGallery
+              :images="moment.images"
+              :image-ratios="moment.imageRatios"
+              :alt-prefix="t('moment_card.author_images', { name: moment.author.name })"
+              :container-width="ownScrollGalleryWidth"
+              @cover-load="handleGalleryCoverLoad"
+              @preview="handleGalleryPreview"
+            >
+              <span v-if="moment.isChargeExclusive" class="moment-card__charge-badge">
+                {{ moment.chargeBadge || t('moment_card.charging_exclusive') }}
+              </span>
+            </MomentImageGallery>
+          </div>
+          <div
+            v-else-if="moment.images.length && !moment.isVideo && !moment.isLive"
+            class="moment-card__gallery moment-card__gallery--1"
+            :style="singleImageGalleryStyle"
+            tabindex="0"
+            role="button"
+            @click="handleImagePreviewClick($event, [getMomentOriginalImageUrl(moment.images[0])], 0)"
+            @keydown="handleImagePreviewKeydown($event, [getMomentOriginalImageUrl(moment.images[0])], 0)"
+          >
+            <img
+              :src="getMomentThumbnailUrl(moment.images[0], LANDSCAPE_SINGLE_IMAGE_MAX_WIDTH * 2)"
+              :alt="t('moment_card.author_images', { name: moment.author.name })"
+              :aria-label="t('moment_card.view_author_images', { name: moment.author.name })"
+              loading="lazy"
+              decoding="async"
+              @load="handleCoverLoad"
+            >
             <span v-if="moment.isChargeExclusive" class="moment-card__charge-badge">
               {{ moment.chargeBadge || t('moment_card.charging_exclusive') }}
             </span>
-          </MomentImageGallery>
-        </div>
-        <div
-          v-else-if="moment.images.length && !moment.isVideo && !moment.isLive"
-          class="moment-card__gallery moment-card__gallery--1"
-          :style="singleImageGalleryStyle"
-          tabindex="0"
-          role="button"
-          @click="handleImagePreviewClick($event, [getMomentOriginalImageUrl(moment.images[0])], 0)"
-          @keydown="handleImagePreviewKeydown($event, [getMomentOriginalImageUrl(moment.images[0])], 0)"
-        >
-          <img
-            :src="getMomentThumbnailUrl(moment.images[0], LANDSCAPE_SINGLE_IMAGE_MAX_WIDTH * 2)"
-            :alt="t('moment_card.author_images', { name: moment.author.name })"
-            :aria-label="t('moment_card.view_author_images', { name: moment.author.name })"
-            loading="lazy"
-            decoding="async"
-            @load="handleCoverLoad"
-          >
-          <span v-if="moment.isChargeExclusive" class="moment-card__charge-badge">
-            {{ moment.chargeBadge || t('moment_card.charging_exclusive') }}
-          </span>
-        </div>
+          </div>
+        </template>
       </div>
 
       <Teleport
@@ -1138,8 +1258,8 @@ function handleAdditionalClick(event: MouseEvent) {
 }
 
 .moment-card__cover:hover .moment-card__watch-later,
-.moment-card__forward-video-cover:hover .moment-card__watch-later,
-.moment-card__forward-video-cover:focus-within .moment-card__watch-later,
+.moment-card__video-card-cover:hover .moment-card__watch-later,
+.moment-card__video-card-cover:focus-within .moment-card__watch-later,
 .moment-card__watch-later:focus-visible,
 .moment-card__watch-later.is-added {
   opacity: 1;
@@ -1287,19 +1407,6 @@ function handleAdditionalClick(event: MouseEvent) {
 
 .moment-card__forward-copy {
   padding: var(--bew-space-3);
-}
-
-.moment-card__forward--portrait {
-  display: grid;
-  grid-template-columns: minmax(96px, 180px) minmax(0, 1fr);
-  align-items: start;
-  gap: var(--bew-space-3);
-  padding: var(--bew-space-3);
-}
-
-.moment-card__forward--portrait .moment-card__forward-copy {
-  min-width: 0;
-  padding: 0;
 }
 
 .moment-card__forward strong {
@@ -1550,38 +1657,93 @@ function handleAdditionalClick(event: MouseEvent) {
   padding: 0 var(--bew-space-4) var(--bew-space-4);
 }
 
-.moment-card__main--has-media {
+/* 官方式横条视频卡：左封面、右标题与简介，投稿视频与转发视频共用 */
+.moment-card__video-card {
   display: grid;
-  grid-template-columns: minmax(170px, 1fr) minmax(0, 1fr);
-  align-items: start;
-  gap: var(--bew-space-3);
+  grid-template-columns: minmax(150px, 44%) minmax(0, 1fr);
+  margin-top: var(--bew-space-3);
+  overflow: hidden;
+  border: 1px solid color-mix(in oklab, var(--bew-border-color), transparent 58%);
+  border-radius: var(--bew-card-radius);
+  color: inherit;
+  background: var(--bew-fill-1);
+  box-sizing: border-box;
+  text-decoration: none;
+  transition:
+    border-color 0.16s ease,
+    background-color 0.16s ease;
 }
 
-.moment-card__main--portrait {
-  grid-template-columns: minmax(96px, 180px) minmax(0, 1fr);
+.moment-card__video-card:hover,
+.moment-card__video-card:focus-visible {
+  border-color: color-mix(in oklab, var(--bew-theme-color), transparent 48%);
+  background: color-mix(in oklab, var(--bew-theme-color) 7%, var(--bew-fill-1));
+  outline: none;
 }
 
-/* 视频动态：左封面、右简介、底部标题。直播仍走文案在上的纵向布局。 */
-.moment-card__main--video:not(.moment-card__main--live) {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-  grid-template-areas:
-    "cover desc"
-    "title title";
-  align-items: stretch;
-  gap: var(--bew-space-3);
-}
-
-.moment-card__main--video:not(.moment-card__main--live) .moment-card__media {
-  grid-area: cover;
-  width: 100%;
+.moment-card__video-card-cover {
+  position: relative;
+  display: block;
   min-width: 0;
+  overflow: hidden;
+  aspect-ratio: 16 / 9;
+  background: #111;
 }
 
-.moment-card__main--video:not(.moment-card__main--live) .moment-card__body {
-  display: contents;
-  height: auto;
-  max-height: none;
+.moment-card__video-card-cover > img,
+.moment-card__video-card-cover > video,
+.moment-card__video-card-cover > .moment-card__text-cover {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.moment-card__video-card-info {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  justify-content: center;
+  gap: var(--bew-space-2);
+  padding: var(--bew-space-2) var(--bew-space-3);
+}
+
+.moment-card__video-card-info strong {
+  display: -webkit-box;
+  min-width: 0;
+  flex: 1 1 auto;
+  overflow: hidden;
+  color: var(--bew-text-1);
+  font-size: var(--bew-font-size-body);
+  font-weight: var(--bew-font-weight-semibold);
+  line-height: var(--bew-line-height-title);
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+/* 继承的视频简介：弱化层级，与发布者本人文字区分 */
+.moment-card__video-card-desc {
+  display: -webkit-box;
+  margin: 0;
+  overflow: hidden;
+  color: var(--bew-text-3);
+  font-size: var(--bew-font-size-caption);
+  line-height: var(--bew-line-height-caption);
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.moment-card__video-card-info small {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: var(--bew-space-1);
+  overflow: hidden;
+  color: var(--bew-text-3);
+  font-size: var(--bew-font-size-caption);
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .moment-card__main--live {
@@ -1715,32 +1877,6 @@ function handleAdditionalClick(event: MouseEvent) {
   overflow: hidden;
 }
 
-.moment-card__main--video .moment-card__desc {
-  min-height: 0;
-  flex: 1 1 auto;
-  -webkit-line-clamp: var(--moment-card-description-lines, unset);
-  text-overflow: ellipsis;
-}
-
-.moment-card__main--video:not(.moment-card__main--live) .moment-card__desc {
-  grid-area: desc;
-  min-width: 0;
-  flex: 0 1 auto;
-  overflow: hidden;
-  -webkit-line-clamp: 8;
-}
-
-.moment-card__main--video:not(.moment-card__main--live) .moment-card__title {
-  display: -webkit-box;
-  grid-area: title;
-  flex: 0 0 auto;
-  margin-bottom: 0;
-  overflow: hidden;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
-  text-overflow: ellipsis;
-}
-
 /* 纯文字卡高度随内容自适应，不设最小高度，避免短动态下方留出大块空白 */
 
 .moment-card--text .moment-card__desc,
@@ -1772,6 +1908,14 @@ function handleAdditionalClick(event: MouseEvent) {
   -webkit-line-clamp: 7;
 }
 
+/* 继承自视频/专栏元数据的简介：弱化层级，与发布者本人文字区分 */
+.moment-card__desc--inherited {
+  color: var(--bew-text-3);
+  font-size: var(--bew-font-size-caption);
+  line-height: var(--bew-line-height-caption);
+  -webkit-line-clamp: 2;
+}
+
 .moment-card__emoji {
   display: inline-block;
   width: 1.35em;
@@ -1795,45 +1939,6 @@ function handleAdditionalClick(event: MouseEvent) {
 
 .moment-card__rich-link:hover {
   text-decoration: underline;
-}
-
-.moment-card__forward-video {
-  display: grid;
-  grid-template-columns: minmax(150px, 44%) minmax(0, 1fr);
-  margin-top: var(--bew-space-3);
-  overflow: hidden;
-  border: 1px solid color-mix(in oklab, var(--bew-border-color), transparent 58%);
-  border-radius: var(--bew-card-radius);
-  color: inherit;
-  background: var(--bew-fill-1);
-  box-sizing: border-box;
-  text-decoration: none;
-  transition:
-    border-color 0.16s ease,
-    background-color 0.16s ease;
-}
-
-.moment-card__forward-video:hover,
-.moment-card__forward-video:focus-visible {
-  border-color: color-mix(in oklab, var(--bew-theme-color), transparent 48%);
-  background: color-mix(in oklab, var(--bew-theme-color) 7%, var(--bew-fill-1));
-  outline: none;
-}
-
-.moment-card__forward-video-cover {
-  position: relative;
-  display: block;
-  min-width: 0;
-  overflow: hidden;
-  aspect-ratio: 16 / 9;
-  background: #111;
-}
-
-.moment-card__forward-video-cover > img {
-  display: block;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
 }
 
 .moment-card__forward-gallery-host {
@@ -1908,40 +2013,6 @@ function handleAdditionalClick(event: MouseEvent) {
   font-variant-numeric: tabular-nums;
 }
 
-.moment-card__forward-video-info {
-  display: flex;
-  min-width: 0;
-  flex-direction: column;
-  justify-content: center;
-  gap: var(--bew-space-2);
-  padding: var(--bew-space-2) var(--bew-space-3);
-}
-
-.moment-card__forward-video-info strong {
-  display: -webkit-box;
-  min-width: 0;
-  flex: 1 1 auto;
-  overflow: hidden;
-  color: var(--bew-text-1);
-  font-size: var(--bew-font-size-body);
-  font-weight: var(--bew-font-weight-semibold);
-  line-height: var(--bew-line-height-title);
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 3;
-}
-
-.moment-card__forward-video-info small {
-  display: flex;
-  min-width: 0;
-  align-items: center;
-  gap: var(--bew-space-1);
-  overflow: hidden;
-  color: var(--bew-text-3);
-  font-size: var(--bew-font-size-caption);
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .moment-card__forward-author {
   overflow: hidden;
   color: inherit;
@@ -1954,32 +2025,6 @@ function handleAdditionalClick(event: MouseEvent) {
 .moment-card__forward-copy .moment-card__forward-author {
   display: inline-block;
   max-width: 100%;
-}
-
-.moment-card__portrait {
-  width: 100%;
-  overflow: hidden;
-  border-radius: var(--bew-media-radius);
-  aspect-ratio: 1 / 2;
-  background: var(--bew-fill-1);
-}
-
-.moment-card__portrait > img {
-  display: block;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  object-position: center top;
-  cursor: zoom-in;
-}
-
-.moment-card__portrait > img:focus-visible {
-  outline: 2px solid var(--bew-theme-color);
-  outline-offset: -2px;
-}
-
-.moment-card--portrait .moment-card__body {
-  min-height: 0;
 }
 
 .moment-card__additional--footer {
@@ -2088,36 +2133,8 @@ function handleAdditionalClick(event: MouseEvent) {
 }
 
 @container (max-width: 359px) {
-  .moment-card__main--has-media {
-    display: flex;
-    flex-direction: column;
-  }
-
   .moment-card__media {
     width: 100%;
-  }
-
-  .moment-card__main--video:not(.moment-card__main--live) {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr);
-    grid-template-areas:
-      "cover"
-      "desc"
-      "title";
-  }
-
-  .moment-card__main--video:not(.moment-card__main--live) .moment-card__desc {
-    -webkit-line-clamp: 4;
-  }
-
-  .moment-card__main--video .moment-card__body {
-    height: auto;
-    max-height: 220px;
-  }
-
-  .moment-card__main--video:not(.moment-card__main--live) .moment-card__body {
-    display: contents;
-    max-height: none;
   }
 
   .moment-card--text .moment-card__body {

--- a/src/components/MomentCard/MomentCard.vue
+++ b/src/components/MomentCard/MomentCard.vue
@@ -1322,6 +1322,7 @@ function handleAdditionalClick(event: MouseEvent) {
 
 .moment-card__forward strong {
   color: var(--bew-text-1);
+  font-weight: var(--bew-font-weight-semibold);
 }
 
 .moment-card__forward p {
@@ -1342,6 +1343,8 @@ function handleAdditionalClick(event: MouseEvent) {
   border-radius: var(--bew-interactive-radius);
   color: inherit;
   background: var(--bew-fill-1);
+  font-size: var(--bew-font-size-body);
+  line-height: var(--bew-line-height-body);
   text-decoration: none;
 }
 
@@ -1386,6 +1389,11 @@ function handleAdditionalClick(event: MouseEvent) {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.moment-card__additional-main strong {
+  color: var(--bew-text-1);
+  font-weight: var(--bew-font-weight-semibold);
 }
 
 .moment-card__additional-main small {

--- a/src/components/MomentCard/MomentCard.vue
+++ b/src/components/MomentCard/MomentCard.vue
@@ -1634,24 +1634,23 @@ function handleAdditionalClick(event: MouseEvent) {
   width: fit-content;
   max-width: 100%;
   overflow: hidden;
-  color: var(--bew-theme-color);
+  color: var(--bew-text-1);
   font-size: var(--bew-font-size-body);
   font-weight: var(--bew-font-weight-semibold);
   line-height: inherit;
   text-decoration: none;
   text-overflow: ellipsis;
   white-space: nowrap;
+  transition: color 0.16s ease;
 }
 
 .moment-card__author-name:hover,
 .moment-card__forward-author:hover {
-  text-decoration: underline;
-  text-underline-offset: 0.15em;
+  color: var(--bew-theme-color);
 }
 
-.moment-card__identity strong,
-.moment-card__identity .moment-card__author-name {
-  color: var(--bew-theme-color);
+.moment-card__identity strong {
+  color: var(--bew-text-1);
   font-size: var(--bew-font-size-body);
   font-weight: var(--bew-font-weight-semibold);
 }
@@ -2023,6 +2022,7 @@ function handleAdditionalClick(event: MouseEvent) {
   text-decoration: none;
   text-overflow: ellipsis;
   white-space: nowrap;
+  transition: color 0.16s ease;
 }
 
 .moment-card__forward-copy .moment-card__forward-author {

--- a/src/components/MomentCard/MomentCard.vue
+++ b/src/components/MomentCard/MomentCard.vue
@@ -11,6 +11,7 @@ import { computeFloatingMenuPosition } from '~/utils/floatingMenu'
 import type { Author, Video } from '../VideoCard/types'
 import VideoCardContextMenu from '../VideoCard/VideoCardContextMenu/VideoCardContextMenu.vue'
 import MomentImageGallery from './MomentImageGallery.vue'
+import MomentVideoStrip from './MomentVideoStrip.vue'
 import type { DisplayForwardVideo, DisplayMoment, WatchLaterTarget } from './types'
 import type { MomentLinkKind } from './utils'
 import {
@@ -576,81 +577,33 @@ function handleAdditionalClick(event: MouseEvent) {
             :aria-label="t('moment_card.open_original_video', { title: moment.title })"
             @click.capture="handlePermalinkClick"
           >
-            <span
-              class="moment-card__video-card-cover"
-              @mouseenter="emit('mediaEnter', moment)"
-              @mouseleave="emit('mediaLeave', moment)"
-            >
-              <img
-                v-if="moment.images.length"
-                :src="getMomentThumbnailUrl(moment.images[0])"
-                :alt="moment.title"
-                loading="lazy"
-                decoding="async"
-                @load="handleCoverLoad"
-              >
-              <span v-else class="moment-card__text-cover moment-card__text-cover--video">
-                <span i-tabler-player-play-filled class="moment-card__text-cover-icon" aria-hidden="true" />
-                <span>{{ t('moment_card.video_post') }}</span>
-              </span>
-              <video
-                v-if="previewActive && previewUrl"
-                :ref="handlePreviewVideo"
-                :src="previewUrl"
-                autoplay
-                muted
-                loop
-                playsinline
-                @canplay="emit('previewCanplay', $event)"
-              />
-              <span
-                v-if="showVideoCoverStats"
-                class="moment-card__video-stats"
-              >
-                <span class="moment-card__video-stat-group">
-                  <span v-if="settings.showVideoCardViewCount && moment.videoPlay">
-                    <span i-mingcute:play-circle-line aria-hidden="true" />
-                    {{ moment.videoPlay }}
-                  </span>
-                </span>
-                <span v-if="showVideoDuration" class="moment-card__video-duration">{{ moment.duration }}</span>
-              </span>
-              <span v-if="moment.isChargeExclusive" class="moment-card__charge-badge">
-                {{ moment.chargeBadge || t('moment_card.charging_exclusive') }}
-              </span>
-              <button
-                v-if="settings.showVideoCardWatchLater"
-                type="button"
-                class="moment-card__watch-later"
-                :class="{ 'is-added': isWatchLaterAdded(moment), 'is-loading': isWatchLaterLoading(moment) }"
-                :aria-busy="isWatchLaterLoading(moment) || undefined"
-                :aria-disabled="isWatchLaterLoading(moment) || undefined"
-                :aria-label="isWatchLaterAdded(moment) ? t('moment_card.added_watch_later') : t('moment_card.add_watch_later')"
-                :aria-pressed="isWatchLaterAdded(moment)"
-                :title="isWatchLaterAdded(moment) ? t('moment_card.added_watch_later') : t('moment_card.add_watch_later')"
-                @click.stop="emit('toggleWatchLater', moment)"
-              >
-                <span v-if="isWatchLaterLoading(moment)" i-svg-spinners:ring-resize aria-hidden="true" />
-                <span v-else-if="isWatchLaterAdded(moment)" i-line-md:confirm aria-hidden="true" />
-                <span v-else i-mingcute:carplay-line aria-hidden="true" />
-              </button>
-            </span>
-            <span class="moment-card__video-card-info">
-              <strong>
-                <VideoWatchedTag
-                  v-if="moment.isVideo"
-                  :aid="moment.aid"
-                  :bvid="moment.bvid"
-                />
-                {{ moment.title || t('moment_card.video_post') }}
-              </strong>
-              <p
-                v-if="moment.descInherited && getCardPreviewText(moment)"
-                class="moment-card__video-card-desc"
-              >
-                {{ getCardPreviewText(moment) }}
-              </p>
-            </span>
+            <MomentVideoStrip
+              :cover="moment.images.length ? getMomentThumbnailUrl(moment.images[0]) : ''"
+              :cover-alt="moment.title"
+              :title="moment.title || t('moment_card.video_post')"
+              :desc="moment.descInherited ? getCardPreviewText(moment) : ''"
+              :author="moment.author.name"
+              :text-cover-text="t('moment_card.video_post')"
+              :charge-badge="moment.isChargeExclusive ? (moment.chargeBadge || t('moment_card.charging_exclusive')) : ''"
+              :show-stats="showVideoCoverStats"
+              :show-play="settings.showVideoCardViewCount && Boolean(moment.videoPlay)"
+              :play="moment.videoPlay"
+              :show-duration="showVideoDuration"
+              :duration="moment.duration"
+              :watched-aid="moment.aid"
+              :watched-bvid="moment.bvid"
+              :watch-later-enabled="settings.showVideoCardWatchLater"
+              :watch-later-added="isWatchLaterAdded(moment)"
+              :watch-later-loading="isWatchLaterLoading(moment)"
+              :preview-active="previewActive"
+              :preview-url="previewUrl"
+              @toggle-watch-later="emit('toggleWatchLater', moment)"
+              @cover-load="handleCoverLoad"
+              @media-enter="emit('mediaEnter', moment)"
+              @media-leave="emit('mediaLeave', moment)"
+              @preview-video="handlePreviewVideo"
+              @preview-canplay="(event: Event) => emit('previewCanplay', event)"
+            />
           </a>
         </template>
         <template v-else>
@@ -780,67 +733,26 @@ function handleAdditionalClick(event: MouseEvent) {
               :aria-label="t('moment_card.open_original_video', { title: moment.forward.video.title })"
               @click="handleForwardVideoClick"
             >
-              <span class="moment-card__video-card-cover">
-                <img
-                  :src="getMomentThumbnailUrl(moment.forward.video.cover)"
-                  :alt="moment.forward.video.title"
-                  loading="lazy"
-                  decoding="async"
-                >
-                <span
-                  v-if="showForwardVideoCoverStats"
-                  class="moment-card__video-stats"
-                >
-                  <span class="moment-card__video-stat-group">
-                    <span v-if="settings.showVideoCardViewCount && moment.forward.video.play">
-                      <span i-mingcute:play-circle-line aria-hidden="true" />
-                      {{ moment.forward.video.play }}
-                    </span>
-                  </span>
-                  <span v-if="showForwardVideoDuration" class="moment-card__video-duration">{{ moment.forward.video.duration }}</span>
-                </span>
-                <span
-                  v-if="settings.showVideoCardWatchLater && getWatchLaterStateKey(moment.forward.video)"
-                  role="button"
-                  :tabindex="isWatchLaterLoading(moment.forward.video) ? -1 : 0"
-                  class="moment-card__watch-later"
-                  :class="{
-                    'is-added': isWatchLaterAdded(moment.forward.video),
-                    'is-disabled': isWatchLaterLoading(moment.forward.video),
-                  }"
-                  :aria-disabled="isWatchLaterLoading(moment.forward.video)"
-                  :aria-label="isWatchLaterAdded(moment.forward.video) ? t('moment_card.added_watch_later') : t('moment_card.add_watch_later')"
-                  :aria-pressed="isWatchLaterAdded(moment.forward.video)"
-                  :title="isWatchLaterAdded(moment.forward.video) ? t('moment_card.added_watch_later') : t('moment_card.add_watch_later')"
-                  @click.stop.prevent="emit('toggleWatchLater', moment.forward.video)"
-                  @keydown.enter.stop.prevent="emit('toggleWatchLater', moment.forward.video)"
-                  @keydown.space.stop.prevent="emit('toggleWatchLater', moment.forward.video)"
-                >
-                  <span v-if="isWatchLaterLoading(moment.forward.video)" i-svg-spinners:ring-resize aria-hidden="true" />
-                  <span v-else-if="isWatchLaterAdded(moment.forward.video)" i-line-md:confirm aria-hidden="true" />
-                  <span v-else i-mingcute:carplay-line aria-hidden="true" />
-                </span>
-              </span>
-              <span class="moment-card__video-card-info">
-                <strong>
-                  <VideoWatchedTag
-                    :aid="moment.forward.video.aid"
-                    :bvid="moment.forward.video.bvid"
-                  />
-                  {{ moment.forward.video.title || moment.forward.fallback }}
-                </strong>
-                <small>
-                  <span i-tabler-user aria-hidden="true" />
-                  <a
-                    v-if="forwardAuthorSpaceUrl"
-                    :href="forwardAuthorSpaceUrl"
-                    class="moment-card__forward-author"
-                    rel="noopener noreferrer"
-                    @click="handleForwardAuthorClick"
-                  >{{ moment.forward.author }}</a>
-                  <template v-else>{{ moment.forward.author }}</template>
-                </small>
-              </span>
+              <MomentVideoStrip
+                :cover="getMomentThumbnailUrl(moment.forward.video.cover)"
+                :cover-alt="moment.forward.video.title"
+                :title="moment.forward.video.title || moment.forward.fallback"
+                :author="moment.forward.author"
+                :author-href="forwardAuthorSpaceUrl"
+                :text-cover-text="moment.forward.fallback"
+                :show-stats="showForwardVideoCoverStats"
+                :show-play="settings.showVideoCardViewCount && Boolean(moment.forward.video.play)"
+                :play="moment.forward.video.play"
+                :show-duration="showForwardVideoDuration"
+                :duration="moment.forward.video.duration"
+                :watched-aid="moment.forward.video.aid"
+                :watched-bvid="moment.forward.video.bvid"
+                :watch-later-enabled="settings.showVideoCardWatchLater && Boolean(getWatchLaterStateKey(moment.forward.video))"
+                :watch-later-added="isWatchLaterAdded(moment.forward.video)"
+                :watch-later-loading="isWatchLaterLoading(moment.forward.video)"
+                @toggle-watch-later="emit('toggleWatchLater', moment.forward.video)"
+                @author-click="handleForwardAuthorClick"
+              />
             </a>
             <div
               v-else-if="moment.forward"
@@ -1210,51 +1122,6 @@ function handleAdditionalClick(event: MouseEvent) {
   z-index: 1;
 }
 
-.moment-card__watch-later {
-  position: absolute;
-  top: var(--bew-space-2);
-  right: var(--bew-space-2);
-  z-index: 3;
-  display: grid;
-  width: 32px;
-  height: 32px;
-  padding: 0;
-  border: 0;
-  border-radius: var(--bew-interactive-radius);
-  place-items: center;
-  color: #fff;
-  background: rgb(0 0 0 / 62%);
-  cursor: pointer;
-  font-size: var(--bew-icon-size-md);
-  opacity: 0;
-  transform: scale(0.78);
-  transition:
-    opacity var(--bew-duration-normal) var(--bew-ease-standard),
-    transform var(--bew-duration-normal) var(--bew-ease-standard),
-    background-color var(--bew-duration-normal) var(--bew-ease-standard);
-}
-
-.moment-card__video-card-cover:hover .moment-card__watch-later,
-.moment-card__watch-later:focus-visible {
-  opacity: 1;
-  transform: scale(1);
-}
-
-.moment-card__watch-later:hover {
-  background: rgb(0 0 0 / 78%);
-}
-
-.moment-card__watch-later:focus-visible {
-  outline: 2px solid #fff;
-  outline-offset: 2px;
-}
-
-.moment-card__watch-later.is-disabled,
-.moment-card__watch-later.is-loading {
-  cursor: wait;
-  opacity: 0.72;
-}
-
 .moment-card__image-count,
 .moment-card__video-mark,
 .moment-card__live-mark {
@@ -1288,43 +1155,6 @@ function handleAdditionalClick(event: MouseEvent) {
   background: var(--bew-theme-color);
   font-weight: var(--bew-font-weight-bold);
   letter-spacing: 0.02em;
-}
-
-.moment-card__charge-badge {
-  position: absolute;
-  top: var(--bew-space-2);
-  left: var(--bew-space-2);
-  z-index: 2;
-  display: inline-flex;
-  align-items: center;
-  gap: var(--bew-space-1);
-  padding: var(--bew-space-1) var(--bew-space-2);
-  border-radius: var(--bew-radius-full);
-  color: #fff;
-  background: linear-gradient(135deg, #ff8eb4, #fb7299);
-  font-size: var(--bew-font-size-control);
-  font-weight: var(--bew-font-weight-semibold);
-  line-height: var(--bew-line-height-control);
-  box-shadow: 0 2px 8px rgb(251 114 153 / 35%);
-}
-
-.moment-card__text-cover {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: var(--bew-space-3);
-  color: var(--bew-text-2);
-  background: linear-gradient(145deg, var(--bew-theme-color-20), var(--bew-fill-1));
-}
-
-.moment-card__text-cover--video {
-  color: #fff;
-  background: linear-gradient(145deg, #394e74, #141b2d);
-}
-
-.moment-card__text-cover-icon {
-  font-size: var(--bew-icon-size-xl);
 }
 
 .moment-card--charge .moment-card__additional-action {
@@ -1595,8 +1425,7 @@ function handleAdditionalClick(event: MouseEvent) {
 }
 
 .moment-card__author-link:focus-visible,
-.moment-card__author-name:focus-visible,
-.moment-card__forward-author:focus-visible {
+.moment-card__author-name:focus-visible {
   outline: 2px solid var(--bew-theme-color);
   outline-offset: 2px;
 }
@@ -1616,8 +1445,7 @@ function handleAdditionalClick(event: MouseEvent) {
   transition: color 0.16s ease;
 }
 
-.moment-card__author-name:hover,
-.moment-card__forward-author:hover {
+.moment-card__author-name:hover {
   color: var(--bew-theme-color);
 }
 
@@ -1656,7 +1484,8 @@ function handleAdditionalClick(event: MouseEvent) {
   background: var(--bew-fill-2);
 }
 
-.moment-card__video-card-cover {
+/* ---- 横条视频卡内容：DOM 在 MomentVideoStrip 子组件内，经 :deep 穿透 ---- */
+.moment-card__video-card :deep(.moment-card__video-card-cover) {
   position: relative;
   display: block;
   min-width: 0;
@@ -1665,9 +1494,9 @@ function handleAdditionalClick(event: MouseEvent) {
   background: #111;
 }
 
-.moment-card__video-card-cover > img,
-.moment-card__video-card-cover > video,
-.moment-card__video-card-cover > .moment-card__text-cover {
+.moment-card__video-card :deep(.moment-card__video-card-cover > img),
+.moment-card__video-card :deep(.moment-card__video-card-cover > video),
+.moment-card__video-card :deep(.moment-card__video-card-cover > .moment-card__text-cover) {
   position: absolute;
   inset: 0;
   width: 100%;
@@ -1675,8 +1504,8 @@ function handleAdditionalClick(event: MouseEvent) {
   object-fit: cover;
 }
 
-/* 信息区从条顶开始排：标题在上、简介/作者紧随，不随封面高度做垂直居中 */
-.moment-card__video-card-info {
+/* 信息区从条顶开始排：标题在上、简介紧随，发布者钉底 */
+.moment-card__video-card :deep(.moment-card__video-card-info) {
   display: flex;
   min-width: 0;
   flex-direction: column;
@@ -1684,7 +1513,7 @@ function handleAdditionalClick(event: MouseEvent) {
   padding: var(--bew-space-3) var(--bew-space-4);
 }
 
-.moment-card__video-card-info strong {
+.moment-card__video-card :deep(.moment-card__video-card-info strong) {
   display: -webkit-box;
   min-width: 0;
   overflow: hidden;
@@ -1697,7 +1526,7 @@ function handleAdditionalClick(event: MouseEvent) {
 }
 
 /* 继承的视频简介：弱化层级，与发布者本人文字区分 */
-.moment-card__video-card-desc {
+.moment-card__video-card :deep(.moment-card__video-card-desc) {
   display: -webkit-box;
   margin: 0;
   overflow: hidden;
@@ -1708,16 +1537,180 @@ function handleAdditionalClick(event: MouseEvent) {
   -webkit-line-clamp: 2;
 }
 
-.moment-card__video-card-info small {
+.moment-card__video-card :deep(.moment-card__video-card-info small) {
+  /* 发布者固定在信息列底部，填充封面高于内容时的剩余空间 */
   display: flex;
   min-width: 0;
+  flex: 0 0 auto;
   align-items: center;
   gap: var(--bew-space-1);
+  margin-top: auto;
   overflow: hidden;
   color: var(--bew-text-3);
   font-size: var(--bew-font-size-caption);
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* 稍后再看：仅横条视频卡使用，显隐只跟封面 hover 与键盘聚焦 */
+.moment-card__video-card :deep(.moment-card__watch-later) {
+  position: absolute;
+  top: var(--bew-space-2);
+  right: var(--bew-space-2);
+  z-index: 3;
+  display: grid;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--bew-interactive-radius);
+  place-items: center;
+  color: #fff;
+  background: rgb(0 0 0 / 62%);
+  cursor: pointer;
+  font-size: var(--bew-icon-size-md);
+  opacity: 0;
+  transform: scale(0.78);
+  transition:
+    opacity var(--bew-duration-normal) var(--bew-ease-standard),
+    transform var(--bew-duration-normal) var(--bew-ease-standard),
+    background-color var(--bew-duration-normal) var(--bew-ease-standard);
+}
+
+.moment-card__video-card :deep(.moment-card__video-card-cover:hover .moment-card__watch-later),
+.moment-card__video-card :deep(.moment-card__watch-later:focus-visible) {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.moment-card__video-card :deep(.moment-card__watch-later:hover) {
+  background: rgb(0 0 0 / 78%);
+}
+
+.moment-card__video-card :deep(.moment-card__watch-later:focus-visible) {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}
+
+.moment-card__video-card :deep(.moment-card__watch-later.is-loading) {
+  cursor: wait;
+  opacity: 0.72;
+}
+
+/* ---- 与旧版封面共用的类：原选择器命中本组件 DOM，:deep 变体命中子组件内部 ---- */
+.moment-card__text-cover,
+.moment-card__video-card :deep(.moment-card__text-cover) {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--bew-space-3);
+  min-height: var(--moment-card-text-cover-min-height, 176px);
+  box-sizing: border-box;
+  color: var(--bew-text-2);
+  background: linear-gradient(145deg, var(--bew-theme-color-20), var(--bew-fill-1));
+}
+
+.moment-card__text-cover--video,
+.moment-card__video-card :deep(.moment-card__text-cover--video) {
+  min-height: 0;
+  aspect-ratio: 16 / 9;
+  color: #fff;
+  background: linear-gradient(145deg, #394e74, #141b2d);
+}
+
+.moment-card__text-cover-icon,
+.moment-card__video-card :deep(.moment-card__text-cover-icon) {
+  font-size: var(--bew-icon-size-xl);
+}
+
+.moment-card__charge-badge,
+.moment-card__video-card :deep(.moment-card__charge-badge) {
+  position: absolute;
+  top: var(--bew-space-2);
+  left: var(--bew-space-2);
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--bew-space-1);
+  padding: var(--bew-space-1) var(--bew-space-2);
+  border-radius: var(--bew-radius-full);
+  color: #fff;
+  background: linear-gradient(135deg, #ff8eb4, #fb7299);
+  font-size: var(--bew-font-size-control);
+  font-weight: var(--bew-font-weight-semibold);
+  line-height: var(--bew-line-height-control);
+  box-shadow: 0 2px 8px rgb(251 114 153 / 35%);
+}
+
+.moment-card__video-stats,
+.moment-card__video-card :deep(.moment-card__video-stats) {
+  position: absolute;
+  inset: auto 0 0;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--bew-space-2);
+  min-height: 28px;
+  padding: var(--bew-space-3) var(--bew-space-2) var(--bew-space-1);
+  color: #fff;
+  background: linear-gradient(to bottom, transparent, rgb(0 0 0 / 72%));
+  box-sizing: border-box;
+  font-size: var(--bew-font-size-control);
+  line-height: var(--bew-line-height-control);
+  text-shadow: 0 1px 2px rgb(0 0 0 / 65%);
+}
+
+.moment-card__video-stat-group,
+.moment-card__video-card :deep(.moment-card__video-stat-group),
+.moment-card__video-stat-group > span,
+.moment-card__video-card :deep(.moment-card__video-stat-group > span) {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+}
+
+.moment-card__video-stat-group,
+.moment-card__video-card :deep(.moment-card__video-stat-group) {
+  gap: var(--bew-space-2);
+}
+
+.moment-card__video-stat-group > span,
+.moment-card__video-card :deep(.moment-card__video-stat-group > span) {
+  gap: var(--bew-space-1);
+}
+
+.moment-card__video-duration,
+.moment-card__video-card :deep(.moment-card__video-duration) {
+  flex: 0 0 auto;
+  margin-left: auto;
+  font-variant-numeric: tabular-nums;
+}
+
+.moment-card__forward-author,
+.moment-card__video-card :deep(.moment-card__forward-author) {
+  overflow: hidden;
+  color: inherit;
+  font-weight: var(--bew-font-weight-semibold);
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  transition: color 0.16s ease;
+}
+
+.moment-card__author-name:hover,
+.moment-card__forward-author:hover,
+.moment-card__video-card :deep(.moment-card__forward-author:hover) {
+  color: var(--bew-theme-color);
+}
+
+.moment-card__author-link:focus-visible,
+.moment-card__author-name:focus-visible,
+.moment-card__forward-author:focus-visible,
+.moment-card__video-card :deep(.moment-card__forward-author:focus-visible) {
+  outline: 2px solid var(--bew-theme-color);
+  outline-offset: 2px;
 }
 
 .moment-card__main--live {
@@ -1788,16 +1781,6 @@ function handleAdditionalClick(event: MouseEvent) {
 .moment-card__gallery .moment-card__image-count {
   right: var(--bew-space-2);
   bottom: var(--bew-space-2);
-}
-
-.moment-card__text-cover {
-  min-height: var(--moment-card-text-cover-min-height, 176px);
-  box-sizing: border-box;
-}
-
-.moment-card__text-cover--video {
-  min-height: 0;
-  aspect-ratio: 16 / 9;
 }
 
 .moment-card__body {
@@ -1946,55 +1929,6 @@ function handleAdditionalClick(event: MouseEvent) {
 
 .moment-card__forward-gallery--1 > img {
   object-fit: cover;
-}
-
-.moment-card__video-stats {
-  position: absolute;
-  inset: auto 0 0;
-  z-index: 2;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--bew-space-2);
-  min-height: 28px;
-  padding: var(--bew-space-3) var(--bew-space-2) var(--bew-space-1);
-  color: #fff;
-  background: linear-gradient(to bottom, transparent, rgb(0 0 0 / 72%));
-  box-sizing: border-box;
-  font-size: var(--bew-font-size-control);
-  line-height: var(--bew-line-height-control);
-  text-shadow: 0 1px 2px rgb(0 0 0 / 65%);
-}
-
-.moment-card__video-stat-group,
-.moment-card__video-stat-group > span {
-  display: inline-flex;
-  min-width: 0;
-  align-items: center;
-}
-
-.moment-card__video-stat-group {
-  gap: var(--bew-space-2);
-}
-
-.moment-card__video-stat-group > span {
-  gap: var(--bew-space-1);
-}
-
-.moment-card__video-duration {
-  flex: 0 0 auto;
-  margin-left: auto;
-  font-variant-numeric: tabular-nums;
-}
-
-.moment-card__forward-author {
-  overflow: hidden;
-  color: inherit;
-  font-weight: var(--bew-font-weight-semibold);
-  text-decoration: none;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  transition: color 0.16s ease;
 }
 
 .moment-card__forward-copy .moment-card__forward-author {

--- a/src/components/MomentCard/MomentCard.vue
+++ b/src/components/MomentCard/MomentCard.vue
@@ -1186,8 +1186,8 @@ function handleAdditionalClick(event: MouseEvent) {
 }
 
 .moment-card__live-mark {
-  top: 8px;
-  left: 8px;
+  top: var(--bew-space-2);
+  left: var(--bew-space-2);
   bottom: auto;
   z-index: 2;
   border-radius: var(--bew-badge-radius);
@@ -1215,7 +1215,6 @@ function handleAdditionalClick(event: MouseEvent) {
 }
 
 .moment-card__text-cover {
-  min-height: 152px;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -1238,20 +1237,12 @@ function handleAdditionalClick(event: MouseEvent) {
   color: #fb7299;
 }
 
-.moment-card__body {
-  padding: var(--bew-space-3);
-}
-
 .moment-card--text .moment-card__body {
   padding-top: var(--bew-space-4);
 }
 
 .moment-card--text .moment-card__desc {
   -webkit-line-clamp: 10;
-}
-
-.moment-card__title {
-  margin: 0 0 var(--bew-space-2);
 }
 
 .moment-card__media-meta {
@@ -1262,11 +1253,11 @@ function handleAdditionalClick(event: MouseEvent) {
 
 .moment-card__media-meta--live {
   align-self: flex-start;
-  padding: 4px 8px;
+  padding: var(--bew-space-1) var(--bew-space-2);
   border-radius: var(--bew-interactive-radius);
   color: var(--bew-theme-color);
   background: var(--bew-theme-color-10);
-  line-height: 1.35;
+  line-height: var(--bew-line-height-control);
 }
 
 .moment-card__desc {
@@ -1277,15 +1268,6 @@ function handleAdditionalClick(event: MouseEvent) {
   -webkit-line-clamp: 4;
   white-space: pre-wrap;
   word-break: break-word;
-}
-
-.moment-card__footer {
-  display: flex;
-  align-items: center;
-  gap: var(--bew-space-2);
-  margin-top: var(--bew-space-3);
-  color: var(--bew-text-2);
-  font-size: var(--bew-font-size-control);
 }
 
 .moment-card__forward {
@@ -1337,9 +1319,9 @@ function handleAdditionalClick(event: MouseEvent) {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
-  gap: 12px;
+  gap: var(--bew-space-3);
   margin-top: var(--bew-space-3);
-  padding: 12px 16px;
+  padding: var(--bew-space-3) var(--bew-space-4);
   border-radius: var(--bew-interactive-radius);
   color: inherit;
   background: var(--bew-fill-1);
@@ -1353,7 +1335,7 @@ function handleAdditionalClick(event: MouseEvent) {
   min-width: 0;
   grid-template-columns: 40px minmax(0, 1fr);
   align-items: center;
-  gap: 12px;
+  gap: var(--bew-space-3);
   color: inherit;
   text-decoration: none;
 }
@@ -1446,8 +1428,8 @@ function handleAdditionalClick(event: MouseEvent) {
 }
 
 .moment-card__avatar {
-  width: 21px;
-  height: 21px;
+  width: 36px;
+  height: 36px;
   border-radius: 50%;
   object-fit: cover;
   background: var(--bew-fill-1);
@@ -1499,11 +1481,6 @@ function handleAdditionalClick(event: MouseEvent) {
   align-items: center;
   gap: var(--bew-space-3);
   padding: var(--bew-space-3) var(--bew-space-4);
-}
-
-.moment-card__header .moment-card__avatar {
-  width: 36px;
-  height: 36px;
 }
 
 .moment-card__identity {
@@ -1624,18 +1601,10 @@ function handleAdditionalClick(event: MouseEvent) {
   width: 100%;
 }
 
-.moment-card__main--live .moment-card__cover--media {
-  aspect-ratio: 16 / 9;
-}
-
 .moment-card__media {
   min-width: 0;
   overflow: hidden;
   border-radius: var(--bew-media-radius);
-}
-
-.moment-card__cover--media {
-  aspect-ratio: 16 / 9;
 }
 
 .moment-card__gallery-host {
@@ -1681,8 +1650,8 @@ function handleAdditionalClick(event: MouseEvent) {
 }
 
 .moment-card__gallery .moment-card__image-count {
-  right: 8px;
-  bottom: 8px;
+  right: var(--bew-space-2);
+  bottom: var(--bew-space-2);
 }
 
 .moment-card__text-cover {
@@ -1789,7 +1758,7 @@ function handleAdditionalClick(event: MouseEvent) {
 }
 
 .moment-card__title {
-  margin-bottom: var(--bew-space-2);
+  margin: 0 0 var(--bew-space-2);
   color: var(--bew-text-1);
   font-size: var(--bew-font-size-title);
   font-weight: var(--bew-font-weight-semibold);
@@ -1910,7 +1879,7 @@ function handleAdditionalClick(event: MouseEvent) {
   justify-content: space-between;
   gap: var(--bew-space-2);
   min-height: 28px;
-  padding: 12px 8px 4px;
+  padding: var(--bew-space-3) var(--bew-space-2) var(--bew-space-1);
   color: #fff;
   background: linear-gradient(to bottom, transparent, rgb(0 0 0 / 72%));
   box-sizing: border-box;
@@ -2087,7 +2056,7 @@ function handleAdditionalClick(event: MouseEvent) {
   min-width: 0;
   height: 100%;
   margin: 0;
-  padding: 0 8px;
+  padding: 0 var(--bew-space-2);
   border: 0;
   border-radius: 0;
   color: inherit;

--- a/src/components/MomentCard/MomentCard.vue
+++ b/src/components/MomentCard/MomentCard.vue
@@ -1914,8 +1914,8 @@ function handleAdditionalClick(event: MouseEvent) {
   color: #fff;
   background: linear-gradient(to bottom, transparent, rgb(0 0 0 / 72%));
   box-sizing: border-box;
-  font-size: var(--bew-font-size-caption);
-  line-height: var(--bew-line-height-caption);
+  font-size: var(--bew-font-size-control);
+  line-height: var(--bew-line-height-control);
   text-shadow: 0 1px 2px rgb(0 0 0 / 65%);
 }
 

--- a/src/components/MomentCard/MomentVideoStrip.vue
+++ b/src/components/MomentCard/MomentVideoStrip.vue
@@ -1,0 +1,131 @@
+<script setup lang="ts">
+import type { ComponentPublicInstance } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import VideoWatchedTag from '~/components/VideoWatchedTag.vue'
+
+// 可选项缺省�?undefined，模板按 falsy 处理；cover/title 等必传项由调用方保证
+defineProps<{
+  /** 最终封面图 URL；空串回落到文字封面 */
+  cover: string
+  coverAlt?: string
+  title: string
+  /** 继承的视频简介，空则不渲�? */
+  desc?: string
+  author: string
+  /** 提供时作者可点击跳转空间页（转发卡）；主卡为纯文�? */
+  authorHref?: string
+  /** 无封面时的文字占位文�? */
+  textCoverText: string
+  /** 非空渲染充电专属徽章 */
+  chargeBadge?: string
+  showStats?: boolean
+  showPlay?: boolean
+  play?: string
+  showDuration?: boolean
+  duration?: string
+  watchedAid?: number | string
+  watchedBvid?: string
+  watchLaterEnabled?: boolean
+  watchLaterAdded?: boolean
+  watchLaterLoading?: boolean
+  previewActive?: boolean
+  previewUrl?: string
+}>()
+
+const emit = defineEmits<{
+  toggleWatchLater: []
+  coverLoad: [event: Event]
+  mediaEnter: []
+  mediaLeave: []
+  previewVideo: [element: Element | null]
+  previewCanplay: [event: Event]
+  authorClick: [event: MouseEvent]
+}>()
+
+const { t } = useI18n()
+
+function handlePreviewRef(element: Element | ComponentPublicInstance | null) {
+  emit('previewVideo', element instanceof Element ? element : null)
+}
+</script>
+
+<template>
+  <span
+    class="moment-card__video-card-cover"
+    @mouseenter="emit('mediaEnter')"
+    @mouseleave="emit('mediaLeave')"
+  >
+    <img
+      v-if="cover"
+      :src="cover"
+      :alt="coverAlt || title"
+      loading="lazy"
+      decoding="async"
+      @load="emit('coverLoad', $event)"
+    >
+    <span v-else class="moment-card__text-cover moment-card__text-cover--video">
+      <span i-tabler-player-play-filled class="moment-card__text-cover-icon" aria-hidden="true" />
+      <span>{{ textCoverText }}</span>
+    </span>
+    <video
+      v-if="previewActive && previewUrl"
+      :ref="handlePreviewRef"
+      :src="previewUrl"
+      autoplay
+      muted
+      loop
+      playsinline
+      @canplay="emit('previewCanplay', $event)"
+    />
+    <span
+      v-if="showStats"
+      class="moment-card__video-stats"
+    >
+      <span class="moment-card__video-stat-group">
+        <span v-if="showPlay">
+          <span i-mingcute:play-circle-line aria-hidden="true" />
+          {{ play }}
+        </span>
+      </span>
+      <span v-if="showDuration" class="moment-card__video-duration">{{ duration }}</span>
+    </span>
+    <span v-if="chargeBadge" class="moment-card__charge-badge">{{ chargeBadge }}</span>
+    <button
+      v-if="watchLaterEnabled"
+      type="button"
+      class="moment-card__watch-later"
+      :class="{ 'is-added': watchLaterAdded, 'is-loading': watchLaterLoading }"
+      :aria-busy="watchLaterLoading || undefined"
+      :aria-disabled="watchLaterLoading || undefined"
+      :aria-label="watchLaterAdded ? t('moment_card.added_watch_later') : t('moment_card.add_watch_later')"
+      :aria-pressed="watchLaterAdded"
+      :title="watchLaterAdded ? t('moment_card.added_watch_later') : t('moment_card.add_watch_later')"
+      @click.stop.prevent="emit('toggleWatchLater')"
+    >
+      <span v-if="watchLaterLoading" i-svg-spinners:ring-resize aria-hidden="true" />
+      <span v-else-if="watchLaterAdded" i-line-md:confirm aria-hidden="true" />
+      <span v-else i-mingcute:carplay-line aria-hidden="true" />
+    </button>
+  </span>
+  <span class="moment-card__video-card-info">
+    <strong>
+      <VideoWatchedTag :aid="watchedAid" :bvid="watchedBvid" />
+      {{ title }}
+    </strong>
+    <p v-if="desc" class="moment-card__video-card-desc">
+      {{ desc }}
+    </p>
+    <small>
+      <span i-tabler-user aria-hidden="true" />
+      <a
+        v-if="authorHref"
+        :href="authorHref"
+        class="moment-card__forward-author"
+        rel="noopener noreferrer"
+        @click="emit('authorClick', $event)"
+      >{{ author }}</a>
+      <template v-else>{{ author }}</template>
+    </small>
+  </span>
+</template>

--- a/src/components/MomentCard/types.ts
+++ b/src/components/MomentCard/types.ts
@@ -50,6 +50,8 @@ export interface DisplayMoment {
   publishedAt: number
   title: string
   text: string
+  /** desc 继承自视频/专栏元数据（简介）而非发布者本人文字，卡片内做弱化展示 */
+  descInherited?: boolean
   richText: DisplayRichTextSegment[]
   images: string[]
   /** 与 images 对齐的宽高比（宽/高），用于多图横向画廊计算共用高度 */

--- a/src/contentScripts/views/Moments/Moments.vue
+++ b/src/contentScripts/views/Moments/Moments.vue
@@ -208,8 +208,10 @@ let detailLoadTimer: ReturnType<typeof setTimeout> | null = null
 let detailFocusRetryTimer: ReturnType<typeof setTimeout> | null = null
 const layoutRef = ref<HTMLElement | null>(null)
 const gridRef = ref<HTMLElement | null>(null)
-/** 按当前实际列数限制单张动态卡片的最大宽度。 */
-const GRID_GAP = 16
+/** 与 .moments-grid__column 的 gap 及 CSS 变量联动，虚拟滚动测量按此计算。 */
+const GRID_GAP = 20
+/** 与 .moments-layout 的 column-gap(--bew-space-6) 一致。 */
+const LAYOUT_GAP = 24
 const CARD_MAX_WIDTH_BY_COLUMNS = {
   1: 720,
   2: 610,
@@ -2362,7 +2364,7 @@ function updateGridColumnCount() {
   const wantRight = settings.value.momentsSidebarShowHotSearch
 
   function tryLayout(cols: number, left: boolean, right: boolean) {
-    const reserve = (left ? SIDEBAR_WIDTH + GRID_GAP : 0) + (right ? SIDEBAR_WIDTH + GRID_GAP : 0)
+    const reserve = (left ? SIDEBAR_WIDTH + LAYOUT_GAP : 0) + (right ? SIDEBAR_WIDTH + LAYOUT_GAP : 0)
     const budget = layoutWidth - reserve
     if (budget < CARD_COMPACT_MIN_WIDTH)
       return null
@@ -4601,14 +4603,14 @@ watch(
 
 <style scoped lang="scss">
 .moments-page {
-  padding: var(--bew-space-2) var(--bew-space-3) var(--bew-space-12);
+  padding: var(--bew-space-2) var(--bew-space-5) var(--bew-space-12);
 }
 .moments-layout {
   display: grid;
   justify-content: center;
   align-items: start;
-  column-gap: var(--bew-space-4);
-  row-gap: var(--bew-space-4);
+  column-gap: var(--bew-space-6);
+  row-gap: var(--bew-space-6);
   width: 100%;
   grid-template-columns: auto;
   grid-template-areas:
@@ -4645,7 +4647,7 @@ watch(
   align-items: stretch;
   gap: 0;
   margin-bottom: var(--bew-space-4);
-  padding: var(--bew-space-3) var(--bew-space-2) var(--bew-space-2);
+  padding: var(--bew-space-4);
   border-radius: var(--bew-card-radius);
   background: var(--bew-elevated);
   box-shadow: none;
@@ -4898,7 +4900,7 @@ watch(
   max-width: 100%;
   max-height: calc(100dvh - var(--bew-top-bar-height, 64px) - var(--bew-space-6));
   flex-direction: column;
-  gap: var(--bew-space-3);
+  gap: var(--bew-space-5);
   min-width: 0;
   overflow-x: hidden;
   overflow-y: auto;
@@ -5096,7 +5098,7 @@ watch(
   height: 72px;
   min-width: 0;
   flex: 0 0 72px;
-  padding: var(--bew-space-2) var(--bew-space-1);
+  padding: var(--bew-space-2);
   border-radius: var(--bew-interactive-radius);
   color: inherit;
   text-decoration: none;
@@ -5232,13 +5234,12 @@ watch(
   display: grid;
   align-items: start;
   justify-content: center;
-  gap: var(--bew-space-4);
   width: 100%;
 }
 .moments-skeleton-column {
   display: flex;
   flex-direction: column;
-  gap: var(--bew-space-4);
+  gap: var(--bew-space-5);
   width: 100%;
   max-width: 100%;
   min-width: 0;
@@ -5411,7 +5412,6 @@ watch(
 }
 .moments-grid {
   display: grid;
-  gap: var(--bew-space-4);
   width: 100%;
   justify-content: center;
   justify-items: stretch;
@@ -5424,7 +5424,8 @@ watch(
   max-width: 100%;
   min-width: 0;
   flex-direction: column;
-  gap: var(--bew-space-4);
+  /* 与 JS 的 GRID_GAP 一致 */
+  gap: var(--bew-space-5);
 }
 .moments-grid :deep(.moment-card) {
   width: 100%;

--- a/src/contentScripts/views/Moments/Moments.vue
+++ b/src/contentScripts/views/Moments/Moments.vue
@@ -31,6 +31,7 @@ import { recordUploaderLatestVideoTimes } from '~/logic/uploaderLatestVideoTimes
 import type { DataItem, MomentResult } from '~/models/moment/moment'
 import { useTopBarStore } from '~/stores/topBarStore'
 import api from '~/utils/api'
+import { numFormatter } from '~/utils/dataFormatter'
 import { getCSRF } from '~/utils/main'
 import { resolvePgcEpisodeVideoIds } from '~/utils/pgcEpisode'
 import { openLinkInBackground } from '~/utils/tabs'
@@ -4000,9 +4001,36 @@ watch(
               </span>
             </a>
             <div v-if="portalUser" class="moments-user-card__stats">
-              <span><strong>{{ portalUser.following }}</strong><small>{{ t('moments.following') }}</small></span>
-              <span><strong>{{ portalUser.follower }}</strong><small>{{ t('moments.followers') }}</small></span>
-              <span><strong>{{ portalUser.dyns }}</strong><small>{{ t('moments.posts') }}</small></span>
+              <a
+                class="moments-user-card__stat"
+                :href="`https://space.bilibili.com/${portalUser.mid}/fans/follow`"
+                :title="`${portalUser.following}`"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <strong>{{ numFormatter(portalUser.following) }}</strong>
+                <small>{{ t('moments.following') }}</small>
+              </a>
+              <a
+                class="moments-user-card__stat"
+                :href="`https://space.bilibili.com/${portalUser.mid}/fans/fans`"
+                :title="`${portalUser.follower}`"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <strong>{{ numFormatter(portalUser.follower) }}</strong>
+                <small>{{ t('moments.followers') }}</small>
+              </a>
+              <a
+                class="moments-user-card__stat"
+                :href="`https://space.bilibili.com/${portalUser.mid}/dynamic`"
+                :title="`${portalUser.dyns}`"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <strong>{{ numFormatter(portalUser.dyns) }}</strong>
+                <small>{{ t('moments.posts') }}</small>
+              </a>
             </div>
             <div v-else class="moments-sidebar-editor-placeholder">
               {{ $t('settings.moments_show_user_card') }}
@@ -4934,7 +4962,7 @@ watch(
   overflow: hidden;
   color: var(--bew-text-1);
   font-size: var(--bew-font-size-heading);
-  font-weight: var(--bew-font-weight-semibold);
+  font-weight: var(--bew-font-weight-medium);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -4963,30 +4991,53 @@ watch(
   color: #fb7299;
   border: 1px solid currentcolor;
 }
+// 统计区对齐 UserPanelPop 的 channel-info-item：竖线分隔、hover 变主题色、可跳转
 .moments-user-card__stats {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  margin-top: var(--bew-space-5);
+  gap: var(--bew-space-2);
+  margin-top: var(--bew-space-4);
+  padding-top: var(--bew-space-2);
+  border-top: 1px solid var(--bew-border-color);
 }
-.moments-user-card__stats > span {
+.moments-user-card__stat {
+  position: relative;
   display: flex;
   min-width: 0;
   flex-direction: column;
   align-items: center;
   gap: var(--bew-space-1);
+  color: inherit;
+  text-decoration: none;
 }
-.moments-user-card__stats strong {
+.moments-user-card__stat + .moments-user-card__stat::before {
+  position: absolute;
+  left: calc(var(--bew-space-2) / -2);
+  top: var(--bew-space-2);
+  bottom: var(--bew-space-2);
+  width: 1px;
+  background: var(--bew-border-color);
+  content: "";
+}
+.moments-user-card__stat:hover strong,
+.moments-user-card__stat:hover small {
+  color: var(--bew-theme-color);
+}
+.moments-user-card__stat strong {
   overflow: hidden;
   max-width: 100%;
   color: var(--bew-text-1);
   font-size: var(--bew-font-size-heading);
   font-weight: var(--bew-font-weight-semibold);
   text-overflow: ellipsis;
+  transition: color var(--bew-duration-normal) var(--bew-ease-standard);
 }
-.moments-user-card__stats small {
-  color: var(--bew-text-3);
-  font-size: var(--bew-font-size-control);
-  line-height: var(--bew-line-height-control);
+.moments-user-card__stat small {
+  color: var(--bew-text-2);
+  font-size: var(--bew-font-size-caption);
+  font-weight: var(--bew-font-weight-semibold);
+  line-height: var(--bew-line-height-caption);
+  transition: color var(--bew-duration-normal) var(--bew-ease-standard);
 }
 .moments-publish-link {
   display: flex;
@@ -5029,6 +5080,7 @@ watch(
 .moments-live-card > header strong {
   color: var(--bew-text-1);
   font-size: var(--bew-font-size-title);
+  font-weight: var(--bew-font-weight-semibold);
   line-height: var(--bew-line-height-title);
 }
 .moments-live-card > header span {

--- a/src/contentScripts/views/Moments/Moments.vue
+++ b/src/contentScripts/views/Moments/Moments.vue
@@ -4767,8 +4767,9 @@ watch(
   flex-direction: column;
   align-items: center;
   gap: var(--bew-space-1);
-  width: 64px;
-  min-width: 64px;
+  // 72px：48px 头像 + 上下留白后内容区 64px
+  width: 72px;
+  min-width: 72px;
   padding: var(--bew-space-1);
   border: 0;
   border-radius: var(--bew-interactive-radius);

--- a/src/contentScripts/views/Moments/Moments.vue
+++ b/src/contentScripts/views/Moments/Moments.vue
@@ -681,13 +681,19 @@ function getMomentContent(item: any) {
 
   // 图文/纯文字（itemOpusStyle）正文：major.opus.summary.text
   // 旧结构可能在 module_dynamic.desc.text；视频/专栏等再回落到各自 desc
+  // 视频动态的 module_dynamic.desc 是简介副本，归入继承来源，避免被当成本人正文
+  const isVideoMajor = Boolean(major.archive || major.ugc_season || major.pgc)
   const selfText = pickText(
     opus.summary?.text,
     typeof opus.summary === 'string' ? opus.summary : '',
-    normalizeDescText(dynamic.desc),
+    isVideoMajor ? '' : normalizeDescText(dynamic.desc),
     common.desc,
   )
-  const inheritedText = pickText(archive.desc, article.desc)
+  const inheritedText = pickText(
+    isVideoMajor ? normalizeDescText(dynamic.desc) : '',
+    archive.desc,
+    article.desc,
+  )
   let text = pickText(selfText, inheritedText)
   /** 简介继承自视频/专栏元数据时标记，卡片内做弱化展示 */
   const descInherited = !selfText && Boolean(inheritedText)
@@ -1698,6 +1704,7 @@ function mapMoment(item: DataItem): DisplayMoment {
     publishedAt: Number(author.pub_ts || 0),
     title: content.title,
     text,
+    descInherited: !isForward && Boolean(content.descInherited),
     richText,
     // 转发卡片只展示原动态摘要，不能把原动态图片提升为外层卡片媒体。
     images: isForward || (isChargeExclusive && !content.isVideo) ? [] : content.images,
@@ -1805,7 +1812,7 @@ function mapMoment(item: DataItem): DisplayMoment {
 function estimateVideoCardStripHeight(contentWidth: number) {
   const coverWidth = Math.max(150, contentWidth * 0.44)
   const coverHeight = Math.round(coverWidth * 9 / 16)
-  const infoHeight = 106
+  const infoHeight = 112
   return Math.max(coverHeight, infoHeight) + 2 /* 描边 */
 }
 

--- a/src/contentScripts/views/Moments/Moments.vue
+++ b/src/contentScripts/views/Moments/Moments.vue
@@ -1746,7 +1746,7 @@ function mapMoment(item: DataItem): DisplayMoment {
     chargeBadge: content.chargeBadge || selfContent.chargeBadge,
     chargeHint: content.chargeHint || selfContent.chargeHint,
     chargeCover: content.chargeCover || selfContent.chargeCover,
-    mediaMeta: content.mediaMeta,
+    mediaMeta: isForward ? '' : content.mediaMeta,
     liveArea: content.liveArea,
     livePopularity: content.livePopularity,
     roomId: content.roomId,

--- a/src/contentScripts/views/Moments/Moments.vue
+++ b/src/contentScripts/views/Moments/Moments.vue
@@ -1808,11 +1808,11 @@ function mapMoment(item: DataItem): DisplayMoment {
   }
 }
 
-/** 横条视频卡高度：封面 44% 宽 16:9，与信息区（标题两行 + 简介两行）取较大者。 */
+/** 横条视频卡高度：封面 44% 宽 16:9，与信息区（标题两行 + 简介两行 + 作者一行）取较大者。 */
 function estimateVideoCardStripHeight(contentWidth: number) {
   const coverWidth = Math.max(150, contentWidth * 0.44)
   const coverHeight = Math.round(coverWidth * 9 / 16)
-  const infoHeight = 112
+  const infoHeight = 136
   return Math.max(coverHeight, infoHeight) + 2 /* 描边 */
 }
 

--- a/src/contentScripts/views/Moments/Moments.vue
+++ b/src/contentScripts/views/Moments/Moments.vue
@@ -5035,7 +5035,7 @@ watch(
   min-height: 44px;
   padding: 0 var(--bew-space-4);
   border: 0;
-  border-radius: var(--bew-interactive-radius);
+  border-radius: var(--bew-panel-radius);
   color: var(--bew-text-1);
   background: var(--bew-elevated);
   box-shadow: none;

--- a/src/contentScripts/views/Moments/Moments.vue
+++ b/src/contentScripts/views/Moments/Moments.vue
@@ -4757,15 +4757,31 @@ watch(
   outline: 2px solid var(--bew-theme-color);
   outline-offset: 2px;
 }
-.moments-up-list__item--active .moments-up-list__name {
-  color: var(--bew-theme-color);
+// hover 即选中态：光环与名称变色复用 active 样式，移开时平滑过渡
+@mixin up-item-selected {
+  .moments-up-list__name {
+    color: var(--bew-theme-color);
+  }
+
+  .moments-up-list__avatar > img,
+  .moments-up-list__avatar--all,
+  .moments-up-list__avatar--wanted {
+    box-shadow:
+      0 0 0 2px var(--bew-elevated),
+      0 0 0 4px var(--bew-theme-color);
+  }
+
+  .moments-up-list__avatar--all,
+  .moments-up-list__avatar--wanted {
+    border-color: var(--bew-theme-color);
+    color: #fff;
+    background: var(--bew-theme-color);
+  }
 }
-.moments-up-list__item--active .moments-up-list__avatar > img,
-.moments-up-list__item--active .moments-up-list__avatar--all,
-.moments-up-list__item--active .moments-up-list__avatar--wanted {
-  box-shadow:
-    0 0 0 2px var(--bew-elevated),
-    0 0 0 4px var(--bew-theme-color);
+
+.moments-up-list__item--active,
+.moments-up-list__item:hover:not(:disabled) {
+  @include up-item-selected;
 }
 .moments-up-list__item--skeleton {
   pointer-events: none;
@@ -4784,6 +4800,7 @@ watch(
   border-radius: 50%;
   object-fit: cover;
   background: var(--bew-fill-1);
+  transition: box-shadow var(--bew-duration-fast) var(--bew-ease-standard);
 }
 .moments-up-list__avatar--all,
 .moments-up-list__avatar--wanted {
@@ -4792,16 +4809,15 @@ watch(
   width: 48px;
   height: 48px;
   box-sizing: border-box;
-  border: 0;
+  border: 2px solid transparent;
   border-radius: 50%;
   color: var(--bew-theme-color);
   background: var(--bew-theme-color-20);
-}
-.moments-up-list__item--active .moments-up-list__avatar--all,
-.moments-up-list__item--active .moments-up-list__avatar--wanted {
-  border: 2px solid var(--bew-theme-color);
-  color: #fff;
-  background: var(--bew-theme-color);
+  transition:
+    color var(--bew-duration-fast) var(--bew-ease-standard),
+    background-color var(--bew-duration-fast) var(--bew-ease-standard),
+    border-color var(--bew-duration-fast) var(--bew-ease-standard),
+    box-shadow var(--bew-duration-fast) var(--bew-ease-standard);
 }
 .moments-up-list__item:disabled {
   opacity: 0.45;
@@ -4836,6 +4852,7 @@ watch(
   text-align: center;
   text-overflow: ellipsis;
   white-space: nowrap;
+  transition: color var(--bew-duration-fast) var(--bew-ease-standard);
 }
 .moments-up-list__item--skeleton .moments-up-list__name {
   width: 40px;

--- a/src/contentScripts/views/Moments/Moments.vue
+++ b/src/contentScripts/views/Moments/Moments.vue
@@ -681,14 +681,16 @@ function getMomentContent(item: any) {
 
   // 图文/纯文字（itemOpusStyle）正文：major.opus.summary.text
   // 旧结构可能在 module_dynamic.desc.text；视频/专栏等再回落到各自 desc
-  let text = pickText(
+  const selfText = pickText(
     opus.summary?.text,
     typeof opus.summary === 'string' ? opus.summary : '',
     normalizeDescText(dynamic.desc),
-    archive.desc,
-    article.desc,
     common.desc,
   )
+  const inheritedText = pickText(archive.desc, article.desc)
+  let text = pickText(selfText, inheritedText)
+  /** 简介继承自视频/专栏元数据时标记，卡片内做弱化展示 */
+  const descInherited = !selfText && Boolean(inheritedText)
   const richText = extractRichTextSegments(
     opus.summary?.rich_text_nodes,
     dynamic.desc?.rich_text_nodes,
@@ -794,6 +796,7 @@ function getMomentContent(item: any) {
   return {
     title: pickText(live?.title, opus.title, archive.title, article.title, common.title),
     text,
+    descInherited,
     richText,
     images,
     imageRatios,
@@ -1798,6 +1801,14 @@ function mapMoment(item: DataItem): DisplayMoment {
   }
 }
 
+/** 横条视频卡高度：封面 44% 宽 16:9，与信息区（标题两行 + 简介两行）取较大者。 */
+function estimateVideoCardStripHeight(contentWidth: number) {
+  const coverWidth = Math.max(150, contentWidth * 0.44)
+  const coverHeight = Math.round(coverWidth * 9 / 16)
+  const infoHeight = 106
+  return Math.max(coverHeight, infoHeight) + 2 /* 描边 */
+}
+
 function estimateCardHeight(moment: DisplayMoment) {
   const columnWidth = Math.max(
     CARD_COMPACT_MIN_WIDTH,
@@ -1838,48 +1849,27 @@ function estimateCardHeight(moment: DisplayMoment) {
   }
   if (moment.forward?.video) {
     const introLines = Math.min(7, Math.max(1, Math.ceil((moment.text || '').length / 28)))
-    const forwardMediaWidth = Math.max(150, contentWidth * 0.44)
-    return 117 + Math.round(forwardMediaWidth * 9 / 16) + introLines * 21 + interactionHeight
+    return 126 + 12 + estimateVideoCardStripHeight(contentWidth) + introLines * 24 + (moment.additional ? 68 : 0) + interactionHeight
   }
   if (moment.isChargeExclusive && !moment.isVideo)
     return 230 + scaledTextBodyExtra + interactionHeight
   if (columnWidth < CARD_MIN_WIDTH) {
     if (moment.isLive)
       return Math.round(columnWidth * 9 / 16) + 210 + interactionHeight
-    if (moment.isVideo) {
-      const mediaWidth = Math.max(1, contentWidth)
-      const charsPerLine = Math.max(12, Math.floor(mediaWidth / 14))
-      const titleLines = moment.title
-        ? Math.min(2, Math.max(1, Math.ceil(Array.from(moment.title).length / charsPerLine)))
-        : 0
-      const previewText = getCardPreviewText(moment)
-      const descLines = previewText
-        ? Math.min(8, Math.max(1, Math.ceil(Array.from(previewText).length / charsPerLine)))
-        : 0
-      const bodyHeight = titleLines * 22
-        + (titleLines && descLines ? 8 : 0)
-        + descLines * 24
-      return Math.round(mediaWidth * 9 / 16)
-        + 126
-        + bodyHeight
-        + (moment.additional ? 68 : 0)
-        + interactionHeight
-    }
   }
   if (moment.isLive)
     return Math.round(contentWidth * 9 / 16) + 190 + interactionHeight
   if (moment.isVideo) {
-    // 左封面右简介：高度由半宽 16:9 封面决定，标题单独落在底部。
-    const innerWidth = contentWidth
-    const coverWidth = Math.max(1, Math.floor((innerWidth - 12) / 2))
-    const titleCharsPerLine = Math.max(12, Math.floor(innerWidth / 14))
-    const titleLines = moment.title
-      ? Math.min(2, Math.max(1, Math.ceil(Array.from(moment.title).length / titleCharsPerLine)))
+    // 官方式横条视频卡：左封面右信息，附言在条上方，继承简介固定两行
+    const noteText = moment.descInherited ? '' : getCardPreviewText(moment)
+    const noteCharsPerLine = Math.max(12, Math.floor(contentWidth / 15))
+    const noteLines = noteText
+      ? Math.min(7, Math.max(1, Math.ceil(Array.from(noteText).length / noteCharsPerLine)))
       : 0
-    const titleHeight = titleLines ? 12 + titleLines * 22 : 0
-    return Math.round(coverWidth * 9 / 16)
-      + titleHeight
-      + 126
+    return 126
+      + 12 /* 条与上方内容的间距 */
+      + estimateVideoCardStripHeight(contentWidth)
+      + noteLines * 24
       + (moment.additional ? 68 : 0)
       + interactionHeight
   }

--- a/src/contentScripts/views/Moments/Moments.vue
+++ b/src/contentScripts/views/Moments/Moments.vue
@@ -4997,11 +4997,8 @@ watch(
   grid-template-columns: repeat(3, 1fr);
   gap: var(--bew-space-2);
   margin-top: var(--bew-space-4);
-  padding-top: var(--bew-space-2);
-  border-top: 1px solid var(--bew-border-color);
 }
 .moments-user-card__stat {
-  position: relative;
   display: flex;
   min-width: 0;
   flex-direction: column;
@@ -5009,15 +5006,6 @@ watch(
   gap: var(--bew-space-1);
   color: inherit;
   text-decoration: none;
-}
-.moments-user-card__stat + .moments-user-card__stat::before {
-  position: absolute;
-  left: calc(var(--bew-space-2) / -2);
-  top: var(--bew-space-2);
-  bottom: var(--bew-space-2);
-  width: 1px;
-  background: var(--bew-border-color);
-  content: "";
 }
 .moments-user-card__stat:hover strong,
 .moments-user-card__stat:hover small {

--- a/src/contentScripts/views/Moments/Moments.vue
+++ b/src/contentScripts/views/Moments/Moments.vue
@@ -4073,7 +4073,7 @@ watch(
               >
                 <span class="moments-live-card__avatar">
                   <img :src="getSidebarAvatarUrl(liveUser.face, 64)" :alt="liveUser.uname" loading="lazy" decoding="async">
-                  <em><span i-tabler-chart-bar />{{ t('moments.live_now') }}</em>
+                  <em>{{ t('moments.live_now') }}</em>
                 </span>
                 <span class="moments-live-card__info">
                   <strong>{{ liveUser.uname }}</strong>
@@ -5124,13 +5124,13 @@ watch(
   bottom: 0;
   display: inline-flex;
   align-items: center;
-  gap: var(--bew-space-0-5);
-  height: 17px;
-  padding: 0 var(--bew-space-1);
+  height: 16px;
+  /* 徽章光学微调：10px 低于 caption 最小档 */
+  padding: 0 var(--bew-space-2);
   border-radius: var(--bew-radius-full);
   color: #fff;
-  background: #fb7299;
-  font-size: var(--bew-font-size-caption);
+  background: var(--bew-theme-color);
+  font-size: 10px;
   font-style: normal;
   line-height: var(--bew-line-height-caption);
   transform: translateX(-50%);
@@ -5139,7 +5139,7 @@ watch(
 .moments-live-card__avatar em::after {
   position: absolute;
   inset: -3px;
-  border: 1px solid #fb7299;
+  border: 1px solid var(--bew-theme-color);
   border-radius: inherit;
   content: "";
   pointer-events: none;

--- a/src/contentScripts/views/Moments/Moments.vue
+++ b/src/contentScripts/views/Moments/Moments.vue
@@ -5015,7 +5015,8 @@ watch(
   overflow: hidden;
   max-width: 100%;
   color: var(--bew-text-1);
-  font-size: var(--bew-font-size-heading);
+  // 与 UserPanelPop .num text-xl (18px) 对齐
+  font-size: 18px;
   font-weight: var(--bew-font-weight-semibold);
   text-overflow: ellipsis;
   transition: color var(--bew-duration-normal) var(--bew-ease-standard);

--- a/src/contentScripts/views/Moments/MomentsHotSearch.vue
+++ b/src/contentScripts/views/Moments/MomentsHotSearch.vue
@@ -96,7 +96,7 @@ onMounted(loadHotSearch)
 .moments-hot-search {
   overflow: auto;
   overscroll-behavior: contain;
-  padding: var(--bew-space-3);
+  padding: var(--bew-space-4);
   border-radius: var(--bew-panel-radius);
   background: var(--bew-elevated);
   scrollbar-width: thin;


### PR DESCRIPTION
## 范围

8 文件，+656/-636，22 个提交（含 2 次 main 合并）。核心改动在 `MomentCard.vue`（±1031）与 `Moments.vue`（±227），其余为 4 个 locale、`types.ts`、`MomentsHotSearch.vue`。

## MomentCard.vue

**视频卡结构**
- 投稿视频与转发视频合并为同一横条结构：`grid-template-columns: minmax(150px, 44%) 1fr`，左封面（16:9、absolute 铺满），右信息列（标题 + 简介两行）；条底 `fill-1` + 描边，hover/focus-visible `fill-2`
- 转发视频引用块不再单独维护封面模板，复用同一套类名
- 无封面数据时回落到「投稿了视频」文字封面

**继承简介**
- 视频动态的 `module_dynamic.desc`（简介副本）按继承来源弱化：13px / text-3 / 两行截断；`descInherited` 为真时本人正文区不重复显示该文本

**时间行**
- `isVideo && !isLive` 时在时间后追加 `video_post`（现值「投稿了视频」）

**昵称**
- 链接与非链接昵称均从 `--bew-theme-color` 改为 `--bew-text-1`；hover 过渡主题色（color 0.16s），删除下划线 hover；转发作者名同步加过渡

**稍后再看按钮**
- `handlePermalinkClick` 头部新增嵌套交互件放行：`closest('button, a')` 命中且非自身时仅 `preventDefault` 后返回（不 `stopPropagation`、不 `openDetail`）；该判断在 `shouldUseNativeLinkOpen` 之前，ctrl+点击按钮也生效
- 显隐规则删除 `:focus-within` 与 `.is-added` 两个常显来源，仅剩封面 `:hover` 与按钮 `:focus-visible`
- 删除 v-else 分支两个不可达按钮（分支条件 `isVideo && !isLive` 与外层互斥）及失去匹配的 `.moment-card__cover:hover` 选择器

**其他**
- 转发引用块补 `fill-1` 底、hover `fill-2`，transition 收敛为 background-color
- 卡内垂直间距统一 16，裸值间距 token 化，删除被后续规则覆盖的死样式
- 封面播放量/时长 13px；附加块显式字号层级、修复 strong 字重

## Moments.vue

**间距（三档：卡内 16 / 卡片流 20 / 栏间 24）**
- `GRID_GAP` 16→20，新增 `LAYOUT_GAP` 24，列数预算的 reserve 改用后者
- page 水平 padding 12→20；layout column/row gap 16→24；主内容列 gap 12→20；骨架列 16→20；grid 的 gap 移至列（20）；筛选栏 padding 统一 16

**侧栏用户卡**
- 统计三项由 span 改为链接，分别跳转空间页关注/粉丝/动态；数字经 `numFormatter` 格式化，`title` 保留完整数值；hover 数字与标签变主题色
- 统计数字 18px（对齐 UserPanelPop，已注释）；名称 semibold→medium

**UP 列表**
- 项宽 64→72px（48px 头像 + 留白）
- 新增 hover 态，与 active 共用 `up-item-selected` mixin（光环 box-shadow、名称变色、all/wanted 头像反色）；头像常驻 2px transparent border 防选中态尺寸跳动；配套 transition

**直播卡**
- 徽章：底色 `#fb7299`→主题色、字号 caption→10px、高 17→16px、去图表图标；涟漪描边同步主题色；标题补 semibold

**发布动态卡**
- 圆角 `interactive-radius`(8)→`panel-radius`(12)

**数据层**
- `getMomentContent` 正文拆分为 `selfText` / `inheritedText`：视频类 major 的 `dynamic.desc` 归入继承来源；输出 `descInherited` 标记
- `mapMoment`：`descInherited` 与 `mediaMeta` 均按 `!isForward` 归零（原动态信息只在引用块出现）

**瀑布流估算**
- 新增共享函数 `estimateVideoCardStripHeight`（max(封面 44%×16:9, 112px 信息列) + 2px 描边）；视频与转发视频分支改用；删除窄列视频专用分支

## locale（cmn-CN / cmn-TW / jyut / en）

- `video_post` 改值（视频动态→投稿了视频），`moments:` 与 `moment_card:` 两段同步
- `live_now` 改值（正在直播→直播中）
- 删除 `moment_card.added` / `moment_card.watch_later`（全站零引用）

## 其他

- `types.ts`：`DisplayMoment` 新增可选 `descInherited`
- `MomentsHotSearch.vue`：面板 padding 12→16

## 审查重点

1. `handlePermalinkClick` 的新分支：对旧 overlay 卡型无影响（无子元素，`target === currentTarget` 走原路径）
2. `estimateCardHeight` 视频分支与横条实际 DOM 的对应关系（112px 信息列是估算常数）
3. 转发卡 `mediaMeta` / `descInherited` 归零后，引用块内信息是否完整（原有时长已在引用块封面角标）
4. UP 列表 hover 与 active 共用样式后，`:disabled`（opacity .45）仍独立生效

## 已知取舍

- 横条封面曾加 `is-ready` 渐入门控（opacity 0→1），上线后出现封面黑屏且根因未定位，已回退为常显；如需渐入需先理清与 `--preparing` 共用 `ready` 的关系
- 用户卡 18px 为一次性硬编码字号（已注明对齐来源）

## 测试

- `pnpm dev` 下人工核验各卡型（视频/转发/直播/图文/专栏）渲染与交互
- pre-push 钩子 `pnpm lint` + `pnpm typecheck` 通过