### PR TITLE
feat(topbar): 恢复可选渐进雾化样式档

### DIFF
--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -549,6 +549,7 @@ settings:
     default: 自动
     frosted_glass: 白雾
     transparent: 阴影
+    progressive_fog: 渐进雾化
     exp_default: 自动（实验）
     exp_frosted_glass: 白雾（实验）
     exp_transparent: 阴影（实验）

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -521,6 +521,7 @@ settings:
     default: 自動
     frosted_glass: 白霧
     transparent: 陰影
+    progressive_fog: 漸進霧化
     exp_default: 自動（實驗）
     exp_frosted_glass: 白霧（實驗）
     exp_transparent: 陰影（實驗）

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -505,6 +505,7 @@ settings:
     default: Auto
     frosted_glass: White fog
     transparent: Shadow
+    progressive_fog: Progressive fog
     exp_default: Auto (experimental)
     exp_frosted_glass: White fog (experimental)
     exp_transparent: Shadow (experimental)

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -506,6 +506,7 @@ settings:
     default: 自動
     frosted_glass: 白霧
     transparent: 陰影
+    progressive_fog: 漸進霧化
     exp_default: 自動（實驗）
     exp_frosted_glass: 白霧（實驗）
     exp_transparent: 陰影（實驗）

--- a/src/components/ProgressiveBlurSurface.vue
+++ b/src/components/ProgressiveBlurSurface.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+// v1.7.6 的渐进雾化实现（b6fdb800）移植恢复。
+//
+// backdrop-filter 的 blur 半径无法用 CSS 渐变做线性插值，只能靠"若干层不同半径的
+// 模糊层 + 各层错位的 alpha mask"叠加出模糊自下而上递增的观感：
+//   层 0..4 的半径依次为 blur(1/2/4/8/16px)，每层的 mask 让半径越大的层只出现在越靠上
+//   的窄条里，叠在一起就形成底部≈1px、顶部≈16px 的连续渐变。
+//
+// 注意：每层都是一个独立 backdrop 合成层，顶部会同时命中五层。这是有意为之的
+// "观感开关"——只在该档被用户显式选择时才挂载，默认不产生任何额外合成开销。
+const BLUR_LAYER_COUNT = 5
+
+const blurLayers = Array.from({ length: BLUR_LAYER_COUNT }, (_, index) => {
+  const solid = ((BLUR_LAYER_COUNT - 1 - index) / BLUR_LAYER_COUNT) * 100
+  const fade = ((BLUR_LAYER_COUNT - index) / BLUR_LAYER_COUNT) * 100
+  const mask = `linear-gradient(to bottom, rgb(0 0 0 / 100%) 0, rgb(0 0 0 / 100%) ${solid}%, rgb(0 0 0 / 0%) ${fade}%)`
+  const filter = index === 0 ? `blur(${2 ** index}px) saturate(180%)` : `blur(${2 ** index}px)`
+
+  return {
+    backdropFilter: filter,
+    WebkitBackdropFilter: filter,
+    maskImage: mask,
+    WebkitMaskImage: mask,
+  }
+})
+</script>
+
+<template>
+  <div class="progressive-blur-surface" aria-hidden="true">
+    <div
+      v-for="(layer, index) in blurLayers"
+      :key="index"
+      class="progressive-blur-surface__layer"
+      :style="layer"
+    />
+  </div>
+</template>
+
+<style scoped lang="scss">
+.progressive-blur-surface,
+.progressive-blur-surface__layer {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+</style>

--- a/src/components/Settings/PluginComponentsAndPages/TopBar/TopBarVisualConfig.vue
+++ b/src/components/Settings/PluginComponentsAndPages/TopBar/TopBarVisualConfig.vue
@@ -100,6 +100,7 @@ const topBarStyleOptions = computed<{ label: string, value: TopBarStyle }[]>(() 
   { label: t('settings.top_bar_style_opt.default'), value: 'default' },
   { label: t('settings.top_bar_style_opt.frosted_glass'), value: 'frostedGlass' },
   { label: t('settings.top_bar_style_opt.transparent'), value: 'transparent' },
+  { label: t('settings.top_bar_style_opt.progressive_fog'), value: 'progressiveFog' },
   { label: t('settings.top_bar_style_opt.exp_default'), value: 'expDefault' },
   { label: t('settings.top_bar_style_opt.exp_frosted_glass'), value: 'expFrostedGlass' },
   { label: t('settings.top_bar_style_opt.exp_transparent'), value: 'expTransparent' },

--- a/src/components/TopBar/components/TopBarHeader.vue
+++ b/src/components/TopBar/components/TopBarHeader.vue
@@ -2,6 +2,7 @@
 import { useMediaQuery, useMutationObserver } from '@vueuse/core'
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 
+import ProgressiveBlurSurface from '~/components/ProgressiveBlurSurface.vue'
 import { useBewlyApp } from '~/composables/useAppProvider'
 import { useLayoutEditMode } from '~/composables/useLayoutEditMode'
 import { AppPage } from '~/enums/appEnums'
@@ -126,6 +127,39 @@ const scrolledShadeStyle = computed(() => ({
 
 // 实验三档走余弦渐变管线；其余档位沿用 v1.5.x 的遮罩表现。
 const useLegacyRendering = computed(() => !experimentalTopBarStyles.includes(settings.value.topBarStyle))
+
+// 渐进雾化（v1.7.6 移植）：五层 blur 半径自下而上递增，仅在用户显式选择时挂载。
+const useProgressiveFog = computed(() => settings.value.topBarStyle === 'progressiveFog')
+
+// 渐进雾化覆盖高度略大于顶栏本体，让模糊渐变在顶栏下缘外自然收尾。
+const PROGRESSIVE_OVERLAY_HEIGHT = 'calc(var(--bew-top-bar-height) * 1.35)'
+const PROGRESSIVE_FOG_GAMMA = 0.7
+const PROGRESSIVE_FOG_STOP_COUNT = 10
+
+function progressiveFogStops(peak: number): [number, number][] {
+  return Array.from({ length: PROGRESSIVE_FOG_STOP_COUNT }, (_, index) => {
+    const t = index / (PROGRESSIVE_FOG_STOP_COUNT - 1)
+    const decay = ((1 + Math.cos(Math.PI * t)) / 2) ** PROGRESSIVE_FOG_GAMMA
+    return [+(t * 100).toFixed(1), peak * decay]
+  })
+}
+
+function progressiveFogGradient(color: string, peak: number) {
+  const stops = progressiveFogStops(peak).map(([position, alpha]) =>
+    `rgb(${color} / ${+alpha.toFixed(2)}%) ${position}%`)
+  return `linear-gradient(to bottom, ${stops.join(', ')})`
+}
+
+// 渐进雾化雾色配方与 v1.7.6 一致：底图/壁纸下压黑雾托白图标；
+// 其余情况暗色压黑雾、亮色铺白雾。
+const progressiveFogTint = computed(() => {
+  if (forceWhiteIcon.value)
+    return progressiveFogGradient('0 0 0', 42)
+
+  return props.isDark
+    ? progressiveFogGradient('0 0 0', 75)
+    : progressiveFogGradient('255 255 255', 80)
+})
 
 // v1.5.x 的三停轻雾：顶部八成、中部六成（黑雾六/四成），随滚动由 0.8 收紧到 1。
 const legacyFadeGradientStyle = computed(() => ({
@@ -278,8 +312,27 @@ function refreshSearchContent() {
     p="x-12" m-auto
     h="$bew-top-bar-height"
   >
+    <!-- 渐进雾化：五层递增模糊 + 余弦雾色，仅在显式选择时挂载（性能敏感） -->
+    <template v-if="useProgressiveFog">
+      <div
+        class="top-bar-header__progressive-fog"
+        :style="{ height: PROGRESSIVE_OVERLAY_HEIGHT }"
+      >
+        <Transition name="fade">
+          <ProgressiveBlurSurface v-if="!reachTop" />
+        </Transition>
+        <div
+          class="top-bar-header__progressive-fog-tint"
+          :style="{
+            background: progressiveFogTint,
+            opacity: reachTop ? 0.8 : 1,
+          }"
+        />
+      </div>
+    </template>
+
     <!-- 旧版三档：常驻雾层沿用 v1.5.x 结构，滚动层只在毛玻璃开启时生效 -->
-    <template v-if="useLegacyRendering">
+    <template v-else-if="useLegacyRendering">
       <div
         class="top-bar-header__legacy-mask"
         :class="{ 'top-bar-header__legacy-mask--glass': settings.enableFrostedGlass }"
@@ -301,7 +354,7 @@ function refreshSearchContent() {
     </template>
 
     <div
-      v-if="isDark"
+      v-if="isDark && !useProgressiveFog"
       class="top-bar-header__scrolled-shade"
       :style="scrolledShadeStyle"
     />
@@ -393,6 +446,21 @@ function refreshSearchContent() {
   width: 100%;
   pointer-events: none;
   transition: opacity var(--bew-duration-fast) linear;
+}
+
+// 渐进雾化容器：绝对定位盖住顶栏，模糊层与雾色层在容器内裁剪
+.top-bar-header__progressive-fog {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  pointer-events: none;
+}
+
+.top-bar-header__progressive-fog-tint {
+  position: absolute;
+  inset: 0;
+  transition: opacity var(--bew-duration-moderate) var(--bew-ease-standard);
 }
 
 .top-bar-header__scrolled-shade {

--- a/src/components/TopBar/composables/useTopBarInteraction.ts
+++ b/src/components/TopBar/composables/useTopBarInteraction.ts
@@ -150,6 +150,10 @@ export function useTopBarInteraction() {
     if (style === 'default')
       return !preferWhiteFogInAuto.value && (hasPageBanner.value || hasWallpaper.value)
 
+    // 渐进雾化沿用 v1.5.x 的横幅判定：页面有横幅/壁纸时压黑雾并强制白图标。
+    if (style === 'progressiveFog')
+      return hasPageBanner.value || hasWallpaper.value
+
     // 实验三档：底图恒用阴影，壁纸只在暗色模式下才是黑雾。
     return hasPageBackdrop.value || (hasWallpaperBackdrop.value && isDark.value)
   })

--- a/src/logic/storage.ts
+++ b/src/logic/storage.ts
@@ -116,11 +116,13 @@ export function normalizeVideoCardCoverRatio(value: unknown, fallback: number): 
 export type TabsPosition = 'left' | 'center'
 export type TopBarLogoStyle = 'icon' | 'brand'
 // 旧版三档（default/transparent/frostedGlass）沿用 v1.5.x 的遮罩结构与色调判定；
+// progressiveFog 为 v1.7.6 的五层渐进雾化（显式选择才挂载，独立渲染分支）；
 // 实验三档（exp 前缀）走余弦渐变遮罩管线。
 export type TopBarStyle
   = | 'default'
     | 'transparent'
     | 'frostedGlass'
+    | 'progressiveFog'
     | 'expDefault'
     | 'expTransparent'
     | 'expFrostedGlass'
@@ -925,7 +927,7 @@ watch(
     if (!validTopBarLogoStyles.includes(record.topBarLogoStyle))
       record.topBarLogoStyle = originalSettings.topBarLogoStyle
 
-    const validTopBarStyles: TopBarStyle[] = ['default', 'transparent', 'frostedGlass', ...experimentalTopBarStyles]
+    const validTopBarStyles: TopBarStyle[] = ['default', 'transparent', 'frostedGlass', 'progressiveFog', ...experimentalTopBarStyles]
     const hasLegacyTopBarStyle = 'alwaysUseTransparentTopBar' in record
       || 'alwaysUseFrostedGlassTopBar' in record
       || 'enableTopBarGradient' in record


### PR DESCRIPTION
## 动机

v1.7.4 引入的多层渐进模糊是「模糊半径真实衰减」的渐进模糊（#983）；
#1091 收敛后该实现被单层化，变成固定 blur(20px) + mask 淡出——模糊强度
不随高度变化，整条区域糊度一致（对比图右图可见）；#1096 删除后，
main 上无论默认档还是实验档都不再有半径衰减的渐进模糊。

本 PR 把它还原为样式下拉中的一个可选项：

- **非默认档位**：默认观感与渲染开销零改动
- **按需挂载**：仅当用户显式选择该档时挂载（`topBarStyle === 'progressiveFog'`），
  不选中则与现在完全一致
- 白图标判定、多语言文案同步补齐

## 视觉对比

同页面、同滚动位置。

**本 PR（渐进雾化，5 层 blur 1/2/4/8/16px，σ≈18.5，半径随高度真实衰减）：**
<img width="1340" height="225" alt="image" src="https://github.com/user-attachments/assets/9e3fbd0d-26a1-4699-8931-7272d75a8830" />

**当前 main 默认档（「自动」+ 启用毛玻璃，固定单层 blur(20px)，无半径渐变）：**
<img width="1346" height="227" alt="image" src="https://github.com/user-attachments/assets/7b7f4eba-ee9d-47ee-8ed0-dc42f7c003f9" />

## 改动清单

| 文件 | 改动 |
|---|---|
| `src/components/ProgressiveBlurSurface.vue` | 新建：5 层递增 blur + 错位 mask（还原 v1.7.6） |
| `src/logic/storage.ts` | `TopBarStyle` 加回 `progressiveFog` |
| `src/components/TopBar/composables/useTopBarInteraction.ts` | 白图标判定补该档分支 |
| `src/components/TopBar/components/TopBarHeader.vue` | 挂载分支 + 滚动渐入 |
| `TopBarVisualConfig.vue` | 样式下拉加「渐进雾化」选项 |
| 4 个语言包 | 标签文案 |

## 性能说明

- 接受 #1091 的成本论证——这正是它作为**可选**而非默认的原因
- 选中时最多 5 个 backdrop 合成层；不选中时与现状零差异

## 验证

- `pnpm lint` / `typecheck` 通过
- 浏览器实测：切至渐进雾化档滚动，模糊半径随高度渐变生效；切回默认档，
  行为与 main 一致（无残留、无额外合成层）
