### PR TITLE
feat(player): 新增播放器滚动位置选择

### DIFF
--- a/src/_locales/cmn-CN.yml
+++ b/src/_locales/cmn-CN.yml
@@ -450,7 +450,11 @@ settings:
     bewly_widescreen_center_vertical_video: Bewly宽屏画面居中
     bewly_widescreen_center_vertical_video_desc: 开启后，宽屏模式下若画面两侧留有足够容纳侧栏的黑边空间，视频将在整个画面水平居中，侧栏完整占据一侧黑边；空间不足时保持现有布局。
   video_player_scroll: 调整显示模式后滚动
-  video_player_scroll_desc: 启用后，在默认模式为宽屏和默认时，会自动滚动到合适位置。
+  video_player_scroll_desc: 启用后，调整显示模式时会自动滚动到所选位置。
+  video_player_scroll_mode:
+    title: 滚动位置
+    sending_bar: 保持弹幕栏可见
+    player_center: 播放器居中
   enlarge_favorite_dialog: 放大收藏弹窗
   enlarge_favorite_dialog_desc: 启用后，视频页收藏弹窗将以更大的尺寸显示，方便查看和管理收藏夹。
   external_watch_later_button: 稍后再看按钮外置

--- a/src/_locales/cmn-TW.yml
+++ b/src/_locales/cmn-TW.yml
@@ -960,7 +960,11 @@ settings:
   hide_comment_image_scrollbar: 評論圖片預覽時隱藏頁面滾動條
   hide_comment_image_scrollbar_desc: 開啟評論區圖片預覽時隱藏頁面右側滾動條，避免滾動條顯示在遮罩右側
   video_player_scroll: 調整顯示模式後滾動
-  video_player_scroll_desc: 啟用後，在默認模式為寬屏和默認時，會自動滾動到合適位置。
+  video_player_scroll_desc: 啟用後，調整顯示模式時會自動捲動到所選位置。
+  video_player_scroll_mode:
+    title: 捲動位置
+    sending_bar: 保持彈幕欄可見
+    player_center: 播放器置中
   enlarge_favorite_dialog: 放大收藏彈窗
   enlarge_favorite_dialog_desc: 啟用後，影片頁收藏彈窗將以更大的尺寸顯示，方便查看和管理收藏夾。
   external_watch_later_button: 稍後再看按鈕外置

--- a/src/_locales/en.yml
+++ b/src/_locales/en.yml
@@ -1062,9 +1062,11 @@ settings:
   hide_comment_image_scrollbar: Hide page scrollbar in comment image preview
   hide_comment_image_scrollbar_desc: Hide the page scrollbar when opening a comment image preview so it does not appear beside the overlay
   video_player_scroll: Scroll after adjusting the display mode
-  video_player_scroll_desc: >-
-    When enabled, it will automatically scroll to the appropriate position when
-    the default mode is widescreen and default.
+  video_player_scroll_desc: Automatically scroll to the selected position after adjusting the display mode.
+  video_player_scroll_mode:
+    title: Scroll position
+    sending_bar: Keep danmaku bar visible
+    player_center: Center player
   enlarge_favorite_dialog: Enlarge favorite dialog
   enlarge_favorite_dialog_desc: When enabled, the favorite dialog on video pages will be displayed in a larger size for easier viewing and management.
   external_watch_later_button: External watch later button

--- a/src/_locales/jyut.yml
+++ b/src/_locales/jyut.yml
@@ -981,7 +981,11 @@ settings:
   hide_comment_image_scrollbar: 留言圖片預覽時隱藏頁面滾動條
   hide_comment_image_scrollbar_desc: 開啟留言區圖片預覽時隱藏頁面右側滾動條，避免滾動條顯示喺遮罩右側
   video_player_scroll: 校好顯示模式後自動轆到合適嘅位置
-  video_player_scroll_desc: 啓用後，若果顯示模式係闊螢幕或預設嗰陣，會自動轆到合適嘅位置。
+  video_player_scroll_desc: 啓用後，調整顯示模式時會自動轆到揀選嘅位置。
+  video_player_scroll_mode:
+    title: 捲動位置
+    sending_bar: 保持彈幕欄可見
+    player_center: 播放器置中
   enlarge_favorite_dialog: 放大收藏彈窗
   enlarge_favorite_dialog_desc: 啓用後，影片頁收藏彈窗會用更大嘅尺寸顯示，方便睇同管理收藏夾。
   external_watch_later_button: 稍後再睇按鈕外置

--- a/src/components/Settings/BilibiliFeaturesEnhancement/VideoPlayback/VideoPlayback.vue
+++ b/src/components/Settings/BilibiliFeaturesEnhancement/VideoPlayback/VideoPlayback.vue
@@ -4,7 +4,7 @@ import { useI18n } from 'vue-i18n'
 import Radio from '~/components/Radio.vue'
 import Select from '~/components/Select.vue'
 import { settings } from '~/logic'
-import type { PlayerDefaultState, VideoPlayerModeContext } from '~/logic/storage'
+import type { PlayerDefaultState, VideoPlayerModeContext, VideoPlayerScrollMode } from '~/logic/storage'
 
 import SettingsItem from '../../components/SettingsItem.vue'
 import SettingsItemGroup from '../../components/SettingsItemGroup.vue'
@@ -77,6 +77,11 @@ const videoPlayerModeContextOptions = computed<{ label: string, value: VideoPlay
   { label: t('settings.video_player_mode.context_playlist'), value: 'playlist' },
 ])
 
+const videoPlayerScrollModeOptions = computed<{ label: string, value: VideoPlayerScrollMode }[]>(() => [
+  { label: t('settings.video_player_scroll_mode.sending_bar'), value: 'sendingBar' },
+  { label: t('settings.video_player_scroll_mode.player_center'), value: 'playerCenter' },
+])
+
 const usesBewlyWidescreen = computed(() => settings.value.defaultVideoPlayerMode === 'bewlyWidescreen'
   || (settings.value.enableVideoPlayerModeOverrides
     && Object.values(settings.value.videoPlayerModeOverrides).includes('bewlyWidescreen')))
@@ -142,9 +147,18 @@ const playerDefaultStateOptions = computed<{ label: string, value: PlayerDefault
 
       <SettingsItem
         :title="t('settings.video_player_scroll')"
+        :desc="t('settings.video_player_scroll_desc')"
         right-width="auto"
       >
         <Radio v-model="settings.videoPlayerScroll" />
+      </SettingsItem>
+
+      <SettingsItem
+        v-if="settings.videoPlayerScroll"
+        :title="t('settings.video_player_scroll_mode.title')"
+        right-width="auto"
+      >
+        <Select v-model="settings.videoPlayerScrollMode" :options="videoPlayerScrollModeOptions" w="160px" />
       </SettingsItem>
 
       <SettingsItem

--- a/src/components/Settings/searchCatalog.ts
+++ b/src/components/Settings/searchCatalog.ts
@@ -483,7 +483,6 @@ export const settingsSearchEntries: SettingsSearchEntry[] = [
     'settings.video_player_mode.enable_overrides',
     'settings.video_player_mode.overrides',
     'settings.video_player_scroll',
-    'settings.video_player_scroll_mode.title',
     'settings.auto_exit_fullscreen_on_end',
     'settings.group_player_components',
     'settings.group_playback_memory',
@@ -496,6 +495,14 @@ export const settingsSearchEntries: SettingsSearchEntry[] = [
     'settings.show_bewly_widescreen_button',
     'settings.show_video_screenshot_button',
   ]),
+  ...createEntries(playerRoute, [
+    'settings.video_player_scroll_mode.title',
+  ], {
+    keywordKeys: [
+      'settings.video_player_scroll_mode.sending_bar',
+      'settings.video_player_scroll_mode.player_center',
+    ],
+  }),
   ...createEntries(playerRoute, [
     'settings.video_default_player_mode',
   ], { keywordKeys: playerModeOptionKeys }),

--- a/src/components/Settings/searchCatalog.ts
+++ b/src/components/Settings/searchCatalog.ts
@@ -483,6 +483,7 @@ export const settingsSearchEntries: SettingsSearchEntry[] = [
     'settings.video_player_mode.enable_overrides',
     'settings.video_player_mode.overrides',
     'settings.video_player_scroll',
+    'settings.video_player_scroll_mode.title',
     'settings.auto_exit_fullscreen_on_end',
     'settings.group_player_components',
     'settings.group_playback_memory',

--- a/src/logic/storage.ts
+++ b/src/logic/storage.ts
@@ -136,6 +136,7 @@ export type CustomPlayOrderOverrides = Record<CustomPlayOrderContext, CustomPlay
 /** 订阅合集「播放全部」起播策略 */
 export type CollectedSeasonPlayAllMode = 'beginning' | 'latest' | 'lastWatched'
 export type DefaultVideoPlayerMode = 'default' | 'webFullscreen' | 'widescreen' | 'bewlyWidescreen'
+export type VideoPlayerScrollMode = 'sendingBar' | 'playerCenter'
 export type BewlyWidescreenSidebarPosition = 'left' | 'right'
 export type BewlyWidescreenSidebarPriority = 'video' | 'sidebar'
 export type PlayerDefaultState = 'system' | 'remember' | 'on' | 'off'
@@ -514,6 +515,7 @@ export interface Settings {
   keyboard: boolean
   shortcuts: ShortcutsSettings
   videoPlayerScroll: boolean // 添加视频播放器滚动设置
+  videoPlayerScrollMode: VideoPlayerScrollMode
 
   // 倍速记忆设置
   rememberPlaybackRate: boolean // 启用倍速记忆功能
@@ -822,6 +824,7 @@ export const originalSettings: Settings = {
 
   keyboard: true, // 总快捷键开关，默认为 true
   videoPlayerScroll: true, // 默认开启视频播放器滚动
+  videoPlayerScrollMode: 'sendingBar',
   shortcuts: {
     danmuStatus: { key: 'Shift+D', enabled: true },
     webFullscreen: { key: 'Shift+W', enabled: true },

--- a/src/logic/storage.ts
+++ b/src/logic/storage.ts
@@ -1115,6 +1115,10 @@ watch(
     Reflect.deleteProperty(record, 'rememberDanmakuState')
     Reflect.deleteProperty(record, 'rememberCaptionState')
 
+    const validVideoPlayerScrollModes: VideoPlayerScrollMode[] = ['sendingBar', 'playerCenter']
+    if (!validVideoPlayerScrollModes.includes(record.videoPlayerScrollMode))
+      record.videoPlayerScrollMode = originalSettings.videoPlayerScrollMode
+
     const validPlayerDefaultStates: PlayerDefaultState[] = ['system', 'remember', 'on', 'off']
     if (!validPlayerDefaultStates.includes(record.defaultDanmakuState))
       record.defaultDanmakuState = originalSettings.defaultDanmakuState

--- a/src/utils/player.ts
+++ b/src/utils/player.ts
@@ -218,7 +218,7 @@ export function webFullscreen(application?: PlayerModeApplication) {
   }).start()
 }
 
-// 将播放器滚动到合适位置，优先保证弹幕栏可见
+// 将播放器滚动到设置的位置
 function scrollPlayerToOptimalPosition(delay = 1000) {
   // 如果设置了不滚动，直接返回
   if (!settings.value.videoPlayerScroll)
@@ -228,6 +228,15 @@ function scrollPlayerToOptimalPosition(delay = 1000) {
     const playerElement = document.querySelector(_videoClassTag.player)
     if (!playerElement)
       return
+
+    if (settings.value.videoPlayerScrollMode === 'playerCenter') {
+      const rect = playerElement.getBoundingClientRect()
+      window.scrollBy({
+        top: rect.top + rect.height / 2 - window.innerHeight / 2,
+        behavior: 'smooth',
+      })
+      return
+    }
 
     // 查找弹幕发送栏
     const sendingBar = document.querySelector('.bpx-player-sending-bar')


### PR DESCRIPTION
## 改动说明

- 保留现有“调整显示模式后滚动”总开关
- 新增滚动位置选择，可选择“保持弹幕栏可见”或“播放器居中”
- 播放器居中模式会在显示模式调整后，将播放器中心与浏览器可视区域中心对齐
- 默认使用原有的弹幕栏可见逻辑，旧用户行为保持不变
- 补充简中、繁中、英文和粤语文案及设置搜索入口

## 验证

- `pnpm lint`
- `pnpm typecheck`
- `git diff --check`